### PR TITLE
Change info data-type back to string to fix swiftype error

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -39,7 +39,7 @@
   <meta name="robots" content="noindex" />
   {%- else -%}
   <meta class="swiftype" name="section" data-type="enum" content="{{ sectionName }}" />
-  <meta class="swiftype" name="info" data-type="enum" content="{{description}}" />
+  <meta class="swiftype" name="info" data-type="string" content="{{description}}" />
   <meta class="swiftype" name="description" data-type="enum" content="{{description}}" />
   <meta class="swiftype" name="title" data-type="string" content="{{page.title}}" />
   <meta class="swiftype" name="priority" data-type="integer" content="{{priority}}" />


### PR DESCRIPTION
### Proposed changes

This changes the swiftype data-type from enum -> string. In the swiftype dashboard, we are getting the error: "The "info" field was previously added using the "string" data type, but the current version of this page is using the "enum" data type. This prevents us from adding the page." According to their docs, this field should be a string: https://swiftype.com/documentation/site-search/crawler-overview#schema