### PR TITLE
Correct rate limit

### DIFF
--- a/src/personas/profile-api.md
+++ b/src/personas/profile-api.md
@@ -195,7 +195,7 @@ Segment  uses conventional HTTP response codes to indicate the success or failur
 
 ### Rate Limit
 
-Every Access Secret has a default rate limit of 60,000 requests/min. That limit can be adjusted over time.
+Every Space has a default rate limit of 60,000 requests/min. That limit can be adjusted over time.
 
 
 ### Pagination


### PR DESCRIPTION
Previously the doc said we rate limited per access secret, but it's actually per space.

Background: https://segment.slack.com/archives/C7F3N3RV4/p1605058151032800?thread_ts=1605051785.031700&cid=C7F3N3RV4
