### PR TITLE
Change Example Property "action" to "type"

### DIFF
--- a/src/connections/spec/b2b-saas.md
+++ b/src/connections/spec/b2b-saas.md
@@ -44,7 +44,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Account Created",
   "properties": {
     "account_name": "Initech"
@@ -57,7 +57,7 @@ This event supports the following semantic properties:
 ```js
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Account Created",
   "properties": {
     "account_name": "Initech"
@@ -85,7 +85,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Account Deleted",
   "properties": {
     "account_name": "Initech"
@@ -98,7 +98,7 @@ This event supports the following semantic properties:
 ```js
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Account Deleted",
   "properties": {
     "account_name": "Initech"
@@ -135,7 +135,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Signed Up",
   "properties": {
     "type": "organic",
@@ -154,7 +154,7 @@ This event supports the following semantic properties:
 ```json
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Signed Up",
   "properties": {
     "type": "organic",
@@ -191,7 +191,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Signed In",
   "properties": {
     "username": "pgibbons"
@@ -204,7 +204,7 @@ This event supports the following semantic properties:
 ```json
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Signed In",
   "properties": {
     "username": "pgibbons"
@@ -235,7 +235,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Signed Out",
   "properties": {
     "username": "pgibbons"
@@ -248,7 +248,7 @@ This event supports the following semantic properties:
 ```js
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Signed Out",
   "properties": {
     "username": "pgibbons"
@@ -278,7 +278,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Invite Sent",
   "properties": {
     "invitee_email": "pgibbons@example.com",
@@ -294,7 +294,7 @@ This event supports the following semantic properties:
 ```js
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Invite Sent",
   "properties": {
     "invitee_email": "pgibbons@example.com",
@@ -325,7 +325,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Account Added User",
   "properties": {
     "role": "Owner"
@@ -338,7 +338,7 @@ This event supports the following semantic properties:
 ```js
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Account Added User",
   "properties": {
     "role": "Owner"
@@ -365,7 +365,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Account Removed User",
   "properties": {},
   "context": {
@@ -376,7 +376,7 @@ This event supports the following semantic properties:
 ```js
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Account Removed User",
   "properties": {},
   "context": {
@@ -404,7 +404,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Trial Started",
   "properties": {
       "trial_start_date": "2018-08-28T04:09:47Z",
@@ -419,7 +419,7 @@ This event supports the following semantic properties:
 ```js
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Trial Started",
   "properties": {
       "trial_start_date": "2018-08-28T04:09:47Z",
@@ -451,7 +451,7 @@ This event supports the following semantic properties:
 
 {% comment %} api-example '{
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Trial Ended",
   "properties": {
       "trial_start_date": "2018-08-28T04:09:47Z",
@@ -466,7 +466,7 @@ This event supports the following semantic properties:
 ```js
 {
   "userId": "019mr8mf4r",
-  "action": "track",
+  "type": "track",
   "event": "Trial Ended",
   "properties": {
       "trial_start_date": "2018-08-28T04:09:47Z",


### PR DESCRIPTION
The property "Action" really indicated the event type and was misleading to customers trying to implement the b2b spec. Our libraries show this property as "type" in event payloads.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->


### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
