### PR TITLE
change wording around refreshing anonymous ID

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/index.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/index.md
@@ -581,7 +581,7 @@ Keep in mind that setting the `anonymousId` in `analytics.js` does not overwrite
 
 A user's `anonymousId` refreshes on any of the following conditions:
 
-* A user clears their cache (cookies and localstorage)
+* A user clears their cookies _and_ `localstorage`
 * [`analytics.reset()`](/docs/connections/sources/catalog/libraries/website/javascript//#reset-logout) is called during in the user's browser session
 * `analytics.identify()` is called with a userId that differs from the current userId
 


### PR DESCRIPTION
### Proposed changes

Our docs stated that a new anonymous ID would be generated when clearing cookies, but if localstorage is not cleared as well then a new anonymous ID will not be generated.

### Merge timing
Once approved

### Related issues (optional)

https://segment.atlassian.net/browse/LIBWEB-95
