### PR TITLE
fix(): Change input to button

### DIFF
--- a/src/_includes/components/callout.html
+++ b/src/_includes/components/callout.html
@@ -17,7 +17,7 @@
               <input class="callout__input input input--expand" id="demoEmailInput" type="email" required placeholder="Your work e-mail">
             </div>
             <div class="flex__column flex__column--12 flex__column--shrink@medium">
-              <input type="submit" class="button button--large button--expand button-fill " value="Request Demo">
+              <button class="button button--large button--expand button-fill">Request Demo</button>
             </div>
           </form>
         </div>


### PR DESCRIPTION
I changed `input type="submit"` to `button`, because `button` is expected tag to mark submit elements. In addition, the button does not need the `type = "submit"` attribute - this is the default behavior and `input` tag change our styles created for `button`.

Fixes #243 