### PR TITLE
Clarify Segment<>Iterable ecommerce connection

### DIFF
--- a/src/connections/destinations/catalog/iterable/index.md
+++ b/src/connections/destinations/catalog/iterable/index.md
@@ -67,7 +67,7 @@ Subsequent `track` with `userId`
 
 Iterable also supports Segment's [ecommerce events](/docs/connections/spec/ecommerce/v2/). This works just as you would expect, using the `track` method.
 
-Iterable has one important difference from the Segment Ecommerce spec. If you use the `Product Added` / `Product Removed`/ `Order Completed` events, you must include the "products" field with the cart info, as in the `Order Completed` example event. You must include [all required fields for the Purchase events in Iterable](https://api.iterable.com/api/docs#commerce_trackPurchase).  This includes the total value of the purchase as `total` (best as a float, double, and possibly an integer), and an array of objects called `products`. Each product must include an `id` or `productId` as a string, `name`, `price`, and a `quantity` on each product object in the array, which is used to map to Iterable's expected `items` array. An example might look like this:
+Iterable has one important difference from the Segment Ecommerce spec. If you use the `Product Added` / `Product Removed`/ `Order Completed` events, you must include the "products" field with the cart info, as in the `Order Completed` example event. You must include [all required fields for the Purchase events in Iterable](https://api.iterable.com/api/docs#commerce_trackPurchase).  This includes the total value of the purchase as `total` (best as a float, double, and possibly an integer), and an array of objects called `products`. Each product must include an `id` or `productId` as a string, and a `name`, `price`, and `quantity` on each product object in the array. These are used to map to Iterable's expected `items` array. An example might look like this:
 
 ```js
 analytics.track("Order Completed", {


### PR DESCRIPTION
Per this ticket: https://segment.zendesk.com/agent/tickets/420194, our docs are pretty unclear on exactly what Iterable requires for the ecommerce events we map for customers. Based on https://github.com/segmentio/integrations/blob/master/integrations/iterable/lib/index.js#L163-L206 and https://github.com/segmentio/integrations/blob/master/integrations/iterable/lib/mapper.js, we pretty much just send the `products` array we are given to Iterable, but turns out, the endpoints we hit requires some basic fields in each product object: https://api.iterable.com/api/docs#commerce_trackPurchase and https://api.iterable.com/api/docs#commerce_updateCart. I tried to clarify these requirements better for less confusion in the future.
