### PR TITLE
fix: code blocks can cause width issue at xlarge breakpoint #1474

### DIFF
--- a/src/_sass/components/_stage.scss
+++ b/src/_sass/components/_stage.scss
@@ -21,5 +21,6 @@
   &__body {
     flex: 1;
     max-width: 100%;
+    min-width: 0;
   }
 }


### PR DESCRIPTION
### Proposed changes

Code blocks can cause width issue at xlarge breakpoint, this is a weird flexbox bug that is being fixed by adding `min-width: 0;` to the parent element.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

Closes #1474
