### PR TITLE
stop adding extra words to the title

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -1,6 +1,6 @@
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 <head>
-  <title> {{page.title}} {{page.integration_type | capitalize }}| Segment Documentation</title>
+  <title> {{page.title}} | Segment Documentation</title>
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Segment" />


### PR DESCRIPTION
Originally we set this to try to add the word "warehouse" or "destination" or "source" to every instance of the right integration, but it ended up causing more issues than it solved, so I'm removing it and we're adding that explicitly in the `title` instead.