### PR TITLE
fix up legal links

### DIFF
--- a/src/_includes/components/footer.html
+++ b/src/_includes/components/footer.html
@@ -26,10 +26,10 @@
           <div class="nav">
             <ul class="nav-list">
               <li>
-                <a class="nav-list__link" href="{{ site.baseurl }}/legal/privacy/">Privacy</a>
+                <a class="nav-list__link" href="https://segment.com/legal/privacy/">Privacy</a>
               </li>
               <li>
-                <a class="nav-list__link" href="{{ site.baseurl }}/legal/terms/">Terms</a>
+                <a class="nav-list__link" href="https://segment.com/legal/terms/">Terms</a>
               </li>
               <li>
                 <a class="nav-list__link" href="#" id="open-consent-manager">Website Data Collection Preferences</a>


### PR DESCRIPTION
### Proposed changes

Static-ifies the legal links in the bottom of every page, since the legal pages are no longer hosted off the /docs/ path.