### PR TITLE
add some backup codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # The default owners for everything in
 # the repo. Unless a later match takes precedence.
-CODEOWNERS  @sanscontext
+CODEOWNERS  @sanscontext @XavierAgostini @danielstjules @stephment
 
 # Content owners should be in the order of PM, TL (team-lead), and EM (in a crisis) for a given team.
 # This team will receive review requests automatically when a PR is submitted modifying the files in


### PR DESCRIPTION
### Proposed change
In the event of my winning the lottery, I'd like to not have the presence of a Codeowners file here ruin things for other people. :)