### PR TITLE
[DOCS-254] Partner Specs for Delete Request

### DIFF
--- a/src/partners/spec.md
+++ b/src/partners/spec.md
@@ -590,7 +590,7 @@ Docs coming soon.
 
 ## Delete
 
-A Segment user can trigger delete action via Config API or App. Partners are required to delete data for `userId` in the request payload in line with GDPR and CCPA. 
+A Segment user can trigger delete action via [Config API](https://reference.segmentapis.com/?version=latest#57a69434-76cc-43cc-a547-98c319182247) or App. Partners are required to delete data for `userId` in the request payload in line with GDPR and CCPA. 
 
 This results in the following event data:
 


### PR DESCRIPTION
### Proposed changes

Adding Partner Specs for Delete Request https://segment.atlassian.net/browse/DOCS-254
This unblocks Destination Functions implementation https://segment.atlassian.net/browse/FUN-515

Note that the Delete action does not originate from `analytics.js`. Hence, it's documentation deviates from the other Partner Specs in the file.

### TODOs

- [x] Link Config API to Deletion API leading to deletion payloads for  Partners
- [x] What's the permalink to Config API  https://reference.segmentapis.com/?version=latest#57a69434-76cc-43cc-a547-98c319182247