### PR TITLE
updated node index.md

### DIFF
--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -1,6 +1,6 @@
 ---
 title: Analytics for Node.js
-redirect_from: '/connections/sources/catalog/libraries/server/node-js'
+redirect_from: '/connections/sources/catalog/libraries/server/node'
 ---
 
 Our Node.js library lets you record analytics data from your node code. The requests hit our servers, and then we route your data to any destinations you have enabled.


### PR DESCRIPTION
### Proposed changes

all nodejs links are pointing to https://segment.com/docs/connections/sources/catalog/libraries/server/node-js/ instead of the correct link: https://segment.com/docs/connections/sources/catalog/libraries/server/node/

I tried parsing our complex jekyll setup and it felt this might the right place to change for the site to render correctly. please review thoroughly
