### PR TITLE
remove more paragraph html from tables.

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/salesforce-marketing-cloud/index.md
+++ b/src/connections/sources/catalog/cloud-apps/salesforce-marketing-cloud/index.md
@@ -118,12 +118,12 @@ refer to the Salesforce Marketing Cloud documentation linked in each [collection
 
 ### Campaign Assets
 
-| Property Name | Description                                                                                                                                                                                                                       |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| campaign_id   | The ID of the campaign this asset is associated to                                                                                                                                                                                |
-| created_date  | Timestamp when the asset was created                                                                                                                                                                                              |
-| id            | The campaign asset ID                                                                                                                                                                                                             |
-| item_id       | The asset's unique ID in Salesforce Marketing Cloud                                                                                                                                                                               |
+| Property Name | Description |
+| ------------- | ------------------------- |
+| campaign_id   | The ID of the campaign this asset is associated to  |
+| created_date  | Timestamp when the asset was created   |
+| id            | The campaign asset ID         |
+| item_id       | The asset's unique ID in Salesforce Marketing Cloud     |
 | type          | The asset type. Can be one of: email, triggered send, mobile message, push message, twitter update, facebook update, facebook tab,  sites, landing pages, subscriber list, subscriber group, data extension, automation, or event |
 
 
@@ -175,6 +175,7 @@ refer to the Salesforce Marketing Cloud documentation linked in each [collection
 |                             |                                                                                                                                                                                        |
 
 ### Goals
+
 | Property Name                                      | Description                                                                                                     |
 | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | interaction_id                                     | The id of the interaction that this goal is associated with                                                     |

--- a/src/connections/sources/catalog/libraries/server/go/v2/index.md
+++ b/src/connections/sources/catalog/libraries/server/go/v2/index.md
@@ -146,8 +146,7 @@ The `page` call has the following fields:
   </tr>
   <tr>
     <td>`Context` _map[string]interface{}, optional_</td>
-    <td>Extra [context]() to attach to the call.
-      <p>**Note:** `context` differs from `traits` because it is not attributes of the user itself.</p></td>
+    <td>Extra [context]() to attach to the call. **Note:** `context` differs from `traits` because it is not attributes of the user itself.</td>
   </tr>
   <tr>
     <td>`AnonymousId` _string, optional_</td>

--- a/src/connections/spec/ecommerce/v2.md
+++ b/src/connections/spec/ecommerce/v2.md
@@ -1492,7 +1492,7 @@ This event supports the following semantic properties:
     <td>total</td>
     <td>Number</td>
     <td>Revenue ($) with discounts and coupons added in
-      <p>Note that our Google Analytics Ecommerce destination accepts `total` *or* `revenue`, but not both. For better flexibility and total control over tracking, we let you decide how to calculate how coupons and discounts are applied</p></td>
+      Note that our Google Analytics Ecommerce destination accepts `total` *or* `revenue`, but not both. For better flexibility and total control over tracking, we let you decide how to calculate how coupons and discounts are applied</td>
   </tr>
   <tr>
     <td>revenue</td>

--- a/src/connections/spec/group.md
+++ b/src/connections/spec/group.md
@@ -107,7 +107,7 @@ The following are the reserved traits we have standardized:
     <td>`address`</td>
     <td>Object</td>
     <td>Street address of a group
-      <p>This should be a dictionary containing optional `city`, `country`, `postalCode`, `state` or `street`.</p></td>
+      This should be a dictionary containing optional `city`, `country`, `postalCode`, `state` or `street`.</td>
   </tr>
   <tr>
     <td>`avatar`</td>
@@ -118,7 +118,7 @@ The following are the reserved traits we have standardized:
     <td>`createdAt`</td>
     <td>Date</td>
     <td>Date the group's account was first created
-    <p>We recommend [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601) date strings.</p></td>
+    We recommend [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601) date strings.</td>
   </tr>
   <tr>
     <td>`description`</td>

--- a/src/connections/spec/identify.md
+++ b/src/connections/spec/identify.md
@@ -174,8 +174,7 @@ Reserved traits we've standardized:
   <tr>
     <td>`createdAt`</td>
     <td>Date</td>
-    <td>Date the user's account was first created
-      <p>We recommend [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601) date strings.</p></td>
+    <td>Date the user's account was first created. We recommend [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601) date strings.</td>
   </tr>
   <tr>
     <td>`description`</td>
@@ -210,8 +209,7 @@ Reserved traits we've standardized:
   <tr>
     <td>`name`</td>
     <td>String</td>
-    <td>Full name of a user
-      <p> If you only pass a first and last name we'll automatically fill in the full name for you.</p>
+    <td>Full name of a user. If you only pass a first and last name we'll automatically fill in the full name for you.
     </td>
   </tr>
   <tr>
@@ -222,15 +220,13 @@ Reserved traits we've standardized:
   <tr>
     <td>`title`</td>
     <td>String</td>
-    <td>Title of a user, usually related to their position at a specific company
-      <p>Example: "VP of Engineering"</p>
+    <td>Title of a user, usually related to their position at a specific company. Example: "VP of Engineering"
     </td>
   </tr>
   <tr>
     <td>`username`</td>
     <td>String</td>
-    <td>User's username
-      <p> This should be unique to each user, like the usernames of Twitter or GitHub.</p></td>
+    <td>User's username. This should be unique to each user, like the usernames of Twitter or GitHub.</td>
   </tr>
   <tr>
     <td>`website`</td>

--- a/src/connections/spec/track.md
+++ b/src/connections/spec/track.md
@@ -115,7 +115,7 @@ The following is all the reserved properties we have standardized that apply to 
     <td>`currency`</td>
     <td>String</td>
     <td>Currency of the revenue an event resulted in
-      <p>This should be sent in the [ISO 4127 format](http://en.wikipedia.org/wiki/ISO_4217). If this is not set, we assume the revenue to be in US dollars.</p></td>
+      This should be sent in the [ISO 4127 format](http://en.wikipedia.org/wiki/ISO_4217). If this is not set, we assume the revenue to be in US dollars.</td>
   </tr>
   <tr>
     <td>`value`</td>


### PR DESCRIPTION
### Proposed changes

Removed a bunch of stray paragraph markers from html tables, 
added a space between a heading and a markdown table.

### Related issues (optional)

Closes #639 