### PR TITLE
Update Intercom Admin Collection

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/intercom/index.md
+++ b/src/connections/sources/catalog/cloud-apps/intercom/index.md
@@ -169,12 +169,6 @@ Collections are the groupings of resources we pull from your source. In your war
 | id | The id of the admin or team |
 | name | The name of the admin or team |
 | email | The email address of the admin. This attribute is null for teams |
-| job_title | The job title of the admin |
-| away_mode_enabled | Identifies if this admin is currently set in away mode to automatically reassign new conversations to your app's default inbox |
-| away_mode_reassign | When in away mode you can still reply to conversations. If this is set to true then any replies will automatically go into your app's default inbox |
-| team_ids | This is a list of teams id's that you are part of. Only set if the type is 'admin' |
-| admin_ids  This is the list of admins on the team. Only set if the type is 'team' |
-| avatar | Image for the associated team or teammate |
 
 
 ## Social Profiles


### PR DESCRIPTION
Docs incorrectly stated that we supported 9 fields within the Admin collection when we only support a subset. Removed the following since we don't support them:

| job_title | The job title of the admin |
| away_mode_enabled | Identifies if this admin is currently set in away mode to automatically reassign new conversations to your app's default inbox |
| away_mode_reassign | When in away mode you can still reply to conversations. If this is set to true then any replies will automatically go into your app's default inbox |
| team_ids | This is a list of teams id's that you are part of. Only set if the type is 'admin' |
| admin_ids  This is the list of admins on the team. Only set if the type is 'team' |
| avatar | Image for the associated team or teammate |


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
