### PR TITLE
Correcting the catalog URL

### DIFF
--- a/src/connections/destinations/catalog/personas-display-video-360/index.md
+++ b/src/connections/destinations/catalog/personas-display-video-360/index.md
@@ -95,7 +95,7 @@ To create audiences based on website browsing events, set up the Segment-to-Goog
 
 The DV360 Personas destination is in beta, and so you must access it using a special link.
 
-Copy example link below, replace all three slugs with your workspace information: replace the instance of `<workspace_slug>` with your Segment workspace slug, and your `<source_slug>` and `<personas_space_slug>` are found in the URL when you are viewing your personas space right after `spaces/`.
+Copy the example link below, replace all three slugs with your workspace information: replace the instance of `<workspace_slug>` with your Segment workspace slug. You can find your `<source_slug>` and `<personas_space_slug>` right after `spaces/` in the URL when viewing your personas space.
 
 ```text
 https://app.segment.com/<workspace_slug>/destinations/catalog/personas-display-video-360?sourceSlug=personas_<source_slug>&spaceSlug=<personas_space_slug>`


### PR DESCRIPTION
### Proposed changes

The URL of where to find dv360 as a destination in the catalog was incorrect. I corrected it and added a line about how to find the values customers are supposed to input.