### PR TITLE
Better make scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,53 @@ docs:
 	echo "Running segment docs at http://localhost:4000/docsv2/" && \
 	docker run -p 4000:80 segment-docs:latest
 
+
+.PHONY: build
+build:
+	docker run -it \
+	  --volume="$(PWD):/srv/jekyll" \
+	  jekyll/jekyll \
+		bundle package && \
+		bundle install && \
+	  bundle exec jekyll build
+
+.PHONY: nav
+nav:
+	docker run -it \
+	  --volume="$(PWD):/srv/jekyll" \
+	  jekyll/jekyll \
+		rake nav:update
+
+.PHONY: catalog
+catalog:
+	docker run -it \
+	  --volume="$(PWD):/srv/jekyll" \
+	  jekyll/jekyll \
+		rake catalog:update
+
+.PHONY: docker-clean
+docker-clean:
+	docker run -it \
+	  --volume="$(PWD):/srv/jekyll" \
+	  jekyll/jekyll \
+	  jekyll clean
+
+.PHONY: docker-deps
+docker-deps:
+	docker run -it \
+	  --volume="$(PWD):/srv/jekyll" \
+	  jekyll/jekyll \
+		bundle install
+
+.PHONY: docker-dev
+docker-dev:
+	docker run -it \
+	  -p 4000:4000 \
+	  --volume="$(PWD):/srv/jekyll" \
+	  jekyll/jekyll \
+	  jekyll serve --incremental -H 0.0.0.0
+		.PHONY: docs
+
 .PHONY: env
 env:
 	gem install bundler && \
@@ -17,15 +64,6 @@ clean:
 .PHONY: deps
 deps:
 	bundle install
-
-.PHONY: build
-build:
-	docker run -it \
-	  --volume="$(PWD):/srv/jekyll" \
-	  jekyll/jekyll \
-		bundle package && \
-		bundle install && \
-	  bundle exec jekyll build
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
This is feedback from @sanscontext. Rather than hooking in to docker, for the dev cycle, we can just do a `make env` and `make dev`