### PR TITLE
Added Documentation for Stripe Invoices Collection

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/stripe/index.md
+++ b/src/connections/sources/catalog/cloud-apps/stripe/index.md
@@ -258,6 +258,8 @@ Below are tables outlining the properties included in the collections listed abo
 | `tax` | The amount of tax included in the total, calculated from tax_percent and the subtotal. If no tax_percent is defined, this value will be null |
 | `tax_percent` | This percentage of the subtotal has been added to the total amount of the invoice, including invoice line items and discounts |
 | `total` | Total after discount |
+| `period_end` | End of the usage period during which invoice items were added to the invoice |
+| `period_start` | Start of the usage period during which invoice items were added to the invoice |
 
 ### invoice_lines
 


### PR DESCRIPTION
### Proposed changes

I had a customer reach in and give us feedback about the fact that there are fields that are pulled into the collection of the invoices which are not documented within our docs. They've therefore had to navigate to the [Stripe API](https://stripe.com/docs/api/invoices/object#invoice_object-period_end) docs and gather information about the fields there. I've confirmed that we do indeed pull the additional fields from our code for the [Stripe Source](https://github.com/segmentio/object-sources/blob/master/golang/internal/stripe/resource/invoice.go#L116) and these are not documented for. In this PR I have documented these additional fields based on the documentation from the Stripe API Docs.

Please take a look and let me know if there are any improvements @sanscontext