### PR TITLE
Replace downcase with slugify to remove spaces in id element

### DIFF
--- a/src/_layouts/catalog.html
+++ b/src/_layouts/catalog.html
@@ -24,7 +24,7 @@ layout: default
         <article class="destinations">
           {% include components/breadcrumbs.html %}
           {%- if page.title -%}
-            <h1 id="{{ page.title | downcase }}" class="destinations__heading page__heading">
+            <h1 id="{{ page.title | slugify }}" class="destinations__heading page__heading">
               {{ page.title }}
             </h1>
           {%- endif -%}

--- a/src/_layouts/home.html
+++ b/src/_layouts/home.html
@@ -16,7 +16,7 @@ layout: main
       <div class="home__body">
         <div>
           {%- if page.title -%}
-            <h1 id="{{ page.title | downcase }}" class="home__heading page__heading">
+            <h1 id="{{ page.title | slugify }}" class="home__heading page__heading">
               {{ page.title }}
             </h1>
           {%- endif -%}

--- a/src/_layouts/integration.html
+++ b/src/_layouts/integration.html
@@ -33,7 +33,7 @@ layout: default
             {%- endif -%}
             <div class="flex__column">
               {%- if page.title -%}
-                <h1 id="{{ page.title | downcase }}" class="page__heading">
+                <h1 id="{{ page.title | slugify }}" class="page__heading">
                   {{ page.title }}
                 </h1>
               {%- endif -%}

--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -14,7 +14,7 @@ layout: main
       {% include components/breadcrumbs.html %}
       <div class="page__body" data-headings-anchors>
         {%- if page.title -%}
-          <h1 id="{{ page.title | downcase }}" class="page__heading">
+          <h1 id="{{ page.title | slugify }}" class="page__heading">
             {{ page.title }}
           </h1>
         {%- endif -%}


### PR DESCRIPTION
### Proposed changes

id elements should never have spaces. Currently, we are taking the page title and using the `downcase` filter as the h1 tag id. I'm changing this to `slugify` so multi-word titles dont leave spaces. This should also fix our swiftype indexing errors (missing h1 tags).