### PR TITLE
Redshift SSH Tunnel not Supported doc outline

### DIFF
--- a/src/connections/warehouses/catalog/redshift/index.md
+++ b/src/connections/warehouses/catalog/redshift/index.md
@@ -190,4 +190,4 @@ You can also unload data to a s3 bucket and then load the data into another Reds
 
 ### Can I use an SSH tunnel to connect to my Redshift instance?
 
-We don't currently support SSH tunneling. Typically our customers will use IP level restrictions to allow Segment's ETL to write to Redshift without leaving the cluster available to other connections.
+Segment does not currently support SSH tunneling to Redshift. You can usually allow Segment's ETL to write to Redshift without leaving the cluster available to other connections by using IP level restrictions.


### PR DESCRIPTION
# Proposed changes

We constantly have customers reaching in and asking if we support SSH Tunneling to a Redshift instance and it's about time we outline the fact that we do not support SSH Tunneling to a Redshift instance in our public-facing docs. This is why I've added this change.

Please take a look and let me know if there are any changes that we would improve this change @sanscontext 