### PR TITLE
[PD-151] Clean up Personas CSV documentation copy

### DIFF
--- a/src/personas/audiences.md
+++ b/src/personas/audiences.md
@@ -125,7 +125,7 @@ Audience CSVs are generated on demand. Before you can download the CSV, you will
 <table>
   <tr>
     <td>![](images/large_audience_csv.png)</td>
-    <td width="45%">Generating a CSV can take a substantial amount of time for large audiences (around 30 seconds for a formatted CSV with 1 million rows). For CSVs that are expected to take over 20 seconds, the Segment app displays an estimated generation time. After clicking Generate, it is recommended that you leave the modal open while the CSV is created.<br/>
+    <td width="45%">Generating a CSV can take a substantial amount of time for large audiences (around 30 seconds for a formatted CSV with 1 million rows). For CSVs that are expected to take over 20 seconds, the Segment app displays an estimated generation time. After clicking Generate, it is recommended that you leave the modal open while the CSV is created.
     (If the audience recalculates between when you click Generate and when you download the file, you might want to regenerate the file. The CSV is a snapshot from when you clicked Generate, and could be outdated.)</td>
   </tr>
 </table>

--- a/src/personas/computed-traits.md
+++ b/src/personas/computed-traits.md
@@ -185,7 +185,7 @@ Computed Trait CSVs are generated on demand. Before you can download the CSV, yo
 <table>
     <tr>
         <td>![](images/large_trait_csv.png)</td>
-        <td width="45%">Generating a CSV can take a substantial amount of time for large traits (around 30 seconds for a formatted CSV with 1 million rows). For CSVs that are expected to take over 20 seconds, we present a rough estimate of generation time. After clicking Generate, it is recommended that you leave the modal and page open while the CSV is created.<br/>
-        (If the audience recalculates between when you click Generate and when you download the file, you might want to regenerate the file. The CSV is a snapshot from when you clicked Generate, and could be outdated.)</td>
+        <td width="45%">Generating a CSV can take a substantial amount of time for large traits (around 30 seconds for a formatted CSV with 1 million rows). For CSVs that are expected to take over 20 seconds, the Segment app displays an estimated generation time. After clicking Generate, it is recommended that you leave the modal and page open while the CSV is created.
+        (If the trait recalculates between when you click Generate and when you download the file, you might want to regenerate the file. The CSV is a snapshot from when you clicked Generate, and could be outdated.)</td>
     </tr>
 </table>


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
* Unify style in computed trait / audience documentation (use back tick code style, e.g.)
* More accurate and specific copy to describe CSV formats (same change made in [app](https://github.com/segmentio/app/pull/9723))
<!--Tell us what you did and why-->


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
