### PR TITLE
fix: remove zero z-index property

### DIFF
--- a/src/_sass/pages/_docs.scss
+++ b/src/_sass/pages/_docs.scss
@@ -19,6 +19,7 @@
 
   &__navbar {
     position: relative;
+    z-index: 1;
     padding: 16px 40px;
     display: none;
 


### PR DESCRIPTION
I removed the zero z-index property from the navbar.

### Related issues (optional)
Closes #1432
