### PR TITLE
Clarify Replay behavior

### DIFF
--- a/src/protocols/transform/index.md
+++ b/src/protocols/transform/index.md
@@ -18,7 +18,7 @@ Our goal is to make Transformations a powerful tool that complements a well stru
 
 ### Other important notes
 
-- **Transformations cannot be applied retroactively:** They only apply to data moving forward. However, you can manually extract and re-send (or even [Replay](/docs/guides/what-is-replay)) events through a source with an active Transformation, which will send the transformed events to your destinations.
+- **Transformations cannot be applied retroactively:** They only apply to data moving forward. However, you can manually extract and re-send (or even [Replay](/docs/guides/what-is-replay)) events through a source with an active destination Transformation, which will send the transformed events to your destinations.
 - **Transformations are only available to Protocols customers:** If you are interested in this feature, contact your Account Executive or CSM to learn more about the Protocols package.
 - **Source-level transformations are irrevocable:** When applied at the source, a transformation permanently changes the structure of the event. The original events are not easily recoverable or [Replayable](/docs/guides/what-is-replay). Assume that transformed data cannot be recovered.
 - **Device-mode destinations are NOT supported:** Source scoped transformations will **only** apply to cloud-mode destinations, warehouses, and S3 destinations. Destination scoped transformations will **only** apply to cloud-mode destinations.


### PR DESCRIPTION
### Proposed changes

Right now, the verbiage makes it seem like customers can apply a source-level transformation, and then replay old events through that source to a destination and have them apply, and this is not true, as confirmed by https://segment.slack.com/archives/CEW467Z2N/p1586367263030200?thread_ts=1586366625.029900&cid=CEW467Z2N and the replays doc: https://paper.dropbox.com/doc/Replay-V2-Usage-Guide-AzWhMNYYdvC6JitKXOHDPSKAg-MogNfI1SWnrCFnxcSVeF7. Replays don't send their events back through the core pipeline, which is what would be required to hit a source level transformation.

### Merge timing
- ASAP once approved