### PR TITLE
Enable with segment- token endpoint

### DIFF
--- a/src/partners/enable-with-segment.md
+++ b/src/partners/enable-with-segment.md
@@ -111,7 +111,7 @@ If you use a standard OAuth library in your programming language, all of this is
 2. If the user is logged out, Segment redirects to `https://app.segment.com/login`
 3. If the user is logged in, Segment redirects to `https://app.segment.com/authorize`
 4. If user consents, Segment redirects with a code to your redirect_uri `http://localhost:8888/auth/segment/callback`. This app listens for this request and runs step #5 below.
-5. You exchange the code with for an install token from `https://id.segmentapis.com/oauth2/token`. The body of this POST request should include the code you received and your redirect_uri. Include your client secret and client id in a basic authorization header.
+5. You exchange the code with for an install token from `https://id.segmentapis.com/oauth2/token`. The body of this POST request should include the code you received and your `redirect_uri`. Include your client secret and client id in a basic authorization header.
 6. You save the access token, install name, workspace name and source name for the user.
 
 At the end of a successful flow you get an "Install Token". If you passed in the scope as `destination/clearbrain` the user is prompted to select a source on which to install your Enable With Segment App, and that source is returned to you as well.


### PR DESCRIPTION

### Proposed changes

Adding details for how to correctly call the token exchange endpoint. We don't mention that you need to put the client secret and ID in a basic authorization header. The library we use in our partnerapp demo does this.

