### PR TITLE
reinstate feedback and personas-partial hider, plus fix redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ defaults:
       beta: false
       seo-priority: 0.5
       seo-changefreq: weekly
+      hide-feedback: false
   - scope:
       path: "connections/destinations"
     values:

--- a/src/_includes/content/integration-foot.md
+++ b/src/_includes/content/integration-foot.md
@@ -2,10 +2,11 @@
 <!-- in the file we're pulling from the API, "name" corresponds with the path to the yml blob for a specific destination.-->
 {% assign name = page.path | replace: "connections", "catalog" | remove: "/index.md" %}
 {% assign destination_from_api = site.data.catalog.destinations.destinations | where: "name", name | first %}
-<!-- if it uses Identify calls and is available on Server, you can use personas?  -->
-{% if destination_from_api.methods.identify == true and destination_from_api.platforms.server == true %}
-{% include content/personas.md %}
 
+{% if destination_from_api.platforms.server == true %}
+{% unless hide-personas-partial %}
+{% include content/personas.md %}
+{% endunless %}
 {% endif %}
 
 

--- a/src/_layouts/catalog.html
+++ b/src/_layouts/catalog.html
@@ -43,7 +43,9 @@ layout: default
 
       <div class="sidebar sidebar--sticky">
         {% include sidebar/{{ page.integration_type }}-menu.html %}
+        {% unless page.hide-feedback %}
         {% include sidebar/feedback.html %}
+        {% endunless %}
       </div>
     </div>
   </div>

--- a/src/_layouts/home.html
+++ b/src/_layouts/home.html
@@ -22,7 +22,9 @@ layout: main
 
     <hr>
 
+    {% unless page.hide-feedback %}
     {% include components/feedback.html %}
+    {% endunless %}
 
     {% include components/callout.html %}
   </div>

--- a/src/_layouts/integration.html
+++ b/src/_layouts/integration.html
@@ -75,9 +75,9 @@ layout: default
           </div>
         {%- endunless -%}
 
-        {% if page.feedback != false %}
+        {% unless page.hide-feedback %}
           {% include sidebar/feedback.html %}
-        {% endif %}
+        {% endunless %}
       </div>
     </div>
   </div>

--- a/src/_layouts/main.html
+++ b/src/_layouts/main.html
@@ -34,9 +34,9 @@ layout: default
           </div>
         {%- endunless -%}
 
-        {% if page.feedback != false %}
+        {% unless page.hide-feedback %}
           {% include sidebar/feedback.html %}
-        {% endif %}
+        {% endunless %}
       </div>
     </div>
   </div>

--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -42,7 +42,9 @@ layout: main
 
     <hr>
 
+    {% unless page.hide-feedback %}
     {% include components/feedback.html %}
+    {% endunless %}
 
     {% include components/callout.html %}
   </div>

--- a/src/api/config-api/reference.md
+++ b/src/api/config-api/reference.md
@@ -1,5 +1,6 @@
 ---
 title: Reference
