### PR TITLE
fix(): Remove context menu from cache

### DIFF
--- a/src/_layouts/integration.html
+++ b/src/_layouts/integration.html
@@ -7,7 +7,7 @@ layout: default
     <div class="docs__aside stage__aside">
       {% include_cached navbar/logo.html %}
 
-      {% include_cached menu/menu-{{ page.integration_type }}.html %}
+      {% include menu/menu-{{ page.integration_type }}.html %}
     </div>
 
     <main class="docs__body stage__body">


### PR DESCRIPTION
Closes:  #255 

We have removed the cache from the context menu, because the integration page used the cached menu from another page. 