### PR TITLE
Link fix

### DIFF
--- a/src/connections/sources/catalog/libraries/server/node/quickstart.md
+++ b/src/connections/sources/catalog/libraries/server/node/quickstart.md
@@ -35,7 +35,7 @@ var Analytics = require('analytics-node');
 var analytics = new Analytics('YOUR_WRITE_KEY');
 ```
 
-That will create an instance of `Analytics` that you can use to send data to Segment for your project. The default initialization settings are production-ready and queue 20 messages before sending any requests. In development you might want to use [development settings](/docs/connections/sources/catalog/libraries/server/node/#development).
+That will create an instance of `Analytics` that you can use to send data to Segment for your project. The default initialization settings are production-ready and queue 20 messages before sending any requests. In development you might want to use [development settings](/docs/connections/sources/catalog/libraries/server/node#development).
 
 Once you've got that, you're ready to...
 


### PR DESCRIPTION
### Proposed changes

A customer wrote in the feedback form that this link `[development settings](/docs/connections/sources/catalog/libraries/server/node/#development)` was broken, and they're right.

For some reason this is rendering through our build system as the url `/docs/connections/sources/catalog/libraries/server/node/quickstart/#development` which is not a heading.  Checking to see if removing the / makes a difference here.
