### PR TITLE
Remove WalkMe Destination from Personas

### DIFF
--- a/src/personas/using-personas-data.md
+++ b/src/personas/using-personas-data.md
@@ -379,7 +379,6 @@ When you create a new Computed Trait or Audience in Personas, you can choose to 
 - [Userlist](/docs/connections/destinations/catalog/userlist/)
 - [Vero](/docs/connections/destinations/catalog/vero/)
 - [Vitally](/docs/connections/destinations/catalog/vitally/)
-- [WalkMe](/docs/connections/destinations/catalog/walkme/)
 - [Watchtower](/docs/connections/destinations/catalog/watchtower/)
 - [WebEngage](/docs/connections/destinations/catalog/webengage/)
 - [Webhooks](/docs/connections/destinations/catalog/webhooks/)


### PR DESCRIPTION
### Proposed changes

I have removed the WalkMe Destination from the list of Personas Compatible Destinations. It is removed as it's a device-mode destination that does not currently support Personas. This edit was brought to my attention by Oliver Han

### Merge timing
Not urgent