### PR TITLE
Savio doc typo correction and beta status removal

### DIFF
--- a/src/connections/destinations/catalog/savio/index.md
+++ b/src/connections/destinations/catalog/savio/index.md
@@ -6,8 +6,6 @@ title: Savio Destination
 
 This destination is maintained by Savio. For any issues with the destination, [contact their team](mailto:support@savio.io).
 
-This document was last updated on August 07, 2020. If you notice any gaps, outdated information or simply want to leave some feedback to help us improve our documentation, please [let us know](https://segment.com/help/contact)!
-
 ## Getting Started
 
 {% include content/connection-modes.md %}


### PR DESCRIPTION
### Proposed changes
Correct type in opening sentence
Remove beta status as partner confirmed they have progressed out of beta
Context: https://segment.zendesk.com/agent/tickets/391362

### Merge timing
ASAP once approved?

### Related issues (optional)
Follows up from https://github.com/segmentio/segment-docs/pull/1041
