### PR TITLE
Update a small detail on our SFMC documentation.

### DIFF
--- a/src/connections/destinations/catalog/salesforce-marketing-cloud/index.md
+++ b/src/connections/destinations/catalog/salesforce-marketing-cloud/index.md
@@ -8,7 +8,7 @@ Segment's Salesforce Marketing Cloud destination allows you to add contacts with
 
 ### A Note About ExactTarget
 
-ExactTarget was recently acquired by Salesforce and renamed "Salesforce Marketing Cloud." Throughout Segment, we'll stick to the name Salesforce Marketing Cloud, but know that the names "Salesforce Marketing Cloud" and "ExactTarget" refer to the same product.
+ExactTarget was acquired by Salesforce in 2013 and renamed "Salesforce Marketing Cloud." Throughout Segment, we'll stick to the name Salesforce Marketing Cloud, but know that the names "Salesforce Marketing Cloud" and "ExactTarget" refer to the same product.
 
 ### API Access
 


### PR DESCRIPTION
I don't think 2013 qualifies as a recent acquisition at this point.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

I changed a sentence that said Salesforce recently acquired ExactTarget.  It's not recent at this point: https://www.salesforce.com/company/news-press/press-releases/2013/06/130604/

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
