### PR TITLE
We don't support .NET Core

### DIFF
--- a/src/connections/sources/catalog/libraries/server/net/index.md
+++ b/src/connections/sources/catalog/libraries/server/net/index.md
@@ -517,3 +517,6 @@ Please note: the logger requires a minimum version of .NET Core 2.1.
 ### Mono
 
 `Analytics.NET` has been tested and works in Mono.
+
+### .NET Core
+`Analytics.NET` is not officially supported using the .NET Core runtime.


### PR DESCRIPTION
### Proposed changes

A customer was attempting to use .NET Core runtime with our Analytics.NET. Added explicit call-out that we don't officially support this runtime.

### Related issues (optional)

https://segment.slack.com/archives/CALA7QMJQ/p1584556597256500
