### PR TITLE
Dont index feedback or callout in Swiftype

### DIFF
--- a/src/_includes/components/callout-mobile.html
+++ b/src/_includes/components/callout-mobile.html
@@ -1,4 +1,4 @@
-<div class="callout panel panel--primary panel--mobile">
+<div class="callout panel panel--primary panel--mobile" data-swiftype-index="false">
   <div class="panel__inner">
     <h4>{{ include.heading }}</h4>
 

--- a/src/_includes/components/callout.html
+++ b/src/_includes/components/callout.html
@@ -1,4 +1,4 @@
-<div class="callout panel">
+<div class="callout panel" data-swiftype-index="false">
     <div class="panel__inner">
       <div class="flex">
         <div class="flex__column flex__column--12 flex__column--9@xlarge">

--- a/src/_includes/components/feedback.html
+++ b/src/_includes/components/feedback.html
@@ -1,4 +1,4 @@
-<div class="flex flex--wrap waffle waffle--xxlarge@medium">
+<div class="flex flex--wrap waffle waffle--xxlarge@medium" data-swiftype-index="false">
   <div class="flex__column flex__column--6 flex">
     <div class="feedback-box flex flex--stack flex--justify waffle waffle--none waffle--small@medium">
       <div class="flex__column flex__column--shrink">


### PR DESCRIPTION
### Proposed changes
Currently because of the use of h4 tags, Swiftype can index "Need support?", "Was this page helpful?", and "Get started with Segment" as sections. Since they're consistent on every page, this is unnecessary.