### PR TITLE
fix link in media icon link

### DIFF
--- a/src/_includes/components/media-icon.html
+++ b/src/_includes/components/media-icon.html
@@ -1,5 +1,5 @@
 <div class="media-icon">
-  <a class="media-icon__inner" href="{{ site.baseurl }}{{ include.href }}">
+  <a class="media-icon__inner" href="{{ include.href }}">
     <span class="media-icon__icon">
       {% if include.icon %}
         {% include icons/{{ include.icon }} %}


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

Fixes broken media link on page: https://segment.com/docs/connections/sources/#website-libraries

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
