### PR TITLE
Clarify Adobe Heartbeat availability

### DIFF
--- a/src/connections/destinations/catalog/adobe-analytics/index.md
+++ b/src/connections/destinations/catalog/adobe-analytics/index.md
@@ -839,7 +839,7 @@ And on iOS:
 - [Custom Video Metadata](#custom-video-metadata)
 - [Troubleshooting and Logging Heartbeat](#troubleshooting-and-logging-heartbeat)
 
-Adobe Heartbeat is an Adobe Analytics add-on that allows you to collect video analytics data from [mobile applications, and Javascript or website sources](https://marketing.adobe.com/resources/help/en_US/sc/appmeasurement/hbvideo/). At this time, Adobe Heartbeat is only available for events sent client side.
+Adobe Heartbeat is an Adobe Analytics add-on that allows you to collect video analytics data from [mobile applications, and Javascript or website sources](https://marketing.adobe.com/resources/help/en_US/sc/appmeasurement/hbvideo/). At this time, Adobe Heartbeat is only available for events sent device mode.
 
 Before you start, complete these required steps.
 


### PR DESCRIPTION
Make it clearer that adobe heartbeat is only available for client-side sent events at this time.