### PR TITLE
Moosend: Correction on identify description in catalog

### DIFF
--- a/src/connections/destinations/catalog/moosend/index.md
+++ b/src/connections/destinations/catalog/moosend/index.md
@@ -4,15 +4,15 @@ title: Moosend Destination
 
 ### Creating a Website Id
 
-Integrating with Segment requires creating a Website Id. Once you login to your Moosend account, navigate to the tracked websites tab in the account submenu. There you will be able to fill in the field with the url of your website.
+Integrating with Segment requires creating a Website Id. Once you login to your Moosend account, navigate to the tracked websites tab in the account submenu. There you can fill enter the url of your website.
 
 ## Page
 
-You can track [Page](https://segment.com/docs/connections/spec/page/) events using Segment's `analytics.page` method. It is highly recommended that, if possible, you add this event to the header of your website, after the library initialization and before you close your script tag.
+You can track [Page](/docs/connections/spec/page/) events using Segment's `analytics.page` method. It is highly recommended that, if possible, you add this event to the header of your website, after the library initialization and before you close your script tag.
 
 ## Identify
 
-An [Identify](https://segment.com/docs/connections/spec/identify/) event lets you tie a user in Moosend to their actions and record traits about them. It includes a unique email and their name.
+An [Identify](/docs/connections/spec/identify/) event lets you tie a user in Moosend to actions they've completed and other recorded traits about that user. It includes a unique email and their name.
 
 Our recommendation is to call `identify` after a user registers, after a user logs in and after a user provides their email as part of your newsletter subscription form (if applicable).
 
@@ -22,18 +22,18 @@ Although you can track any custom event, Moosend has some known events that impl
 
 ## Product Viewed
 
-A [Product Viewed](https://segment.com/docs/connections/spec/ecommerce/v2/#product-viewed) event should be used to track when a user views a product (before adding to cart or purchasing). This event helps to implement advanced retargeting strategies in Moosend like browse abandonment and engage with customers that view, but do not purchase, a product.
+A [Product Viewed](/docs/connections/spec/ecommerce/v2/#product-viewed) event should be used to track when a user views a product (before adding to cart or purchasing). This event helps to implement advanced retargeting strategies in Moosend like browse abandonment and engage with customers that view, but do not purchase, a product.
 
 Make sure you follow the spec format explained in the documentation linked above.
 
 ## Order Completed
 
-An [Order Completed](https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed) event should be used to track when a user succesfully completes their order.
+An [Order Completed](/docs/connections/spec/ecommerce/v2/#order-completed) event should be used to track when a user succesfully completes their order.
 
 Make sure you follow the spec format explained in the documentation linked above.
 
 ## Added To Cart
 
-A [Product Added](https://segment.com/docs/connections/spec/ecommerce/v2/#product-added) event should be used to track when a user adds an item to their cart. These events can be then used to implement cart abandonment emails.
+A [Product Added](/docs/connections/spec/ecommerce/v2/#product-added) event should be used to track when a user adds an item to their cart. These events can be then used to implement cart abandonment emails.
 
 Make sure you follow the spec format explained in the documentation linked above.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
We made the correction on the documentation instructions according to your instructions:
_The article here describes how the integration between segment and moosend works:_ _https://segment.com/docs/connections/destinations/catalog/moosend/_
_It says that someone can identify any optional trait about the customer apart from the email/name, but since that is not an_ _option at the moment, can we please clarify that only the email and name fields can be captured?_

Thank you!
<!--Tell us what you did and why-->

### Merge timing
- ASAP once approved
<!-- When should this get merged/published?
- On a specific date?
- Depending on a specific project?-->



<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
