### PR TITLE
[ID-688] Update external IDs ios.idfa to latest behavior

### DIFF
--- a/src/personas/identity-resolution/externalids.md
+++ b/src/personas/identity-resolution/externalids.md
@@ -26,7 +26,7 @@ Segment automatically promotes the following traits and IDs in track and identif
 | ga_client_id       | context.integrations['Google Analytics'].clientId when explicitly captured by users                           |
 | group_id           | groupId                                                                                                       |
 | ios.id             | context.device.id when context.device.type = 'ios'                                                            |
-| ios.idfa           | context.device.advertisingId when context.device.type = 'ios' AND context.device.adTrackingEnabled = true     |
+| ios.idfa           | context.device.advertisingId when context.device.type = 'ios'     |
 | ios.push_token     | context.device.token when context.device.type = 'ios'                                                         |
 
 


### PR DESCRIPTION
### Proposed changes

Updated documentation for the `ios.idfa` external ID to the latest behavior, wherein `adTrackingEnabled` is no longer taken into consideration.

### Merge timing

ASAP.

### Related issues (optional)

https://segment.atlassian.net/browse/ID-688