### PR TITLE
Update SS permissions to match current fcn

### DIFF
--- a/src/connections/warehouses/selective-sync.md
+++ b/src/connections/warehouses/selective-sync.md
@@ -43,4 +43,4 @@ To manage data from one specific source to an individual warehouse, go to the Wa
 All changes made through Selective Sync only impact an individual warehouse - they do **not** propagate to multiple warehouses at once. To make changes to multiple warehouses, you need to enable/disable data for each individual warehouse.
 
 > warning ""
-> Note: Only Workspace or Warehouse Administrators can change Selective Sync settings.
+> Note: Only Workspace Owners can change Selective Sync settings.


### PR DESCRIPTION
selective sync permissions currently aren't set up as intended so only workspace owners can update selective sync, and warehouse admins cannot. we aren't able to fix this immediately, so in the meantime we're updating the docs to reflect the current functionality. https://segment.atlassian.net/browse/WARE-321