### PR TITLE
remove note about Mixpanel People only working on a.js and mobile

### DIFF
--- a/src/connections/destinations/catalog/mixpanel/index.md
+++ b/src/connections/destinations/catalog/mixpanel/index.md
@@ -283,7 +283,10 @@ Mixpanel's [Autotrack](https://mixpanel.com/autotrack/) feature is supported via
 
 By default we don't send data to Mixpanel People since it usually requires upgrading your Mixpanel account. If you want to enable Mixpanel People simply check the box for: **Use Mixpanel People** from your source destinations page in the Mixpanel sheet.
 
-If you want to add people properties in Mixpanel before you know the user's unique databse `userId` you can identify `traits` without the `userId`. **Note:** this only works in Analytics.js and our mobile SDKs.
+If you want to add people properties in Mixpanel before you know the user's unique databse `userId` you can identify `traits` without the `userId`. 
+
+<!-- Removing this note as this has been tested with our server libraries and works (Feb 2020) -->
+<!--**Note:** this only works in Analytics.js and our mobile SDKs.-->
 
 Your `identify` call would look like this in Analytics.js if you only want to set people properties without a `userId`:
 


### PR DESCRIPTION
We have tested on server-side libraries (node.js and PHP) and also reviewed the server-side integration code and it looks like Mixpanel People works with server-side libraries. Traits like first name and last name are picked up automatically as long as the "Use Mixpanel People" setting is toggled on.