+redirect_to: https://reference.segmentapis.com/
 ---
 
 See the [Segment Config API Reference](https://reference.segmentapis.com/) hosted by [Postman](https://www.getpostman.com/).

--- a/src/glossary.md
+++ b/src/glossary.md
@@ -2,7 +2,7 @@
 title: "Segment Glossary"
 description: "Glossary of terms used in the Segment documentation"
 hide_toc: true
-feedback: false
+hide-feedback: true
 layout: page
 ---
 <span id="doc-content" />

--- a/src/legal/acceptable-use-policy.md
+++ b/src/legal/acceptable-use-policy.md
@@ -1,7 +1,7 @@
 ---
 title: "Acceptable Use Policy"
 sidebar: "Acceptable Use Policy"
-feedback: false
+hide-feedback: true
 ---
 
 ### Acceptable Use Policy

--- a/src/legal/first-access-beta-preview.md
+++ b/src/legal/first-access-beta-preview.md
@@ -1,7 +1,7 @@
 ---
 title: "First-Access and Beta Preview"
 sidebar: "First-Access and Beta Preview"
-feedback: false
+hide-feedback: true
 ---
 
 ### SEGMENT FIRST-ACCESS AND BETA PREVIEW TERMS AND CONDITIONS

--- a/src/legal/index.md
+++ b/src/legal/index.md
@@ -1,5 +1,5 @@
 ---
 title: Terms of Service
 sidebar: Terms of Service
-feedback: false
+hide-feedback: true
 ---

--- a/src/legal/partnersagreement.md
+++ b/src/legal/partnersagreement.md
@@ -1,7 +1,7 @@
 ---
 title: Segment Partner Program Agreement
 sidebar: Segment Partner Program Agreement
-feedback: false
+hide-feedback: true
 ---
 
 ## Segment Partner Program Agreement

--- a/src/legal/personas-terms.md
+++ b/src/legal/personas-terms.md
@@ -1,7 +1,7 @@
 ---
 title: "Terms of Service: Personas"
 sidebar: "Terms of Service: Personas"
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/premium-tos-security.md
+++ b/src/legal/premium-tos-security.md
@@ -1,7 +1,7 @@
 ---
 hidden: true
 title: Segment Premium Information Security Policy
-feedback: false
+hide-feedback: true
 ---
 
 _Last Updated June 22nd, 2019_

--- a/src/legal/premium-tos-sla.md
+++ b/src/legal/premium-tos-sla.md
@@ -1,7 +1,7 @@
 ---
 hidden: true
 title: Segment SLA for Premium Terms of Service
-feedback: false
+hide-feedback: true
 ---
 
 _Last Updated June 22nd, 2019_

--- a/src/legal/premium-tos.md
+++ b/src/legal/premium-tos.md
@@ -1,7 +1,7 @@
 ---
 hidden: true
 title: Segment Premium Online Terms of Service
-feedback: false
+hide-feedback: true
 ---
 
 **SEGMENT PREMIUM ONLINE CUSTOMER AGREEMENT**

--- a/src/legal/privacy-04-2018.md
+++ b/src/legal/privacy-04-2018.md
@@ -1,7 +1,7 @@
 ---
 title: Privacy Policy
 hidden: true
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/privacy-2017.md
+++ b/src/legal/privacy-2017.md
@@ -1,7 +1,7 @@
 ---
 title: Privacy Policy - 2016
 hidden: true
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/privacy-updates.md
+++ b/src/legal/privacy-updates.md
@@ -1,7 +1,7 @@
 ---
 title: Updates - Privacy Policy
 sidebar: Updates - Privacy Policy
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/privacy.md
+++ b/src/legal/privacy.md
@@ -1,7 +1,7 @@
 ---
 title: Privacy Policy
 sidebar: Privacy Policy
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/security.md
+++ b/src/legal/security.md
@@ -1,7 +1,7 @@
 ---
 title: Security
 sidebar: Security
-feedback: false
+hide-feedback: true
 ---
 
 We take the responsibility of helping you manage your customer data seriously. That’s why security and privacy are key focus areas for our organization and product development. To learn more about Segment's Security program, please visit [our security page](https://segment.com/security/).

--- a/src/legal/subprocessors.md
+++ b/src/legal/subprocessors.md
@@ -1,7 +1,7 @@
 ---
 title: List of Data Subprocessors
 sidebar: List of Data Subprocessors
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/terms-2016.md
+++ b/src/legal/terms-2016.md
@@ -1,7 +1,7 @@
 ---
 title: Terms of Service - 2016
 hidden: true
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/terms-2017.md
+++ b/src/legal/terms-2017.md
@@ -1,7 +1,7 @@
 ---
 title: Terms of Service - 2017
 hidden: true
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/terms-updates.md
+++ b/src/legal/terms-updates.md
@@ -1,7 +1,7 @@
 ---
 title: Updates - Terms of Service
 sidebar: Updates - Terms of Service
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/terms.md
+++ b/src/legal/terms.md
@@ -1,7 +1,7 @@
 ---
 title: Terms of Service
 sidebar: Terms of Service
-feedback: false
+hide-feedback: true
 ---
 
 [email]: mailto:legal@segment.com

--- a/src/legal/website-data-collection-policy.md
+++ b/src/legal/website-data-collection-policy.md
@@ -1,7 +1,7 @@
 ---
 title: Website Data Collection Policy
 sidebar: Website Data Collection Policy
-feedback: false
+hide-feedback: true
 ---
 
 Segment uses data collected by cookies and javascript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.

--- a/src/protocols/anomaly_detection.md
+++ b/src/protocols/anomaly_detection.md
@@ -47,13 +47,13 @@ Source: \{{properties.sourceName}} \nEvent: \{{properties.eventName}} \nViolatio
 ```
 When you're done, it'll look like the screenshot below.
 
-![](images/slack_violation_generated_setup.png)
+![](../images/slack_violation_generated_setup.png)
 
 
 ### Create customized Anomaly Detection dashboards in a BI tool
 Custom dashboards are a great way to focus your teams around the metrics and events that matter most to your business. With a few simple queries you can build a dashboard to share with teams, so everyone can understand how well they're doing against your data quality objectives. Here's an example dashboard that can be built with the queries.
 
-![](images/anomaly_detection_dashboard.png)
+![](../images/anomaly_detection_dashboard.png)
 
 Note: For all queries below, replace `protocols_audit_source` with whatever schema name you set for your forwarded violations source.
 


### PR DESCRIPTION
Fixing some of the frontmatter to align with the ongoing/current docs, for ease of content sync later.

This includes:
- changing how we do the "hide feedback footer" for pages we don't want feedback on (for example, legal, or a page with redirects)
- adding a redirect for the config-api reference page (which we did already in the main docs)
- updating the personas partial and "hide" frontmatter.
