### PR TITLE
add datalakes cta so we do not encounter a 404

### DIFF
--- a/src/connections/destinations/catalog/data-lakes/index.md
+++ b/src/connections/destinations/catalog/data-lakes/index.md
@@ -1,0 +1,6 @@
+---
+hidden: true
+title: Data Lakes (Private Beta)
+---
+
+Data lakes is currently in private beta for BT customers. Please contact your Customer Success Manager (CSM) or Account Executive (AE) for details.


### PR DESCRIPTION
### Proposed changes

This adds an entry for the new Data Lakes destination, so that customers clicking through the documentation link from the catalog page have some content to view. This is just to mitigate the 404 for now, while we build out real docs on the path to GA.

<img width="895" alt="Screen Shot 2020-01-22 at 12 44 01 PM" src="https://user-images.githubusercontent.com/843979/72933506-b1d01380-3d16-11ea-84b1-f7769597cfa4.png">

### Related issues (optional)

https://github.com/segmentio/segment-docs/pull/543