### PR TITLE
Add example for altering the context.device object on Android

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/android/index.md
@@ -378,6 +378,13 @@ analyticsContext.putValue(...).putReferrer(...).putCampaign(...);
 
 You can read more about these [special fields](/docs/connections/spec/common/#context).
 
+To alter data specific to the device object you can use the following:
+
+```java
+AnalyticsContext analyticsContext = Analytics.with(context).getAnalyticsContext();
+analyticsContext.device().putValue("advertisingId", "1");
+```
+
 If you'd prefer to opt out of automatic data collection, simply clear the context right after initializing the client. It's important to do this _BEFORE_ sending any events.
 
 ```java


### PR DESCRIPTION
### Proposed changes

While we do have some examples here: https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/#context

But we do not document how to alter properties in the context.device object, such as advertising id. 
