### PR TITLE
functions: remove kafka-node dependency

### DIFF
--- a/src/_includes/content/functions/runtime.md
+++ b/src/_includes/content/functions/runtime.md
@@ -16,7 +16,6 @@ The following dependencies are installed in the function environment by default.
 - [`@google-cloud/pubsub v2.6.0`](https://www.npmjs.com/package/@google-cloud/pubsub) exposed as `google.cloud.pubsub`
 - [`@google-cloud/storage v5.3.0`](https://www.npmjs.com/package/@google-cloud/storage) exposed as `google.cloud.storage`
 - [`jsonwebtoken v8.5.1`](https://www.npmjs.com/package/jsonwebtoken) exposed as `jsonwebtoken`
-- [`kafka-node v5.0.0`](https://www.npmjs.com/package/kafka-node) exposed as `kafka-node`
 - [`lodash v4.17.15`](https://www.npmjs.com/package/lodash) exposed as `_`
 - [`node-fetch v2.6.0`](https://www.npmjs.com/package/node-fetch) exposed as `fetch`
 - [`oauth v0.9.15`](https://www.npmjs.com/package/oauth) exposed as `OAuth`


### PR DESCRIPTION
### Proposed changes

The `kafka-node` dependency was removed from the functions runtime in https://github.com/segmentio/funk/pull/102. We should remove the reference in the docs.

### Merge timing

To be merged/published ASAP so we don't confuse customers.

### Related issues (optional)

- https://github.com/segmentio/funk/pull/102
- https://segment.atlassian.net/browse/DEST-3026
