### PR TITLE
Minor doc update around the details of `campaign` and `page` objects

### DIFF
--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -189,7 +189,7 @@ Context is a dictionary of extra information that provides useful context about 
   <tr>
     <td>`page`</td>
     <td>Object</td>
-    <td>Dictionary of information about the current page in the browser, containing `path`, `referrer`, `search`, `title` and `url`. This is automatically collected by Analytics.js.
+    <td>Dictionary of information about the current page in the browser, containing `path`, `referrer`, `search`, `title` and `url`. This is automatically collected by [Analytics.js](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#context--traits).
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
- Added a note about tracking custom UTM parameters, as there was a confusion around including those in the `campaign` object as a response to https://segment.atlassian.net/browse/LIBWEB-52
- Removed hash from the `page` object as it was included in the docs incorrectly as a response to https://segment.atlassian.net/browse/LIBWEB-25