### PR TITLE
Fix Golang quickstart with deferred client.Close()

### DIFF
--- a/src/connections/sources/catalog/libraries/server/go/quickstart.md
+++ b/src/connections/sources/catalog/libraries/server/go/quickstart.md
@@ -39,6 +39,7 @@ import "gopkg.in/segmentio/analytics-go.v3"
 
 func main() {
   client := analytics.New("YOUR_WRITE_KEY")
+  defer client.Close()
 }
 ```
 


### PR DESCRIPTION
### Proposed changes

While walking through the Golang quickstart I was unable to get my data to send until adding `defer client.Close()`

### Merge timing

ASAP once approved
