### PR TITLE
Taking our erroneous spaces

### DIFF
--- a/src/connections/destinations/catalog/impact-radius/index.md
+++ b/src/connections/destinations/catalog/impact-radius/index.md
@@ -40,7 +40,7 @@ Impact recommends you cache this value in the users browser (using a cookie or l
 analytics.track('Some Conversion Event' { someProperty: true }, {
   context: {
     referrer: {
-      type: ' impactRadius ',
+      type: 'impactRadius',
       id: <CACHED_CLICK_ID>
     }
   }


### PR DESCRIPTION
### Proposed changes

Those 2 spaces cause the mapping to fail when hitting our integration code. Taking them out so customers can copy and paste and have it succeed.
