### PR TITLE
Add userId is required for audiences/computed traits

### DIFF
--- a/src/connections/destinations/catalog/customer-io/index.md
+++ b/src/connections/destinations/catalog/customer-io/index.md
@@ -230,6 +230,9 @@ Page events will only be associated to a user if the user has been previously id
 
 You can send computed traits and audiences generated using [Segment Personas](/docs/personas) to this destination as a **user property**. To learn more about Personas, contact us for a [demo](https://segment.com/contact/demo).
 
-For user-property destinations, an [identify](/docs/connections/spec/identify/) call is sent to the destination for each user being added and removed. The property name is the snake_cased version of the audience name, with a true/false value to indicate membership. For example, when a user first completes an order in the last 30 days, Personas sends an Identify call with the property `order_completed_last_30days: true`. When the user no longer satisfies this condition (for example, it's been more than 30 days since their last order), Personas sets that value to `false`. A `userId` is required when syncing an Audience or Computed Traits to Customer.io. 
+For user-property destinations, an [identify](/docs/connections/spec/identify/) call is sent to the destination for each user being added and removed. The property name is the snake_cased version of the audience name, with a true/false value to indicate membership. For example, when a user first completes an order in the last 30 days, Personas sends an Identify call with the property `order_completed_last_30days: true`. When the user no longer satisfies this condition (for example, it's been more than 30 days since their last order), Personas sets that value to `false`. 
+
+> note""
+> Customer.io requires you to pass a `userId` value when you sync Audiences or Computed Traits.
 
 When you first create an audience, Personas sends an Identify call for every user in that audience. Later audience syncs only send updates for users whose membership has changed since the last sync.


### PR DESCRIPTION
Received request from Solutions Architect extraordinaire Joe Ayoub:

Hi friends@ team, 

A customer of ours noticed that the Customer.io Destination requires users in a Personas Audience to have userIds. If the users don't have userIds then the user will not be synced to Customer.io (as part of a Personas Audience). 

There is no mention of this requirement in the Personas documentation. 
It essentially means that it is not possible to sync anonymous Audiences to Customer.io, even if all the users have email addresses. This is important information for our customers to have. 

Would it be possible to update the Destination docs to state that a userId is required when syncing an Audience or Computed Trait? Obviously, an email address is important when syncing Audiences to Customer.io (but I don't know if email is actually required...)

Thanks,
Joe

This can be added to the doc ASAP, no intended timeline. 
