### PR TITLE
removed Beta sections

### DIFF
--- a/src/connections/destinations/catalog/adquick/index.md
+++ b/src/connections/destinations/catalog/adquick/index.md
@@ -7,7 +7,7 @@ rewrite: true
 
 This destination is maintained by AdQuick. For any issues with the destination, please [reach out to their team](mailto:segment@adquick.com).
 
-_**NOTE:** The AdQuick Destination is currently in beta, which means that they are still actively developing the destination. This doc was last updated on October 2, 2019. If you are interested in joining their beta program or have any feedback to help improve the AdQuick Destination and its documentation, please [let  their team know](mailto:segment@adquick.com)!_
+This document was last updated on January 8, 2020. If you notice any gaps, out-dated information, or simply want to leave some feedback to help us improve our documentation, please [let  their team know](mailto:segment@adquick.com)!
 
 
 ## Getting Started

--- a/src/connections/destinations/catalog/criteo-offline-conversions/index.md
+++ b/src/connections/destinations/catalog/criteo-offline-conversions/index.md
@@ -8,7 +8,7 @@ hide-personas-partial: true
 
 The Criteo Offline Conversions Destination and this document are maintained by Criteo. For any issues with the destination, please [let us know!](mailto:support@criteo.com).
 
-_**NOTE:** The Criteo Offline Conversions Destination is currently in beta, which means that we are still actively developing the destination. This doc was last updated on October 8, 2019. If you are interested in joining our beta program or have any feedback to help improve the Criteo Offline Conversions Destination and its documentation, please [let  us know](mailto:support@criteo.com)!_
+This document was last updated on January 8, 2020. If you notice any gaps, out-dated information, or simply want to leave some feedback to help us improve our documentation, please [let  us know](mailto:support@criteo.com)!
 
 
 ## Getting Started

--- a/src/connections/destinations/catalog/modern-pricing/index.md
+++ b/src/connections/destinations/catalog/modern-pricing/index.md
@@ -7,11 +7,11 @@ hide-personas-partial: true
 
 This destination is maintained by Modern Pricing. For any issues with the destination, please [reach out to their team](mailto:john@modernpricing.com).
 
-_**NOTE:** The Modern Pricing Destination is currently in beta, which means that they are still actively developing the destination. This doc was last updated on November 6, 2019. If you are interested in joining their beta program or have any feedback to help improve the Modern Pricing Destination and its documentation, please [let  their team know](mailto:john@modernpricing.com)!_
+This document was last updated on January 8, 2020. If you notice any gaps, out-dated information, or simply want to leave some feedback to help us improve our documentation, please [let  their team know](mailto:john@modernpricing.com)!
 
 ## Getting Started
 
-{% include content/connection-modes.md %} 
+{% include content/connection-modes.md %}
 
 1. From your Segment UI's Destinations page click on "Add Destination".
 2. Search for "Modern Pricing" within the Destinations Catalog and confirm the Source you'd like to connect to.
@@ -40,7 +40,7 @@ analytics.page(
     ip_address: request.remote_ip,
     user_agent: request.user_agent
   },
-  properties: { 
+  properties: {
     url: request.original_url,
     path: request.path,
     referrer: request.referrer
@@ -89,11 +89,11 @@ For *logged in* visitors:
 
 ## Identify Postback
 
-When you integrate Modern Pricing via Segment, Modern Pricing returns a postback Identify call to your source so that you'll be able to easily pass the score to your downstream destinations. 
+When you integrate Modern Pricing via Segment, Modern Pricing returns a postback Identify call to your source so that you'll be able to easily pass the score to your downstream destinations.
 
 How does it work?
 
-1. You send a Page call from your server-source like normal. 
-2. Modern Pricing then recognizes your Page call and automatically returns and Identify call with the `modern_pricing_score` trait. 
+1. You send a Page call from your server-source like normal.
+2. Modern Pricing then recognizes your Page call and automatically returns and Identify call with the `modern_pricing_score` trait.
 
 Segment is then able to send the Modern Pricing score to the other destinations you have connected to your source.


### PR DESCRIPTION
removed sections stating destination was in beta for adquick, criteo offline, and modern pricing

(note: also changed status in Partner Portal)
