### PR TITLE
Hiding Personas section from the Launchdarkly Events destination

### DIFF
--- a/src/connections/destinations/catalog/launchdarkly-events/index.md
+++ b/src/connections/destinations/catalog/launchdarkly-events/index.md
@@ -2,6 +2,7 @@
 title: LaunchDarkly Events Destination
 rewrite: true
 redirect_from: /connections/destinations/catalog/launchdarkly-subscription
+hide-personas-partial: true
 ---
 LaunchDarkly is a feature management platform that empowers development teams to safely deliver and control software through feature flags.
 


### PR DESCRIPTION
### Proposed changes
I have disabled the Personas section from the Launchdarkly Events destination. The team from Launchdarkly Events sent in a ticket asking to remove this section as they don't handle Personas requests. Thanks @markzegarelli for sharing how to hide the section. 

### Merge timing
Whenever approved.

I had a look locally and everything looked good. I can merge as soon as one of you approve @sanscontext @markzegarelli 
