### PR TITLE
remove beta note for now.

### DIFF
--- a/src/_layouts/integration.html
+++ b/src/_layouts/integration.html
@@ -54,10 +54,7 @@ layout: default
 
           <div class="integration__body page__body">
             <div class="markdown">
-              {% if page.beta %}
-                {% capture beta-note %}{% include content/beta-note.md %}{% endcapture %}
-                {{ beta-note | markdownify }}
-              {% endif %}
+
               {% if page.integration_type == 'source' %}
                 {% capture cloud-app-note %}{% include content/cloud-app-note.md %}{% endcapture %}
                 {{ cloud-app-note | markdownify }}


### PR DESCRIPTION
### Proposed changes

this got rolled in to some cloud-sources changes, so we need to remove it until we've had a better chance to normalize the beta flagging. :)

in `integrations.html`
```
              {% if page.beta %}
                {% capture beta-note %}{% include content/beta-note.md %}{% endcapture %}
                {{ beta-note | markdownify }}
              {% endif %}
```
