### PR TITLE
fix the wrong examples for Algolia destination

### DIFF
--- a/src/connections/destinations/catalog/algolia-insights/index.md
+++ b/src/connections/destinations/catalog/algolia-insights/index.md
@@ -67,6 +67,8 @@ Algolia supports the following six events from Segment's [Ecommerce Spec](https:
   </tr>
 </table>
 
+For a full list of required properties for each event type, see the [Spec: V2 Ecommerce Events](/docs/connections/spec/ecommerce/v2/)
+
 ```js
 analytics.track('Product List Viewed', {
     index: "my-index-name",


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Hello, I'm Eunjae Lee from Algolia.
We've got some feedback from our customer and it turned out some of the doc is wrong.

For example, [Order Completed from the spec](https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed) looks quite different from [the destination doc](https://segment.com/docs/connections/destinations/catalog/algolia-insights/#track).

Let me know if the change makes sense to you.