### PR TITLE
Change DV360 to just 360 and remove hyperlink

### DIFF
--- a/src/connections/destinations/catalog/google-analytics/index.md
+++ b/src/connections/destinations/catalog/google-analytics/index.md
@@ -4,7 +4,7 @@ strat: google
 ---
 
 > warning "Migrate mobile implementations to Firebase"
-> Google ended support for Google Analytics classic on iOS and Android mobile apps on October 31st 2019. To continue measuring and optimizing user engagement in your mobile apps, [migrate your implementation to use the Firebase SDKs](migrating). If you are using [Google Analytics DV360](/docs/connections/destinations/catalog/doubleclick-floodlight/) you do not need to migrate.
+> Google ended support for Google Analytics classic on iOS and Android mobile apps on October 31st 2019. To continue measuring and optimizing user engagement in your mobile apps, [migrate your implementation to use the Firebase SDKs](migrating). If you are using Google Analytics 360 you do not need to migrate.
 
 
 ## Getting Started


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

The deprecation warning should be that GA360 customers do not need to migrate off iOS/Android SDKs. This is not the same as doubleclick which is what it was linking to. This was raised as a question to the destinations team re: confusing docs. 
Google official documentation re the deprecation here: https://support.google.com/firebase/answer/9167112?hl=en

### Merge timing
- ASAP once approved

### Related issues (optional)
 https://segment.slack.com/archives/CC97A542H/p1603726563121600
