### PR TITLE
Updates to Group Using Cloud-mode

### DIFF
--- a/src/connections/destinations/catalog/mixpanel/index.md
+++ b/src/connections/destinations/catalog/mixpanel/index.md
@@ -148,7 +148,7 @@ You won't see server-side `traits` appear as super-properties on any events you 
 
 For Mixpanel People, it's important to `identify` a user before you call `track`. A `track` without an `identify` won't create a user in Mixpanel People.
 
-if you're using Cloud-mode you must explicitly include the grouping value as an event property on any event you wish to analyze with Mixpanel's Group Analytics.
+If you use Cloud-mode, you must explicitly include the grouping value as an event property for any event you want to analyze using Mixpanel's Group Analytics.
 
 ### Register Super Properties
 


### PR DESCRIPTION
Mixpanel's Director of Technology Partnerships submitted a ticket to Friends@segment:

We’ve received some feedback from a customer using Segment & Mixpanel for group analytics, how to improve (y)our docs. The issue is that our super properties don’t work when using Group Analytics in Cloud mode.

Would you be open to adding some language to this doc, under the "Group using Cloud-mode" section
https://segment.com/docs/connections/destinations/catalog/mixpanel/#group

"if you're using Cloud-mode you must explicitly include the grouping value as an event property on any event you wish to analyze with group analytics” (or something similar)

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
