### PR TITLE
build(): Fix watch after changes in UNIX OSs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ JEKYLL_ENV ?= development
 dev: node_modules vendor/bundle
 	@$(BIN)/concurrently --raw --kill-others -n webpack,jekyll \
 		"$(BIN)/webpack --mode=development --watch" \
-		"bundle exec jekyll serve --trace --incremental -H 0.0.0.0 -V"
+		"bundle exec jekyll serve --force_polling --trace --incremental -H 0.0.0.0 -V"
 
 .PHONY: build
 build: node_modules vendor/bundle


### PR DESCRIPTION
### Proposed changes

Adds `--force_polling` flags to `jekyll serve` command runned by `make dev` command.

Live Reload does not work on the UNIX system without this flags.
