### PR TITLE
Updated PR re: sync history status

### DIFF
--- a/src/connections/warehouses/faq.md
+++ b/src/connections/warehouses/faq.md
@@ -44,19 +44,20 @@ Real-time loading of the data into Segment Warehouses would cause significant pe
 
 As we improve and update our ETL processes and optimize for SQL query performance downstream, the actual load time will vary, but we'll ensure it's always within 24 hours.
 
-To understand how successfully each Warehouse sync run is updating the data in your warehouse, you can visit the Sync History page which is available for every source connected to each warehouse. This page will help you answer questions such as, is the data for a specific source fresh because the most recent sync was successful? Did a sync completely fail, or only partially fail? Why was a particular sync not successful?
+You can use the Sync History page to see the status and history of data updates in your warehouse. The Sync History page is available for every source connected to each warehouse. This page helps you answer questions like, "has the data from a specific source been updated recently?" "Did a sync completely fail, or only partially fail?" and "Why wasn't this sync successful?"
 
-Sync History will provide the following insights: 
-- Sync Status: Performance of each sync is based on notices (errors or warnings) from sync run as well as the number of rows synced to the warehouse. The possible values are:
-    - Success: Sync run complete without any notices and all rows synced, OR no rows synced because no data found.
-    - Partial: Sync run with some notices and some rows synced.
-    - Failure: Sync run with some notices and no rows synced.
-- Start Time: Time which the sync began. Shown in a user’s local timezone. 
-- Duration: Length of sync.
-- Synced Rows: Number of rows successfully synced from the sync run.
-- Notices: Errors or warnings found which are likely impacting the success of the sync run. Clicking on the notice message will show details about the results and any errors or warnings found for each of the collections within the sync run.
+The Sync History includes the following information:
+- **Sync Status**: The possible statuses are:
+  - _Success_: Sync run completed without any notices and all rows synced, OR no rows synced because no data was found.
+  - _Partial_: Sync run completed with some notices and some rows synced.
+  - _Failure_: Sync run with some notices and no rows synced.
+- **Start Time**: The time at which the sync began. Shown in your local timezone.
+- **Duration**: Length of time this sync took.
+- **Synced Rows**: Number of rows successfully synced from the sync run.
+- **Notices**: A list of errors or warnings found, which could indicate problems with the sync run. Click a notice message to show details about the result, and any errors or warnings for each collection included in the sync run.
 
-Please note that if a sync run shows a partial success or failure, the next sync will retry syncing the data which was not successfully synced in the prior run.
+> info ""
+> If a sync run shows a partial success or failure, the next sync attempts to syncing any data which was not successfully synced in the prior run.
 
 
 ## What if I want to add custom data to my warehouse?


### PR DESCRIPTION
In the question about data freshness, we added a section explaining how the Sync History page can help share insights into data freshness.

Note: I'm not 100% sure if the formatting for the bullets is correct.