### PR TITLE
Remove callout about reserved account-level traits

### DIFF
--- a/src/personas/audiences/account-audiences.md
+++ b/src/personas/audiences/account-audiences.md
@@ -35,9 +35,6 @@ A single account-level audience can incorporate any combination of the following
 - Account-level audience membership
 - Account-level custom traits (set through a [group](/docs/connections/spec/group) call)
 
-> warning ""
-> [Reserved account-level custom traits](/docs/connections/spec/group/#traits) are not available in audience conditions. You must include them in the traits dictionary a second time using a non-reserved trait name to make them available in the audience builder.
-
 The three types of user-level conditions are:
 - **Any User** (default): Returns all accounts where *at least one user* associated with the account satisfies the specified condition
 - **All users**: Returns all accounts where *all users* associated with the account satisfy the specified condition


### PR DESCRIPTION
### Proposed changes
A customer pointed out that it was inaccurate to say that it wasn't possible to use account-level reserved traits in the audience builder. I confirmed in their workspace, looks like my blackbox testing was wrong on this point!

### Merge timing
- ASAP once approved