### PR TITLE
Clarify schema defaults BT only access

### DIFF
--- a/src/guides/filtering-data.md
+++ b/src/guides/filtering-data.md
@@ -70,7 +70,7 @@ Schema defaults allow you to prevent unexpected or malformed data from a Source 
 
 Data blocked using schema defaults is permanently discarded, and cannot be recovered or replayed through Segment. You can forward blocked data to a new Source, but these events count toward your account MTU limits, and may not be worth saving.
 
-Schema Defaults are available to all customers, regardless of Segment plan.
+Schema Defaults are only available to Business Tier customers.
 
 You can find the Schema Defaults in the **Settings** tab for each Source, in **Schema Configuration** section.
 


### PR DESCRIPTION
### Proposed changes

Update language confirming that Schema Defaults are only available to BT customers

### Related issues (optional)
Surfaced in Slack by @davidjodononvan 
https://segment.slack.com/archives/CKD8PTVDH/p1576760256000600