### PR TITLE
Fix commenting out and add note for list property.md

### DIFF
--- a/src/connections/destinations/catalog/google-analytics/index.md
+++ b/src/connections/destinations/catalog/google-analytics/index.md
@@ -365,9 +365,9 @@ analytics.track('Clicked Promotion', {
 ```
 
 For client-side integrations, we use Google Analytics' Promotions class to measure promotions. You can read their developer docs for information on specific methods:
-<!-- same note as above re mobile
-- [Android](https://developers.google.com/android/reference/com/google/android/gms/analytics/ecommerce/Promotion)
-- [iOS](https://developers.google.com/analytics/devguides/collection/ios/v3/reference/interface_g_a_i_ecommerce_promotion)-->
+<!-- same note as above re mobile -->
+<!-- - [Android](https://developers.google.com/android/reference/com/google/android/gms/analytics/ecommerce/Promotion)-->
+<!-- - [iOS](https://developers.google.com/analytics/devguides/collection/ios/v3/reference/interface_g_a_i_ecommerce_promotion)-->
 - [Analytics.js - Enhanced E-Commerce](https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce)
 - [Analytics.js - E-Commerce](https://developers.google.com/analytics/devguides/collection/analyticsjs/ecommerce)
 
@@ -469,6 +469,9 @@ analytics.track('Product List Filtered', {
 });
 ```
 
+> tip ""
+> **Tip!** To tie product clicks and views to the same Product List Name in Google Analytics, include a `list` property in your 'Product Viewed' and 'Product Clicked' events. The value in the `list` property should match the value in the `list_id` property for the corresponding 'Product List Viewed' and 'Product List Filtered' events.
+
 ### Refunds
 
 To view refund in Google Analytics, you must have enhanced e-commerce enabled.
@@ -494,7 +497,6 @@ analytics.track('Order Refunded', {
     ]
   });
 ```
-
 
 
 ## Server Side


### PR DESCRIPTION
### Proposed changes
- Fix commenting out issue
- Add a note about using the `list` property on Product Viewed and Product Clicked. We previously did not mention this anywhere in our docs, but it is definitely supported in the integration code. I also tested it and confirmed. I think we should proactively let our customers know this is possible, since it's something GA does natively and customers might be concerned Segment doesn't support it if we don't call it out. 

Code:
Device mode, Product Viewed: https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/google-analytics/lib/index.js#L930
Device mode, Product Clicked: https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/google-analytics/lib/index.js#L958
Cloud mode: https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/google-analytics/lib/index.js#L958