### PR TITLE
this should be 2020, and a variable

### DIFF
--- a/src/_includes/components/footer.html
+++ b/src/_includes/components/footer.html
@@ -21,7 +21,7 @@
         <div class="footer__aside">
           {% include icons/segment.svg %}
 
-          <p>© 2019 Segment.io, Inc.</p>
+          <p>© {{ site.time | date: "%Y" }} Segment.io, Inc.</p>
 
           <div class="nav">
             <ul class="nav-list">
@@ -68,7 +68,7 @@
 
 <div class="footer-mobile">
   <div class="footer__aside">
-    <p>© Copyright 2019 Segment</p>
+    <p>© Copyright {{ site.time | date:"%Y" }} Segment</p>
   </div>
 
   <ul class="social-list social-list--dark flex flex--middle flex--center gutter gutter--xlarge">


### PR DESCRIPTION
update footer template, and make it a variable.

Note: Current variable will take the time of the last site update, not absolute current_date, which appears to be broken.
