### PR TITLE
DL-234: Fixed Data Lakes logo in catalog

### DIFF
--- a/src/_data/catalog/warehouse.yml
+++ b/src/_data/catalog/warehouse.yml
@@ -20,9 +20,9 @@ items:
   url: connections/storage/catalog/data-lakes
   status: PUBLIC_BETA
   logo:
-    url: 'https://cdn.filepicker.io/api/file/JrQWOYvMRRCVvSHp4HL0'
+    url: 'https://cdn.filepicker.io/api/file/YR7dKXAiQWyYvBiVOZNX'
   mark:
-    url: 'https://cdn.filepicker.io/api/file/OBhrGoCRKaSyvAhDX3fw'
+    url: 'https://cdn.filepicker.io/api/file/zKQw43MuQjmTtXBXs4VL'
   categories:
     - Warehouses
 - display_name: BigQuery


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

https://segment.atlassian.net/browse/DL-234

Currently, Snowflake logo is used for Data Lakes. This PR is to fix the Data Lakes logo by providing the correct URLs.

After the fix, the catalog page will look like this
<img width="1073" alt="Screen Shot 2020-08-05 at 12 23 26 PM" src="https://user-images.githubusercontent.com/60331949/89455507-4cbe9700-d717-11ea-86e5-30198e847d00.png">

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

This should be merged once approved.
