### PR TITLE
Set build to string for Mobile Spec

### DIFF
--- a/src/connections/spec/mobile.md
+++ b/src/connections/spec/mobile.md
@@ -68,7 +68,7 @@ This event fires when a user **first** opens your mobile application. Note, if t
 | **Property** | **Type** | **Description**                        |
 | ------------ | -------- | -------------------------------------- |
 | `version`    | String   | The version installed.                 |
-| `build`      | Number   | The build number of the installed app. |
+| `build`      | String   | The build number of the installed app. |
 
 
 ### Application Opened
@@ -96,7 +96,7 @@ This event fires when a user launches or foregrounds your mobile application aft
 | `url`                   | String   | The value of `UIApplicationLaunchOptionsURLKey` from `launchOptions`.**Collected on iOS only**.                                                                                                                                                                                                                |
 | `referring_application` | String   | The value of `UIApplicationLaunchOptionsSourceApplicationKey` from `launchOptions`. **Automatically collected on iOS only**.                                                                                                                                                                                   |
 | `version`               | String   | The version installed.                                                                                                                                                                                                                                                                                         |
-| `build`                 | Number   | The build number of the installed app.                                                                                                                                                                                                                                                                         |
+| `build`                 | String   | The build number of the installed app.                                                                                                                                                                                                                                                                         |
 
 
 ### Application Backgrounded
@@ -137,9 +137,9 @@ This event fires when a user updates the application. Our SDK will automatically
 | **Property**       | **Type** | **Description**                  |
 | ------------------ | -------- | -------------------------------- |
 | `previous_version` | String   | The previously recorded version. |
-| `previous_build`   | Number   | The previously recorded build.   |
+| `previous_build`   | String   | The previously recorded build.   |
 | `version`          | String   | The new version.                 |
-| `build`            | Number   | The new build.                   |
+| `build`            | String   | The new build.                   |
 
 ### Application Uninstalled
 


### PR DESCRIPTION
### Proposed changes

Our mobile spec say the build should be a number: https://segment.com/docs/connections/spec/mobile/

But all our SDKs set this as a string. 
Recent PR: https://github.com/segmentio/analytics-android/pull/656
iOS SDK sets it a s a string: https://github.com/segmentio/analytics-ios/blob/b5cae4933e64df469fd014935e48abf874d8cce8/Analytics/Classes/SEGAnalytics.m#L145 
Our common spec also has this as a string: https://segment.com/docs/connections/spec/#structure

