### PR TITLE
Add "last modified" plugin, add to layouts.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,8 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
+
+# add "last modified" date to template
+group :jekyll_plugins do
+  gem "jekyll-last-modified-at"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-include-cache (0.2.0)
       jekyll (>= 3.7, < 5.0)
+    jekyll-last-modified-at (1.2.1)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-redirect-from (0.15.0)
       jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.0.1)
@@ -65,6 +68,7 @@ GEM
     multipart-post (2.1.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.13)
     premonition (2.0.0)
     public_suffix (4.0.1)
     rake (13.0.1)
@@ -96,6 +100,7 @@ DEPENDENCIES
   jekyll!
   jekyll-commonmark
   jekyll-include-cache
+  jekyll-last-modified-at
   jekyll-redirect-from
   jekyll-sitemap
   liquid-c

--- a/_config.yml
+++ b/_config.yml
@@ -44,3 +44,4 @@ plugins:
   - jekyll-redirect-from
   - premonition
   - jekyll-commonmark
+  - jekyll-last-modified-at

--- a/src/_layouts/integration.html
+++ b/src/_layouts/integration.html
@@ -65,6 +65,7 @@ layout: default
                 {{ integration-foot | markdownify }}
               {% endif %}
             </div>
+            <p><i style="color: #a5b0ba;font-size: small;">This page was last modified: {{ page.last_modified_at | date: '%d %b %Y' }} </i></p>
 
             {% if page.contributors %}
               {% include components/avatar.html contributors=page.contributors %}

--- a/src/_layouts/main.html
+++ b/src/_layouts/main.html
@@ -12,8 +12,6 @@ layout: default
         {% include menu/menu-glossary.html %}
       {% elsif currentPage[1] == 'partners' %}
         {% include menu/menu-partners.html %}
-      {% elsif currentPage[1] == 'legal' %}
-        {% include menu/menu-legal.html %}
       {% else %}
         {% include menu/menu.html %}
       {% endif %}

--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -27,6 +27,7 @@ layout: main
         <div class="markdown">
           {{ content }}
         </div>
+        <p><i style="color: #a5b0ba;font-size: small;">This page was last modified: {{ page.last_modified_at | date: '%d %b %Y' }} </i></p>
         {% if page.contributors %}
           {% include components/avatar.html contributors=page.contributors %}
         {% endif %}


### PR DESCRIPTION
### Proposed changes
Adds the "last modified at" plugin to Jekyll, adds the snippet to the page layouts. Which means we can now remove the "and this doc was last updated on" text everywhere.

https://github.com/gjtorikian/jekyll-last-modified-at
![image](https://user-images.githubusercontent.com/17016388/75075098-f1268700-54b1-11ea-94e9-7920cb316e70.png)

### Related issues (optional)

 Closes #655 