### PR TITLE
fix(markdown): Limit styling of li elements to one level deep

### DIFF
--- a/src/_sass/components/_markdown.scss
+++ b/src/_sass/components/_markdown.scss
@@ -131,7 +131,7 @@
     list-style-type: none;
     padding-left: 25px;
 
-    li {
+    & > li {
       position: relative;
       font-size: 15px;
       color: color(secondary-dark);
@@ -158,7 +158,7 @@
     counter-reset: list-items;
     padding-left: 25px;
 
-    li {
+    & > li {
       counter-increment: list-items;
       line-height: 30px;
       position: relative;


### PR DESCRIPTION
Fixes this situation:

![Zrzut ekranu 2019-10-28 o 13 46 31](https://user-images.githubusercontent.com/3652932/67679434-5d243300-f989-11e9-863c-c061df35f15c.png)
