### PR TITLE
Add Alias requirement

### DIFF
--- a/src/connections/destinations/catalog/amplitude/index.md
+++ b/src/connections/destinations/catalog/amplitude/index.md
@@ -446,7 +446,8 @@ with the user's `userId`, or what Amplitude refers to, respectively, as a
 
 By default, Segment does **NOT** send Alias events to Amplitude. To forward Alias events from Segment, go to your Amplitude destination settings in the Segment web app, and set the **Enable Alias** setting to "on". Once enabled, Segment forwards both client-based and server-based Alias calls. Segment processes _all_ Alias calls before sending them to Amplitude, so you won't see a `usermap` request to Amplitude if you check your browser's Network activity after making a Segment Alias call.
 
-note "" For Alias to work you must have the Amplitude Portfolio add-on. 
+> note ""  
+> To use Alias, you must have the Amplitude Portfolio add-on enabled.
 
 For more information, see the [Segment Spec page for the Alias method](https://segment.com/docs/connections/spec/alias/) and [the Amplitude `usermap` documentation](https://amplitude.zendesk.com/hc/en-us/articles/360002750712-Portfolio-Cross-Project-Analysis#user-mapping-aliasing).
 


### PR DESCRIPTION
Our friends at amplitude reached out requesting we add in that alias would only work if our mutual customer has Amplitude Portfolio add-on


### Proposed changes

Added a small note to the alias section of the amplitude doc advising that alias requires an amplitude add on called Amplitude Portfolio

### Merge timing
<!-- When should this get merged/published?
- No rush, just add once approved?


### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
