### PR TITLE
Add minimum snippet version to AJS Middleware doc

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/middleware.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/middleware.md
@@ -4,7 +4,7 @@ strat: ajs
 ---
 
 
-Middlewares allow developers to extend Analytics.js with custom code which runs on every event. This code has full access to the DOM and Browser API, and helps customers enrich and transform event payloads.
+Middlewares allow developers to extend Analytics.js with custom code which runs on every event. This code has full access to the DOM and Browser API, and helps customers enrich and transform event payloads. Source Middlewares and Destination Middlewares are available on the Analytics.js snippet version `4.12.0` and later.
 
 Analytics.js can be extended using two functions:
 


### PR DESCRIPTION
### Proposed changes

Destination middlewares were added in the snippet version 4.12.0 so customers need to update their snippet to a minimum version to use middlewares

### Merge timing
Whenever it can be reviewed, please +1! If possible to merge if everything looks good, that'd be appreciated! 🙏 

### Related issues (optional)

https://github.com/segmentio/snippet/blob/master/History.md#4120--2020-05-21
