### PR TITLE
typo with URL

### DIFF
--- a/src/connections/storage/data-lakes/index.md
+++ b/src/connections/storage/data-lakes/index.md
@@ -39,7 +39,7 @@ Data Lakes uses an EMR cluster to run jobs that load events from all sources int
 ### AWS IAM Role
 
 Data Lakes uses an IAM role to grant Segment secure access to your AWS account. The required inputs are:
-- **external_ids**: External IDs are the part of the IAM role which Segment uses to assume the role providing access to your AWS account. You will define the external ID in the IAM role as the Segment source ID which you want to connect to  Data Lakes. The Segment source ID can be retrieved from the [Segment app[(https://app.segment.com/goto-my-workspace/overview)] when navigating to the Source > Settings > API Keys > Source ID.
+- **external_ids**: External IDs are the part of the IAM role which Segment uses to assume the role providing access to your AWS account. You will define the external ID in the IAM role as the Segment source ID which you want to connect to  Data Lakes. The Segment source ID can be retrieved from the [Segment app](https://app.segment.com/goto-my-workspace/overview)] when navigating to the Source > Settings > API Keys > Source ID.
 - **s3_bucket**: Name of the S3 bucket used by the Data Lake.
 
 


### PR DESCRIPTION
DL docs have a typo which doesn't hyperlink the Segment App link
