### PR TITLE
Updates about session-id timestamp

### DIFF
--- a/src/connections/destinations/catalog/amplitude/index.md
+++ b/src/connections/destinations/catalog/amplitude/index.md
@@ -540,15 +540,15 @@ analytics.alias({
 
 ### sessionId
 
-[Segment doesn't have a concept for a
-session](https://segment.com/blog/facts-vs-stories-why-segment-has-no-sessions-api/).
+[Segment doesn't have a concept for a session](https://segment.com/blog/facts-vs-stories-why-segment-has-no-sessions-api/).
+
 Client-side calls to Amplitude will include session information since we are
 bundling Amplitude's SDK. To set up the same `sessionId` for server-side calls
-to Amplitude, you will have to explicitly set the
+to Amplitude, you must explicitly set the
 [session\_id](https://amplitude.zendesk.com/hc/en-us/articles/204771828-HTTP-API#optional-amplitude-specific-keys-for-the-event-argument)
 as an integration-specific option like so:
 
-```
+```js
 {
   "userId": "1234",
   "traits": {
@@ -568,9 +568,9 @@ as an integration-specific option like so:
 }
 ```
 
-You will need to pass the start time of a session as `<Timestamp>`.
+You must pass the start time of a session as `<Timestamp>`.
 
-Important: The timestamp value that passes via session_id needs to be unix format; if it is ISO 8601 for instance this generates an error upon delivery to Amplitude.
+When you pass a timestamp value from the `session_id` it must be in Unix format or else it generates an error when it is delivered to Amplitude. For example, a date of January 1, 2020 and 9:30am UTC would be written as `2020-12-07T19:33:44+00:00` in ISO 8601, but `1577871000` in Unix epoch time. There are many tools and libraries available to help you convert your timestamps.
 
 ### Setting event-level groups using .track()
 
@@ -641,7 +641,7 @@ This `identify` event would create or update a new user in Amplitude and set
 
 Supported using our iOS and Android components.
 
-Defaults to enabled. If a user has granted your app location permissions,
+This feature defaults to `enabled`. If a user granted your app location permissions,
 enable this setting so that the SDK will also grab the location of the user.
 Amplitude will never prompt the user for location permission, so this must be
 done by your app.


### PR DESCRIPTION
A customer reached out to friends@segment with the following info:

We discovered after implementation that the timestamp value that passes via session_id needs to be unix format; if it is ISO 8601 for instance this generates an error upon delivery to Amplitude (and the event will not be delivered). This requirement is not clearly described in the above documentation so wanted to relay so it can be updated.

--------------

This seemed like a good addition to the docs so other customers could avoid running into this issue :-).

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
