### PR TITLE
Update index.md

### DIFF
--- a/src/connections/destinations/catalog/facebook-app-events/index.md
+++ b/src/connections/destinations/catalog/facebook-app-events/index.md
@@ -188,7 +188,7 @@ analytics.track({
 
 #### iOS Device Mode
 
-You must be using the Facebbok App Events integration SDK version `2.0.0` or higher to be able to call `setDataProcessingOptions` when you enable the **Use Limited Data Use** destination setting. Events sent from Facebbok App Events integration SDK versions older than `v2.0.0` will not have acess to call `setDataProcessingOptions`, but Facebook will have access to the IP address in the events to process LDU based on geolocation.
+You must use the Facebbok App Events integration SDK version `2.0.0` or later to call `setDataProcessingOptions` when you enable the **Use Limited Data Use** destination setting. Events sent from earlier versions of the Facebook App Events integration SDK cannot call `setDataProcessingOptions`, but Facebook still has access to the IP address in the events to process LDU based on geolocation.
 
 When you use Segment’s mobile libraries, you must set the Data Processing Options when you declare the destination in your app delegate’s instance. The example below shows how you might set custom Data Processing parameters in an iOS project.
 


### PR DESCRIPTION
Add note about which iOS FB App Event SDK version supports the LDU `setDataProcessingOptions` method. This is based on Gabe's comment here: https://paper.dropbox.com/doc/Doc-Draft-Facebook-Limited-Data-Use-feature--A4sV0zVhCiDuhOfYhNRrwBulAg-UbRCD9TuYIyivvQugSgJF#:uid=165569862214276867958992&h2=App-Events-(iOS%2C-device-mode)