### PR TITLE
fix source function url query param

### DIFF
--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -73,7 +73,7 @@ To access the URL details, refer to `request.url` object, which is an instance o
 ```js
 async function onRequest(request) {
   // Access a query parameter (e.g. `?name=Jane`)
-  const name = request.headers.searchParams.get('name')
+  const name = request.url.searchParams.get('name')
 }
 ```
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
The code should be
`  const name = request.url.searchParams.get('name')`
instead of   const name = request.headers.searchParams.get('name')

I verified this works on staging:
https://fn.segmentapis.build/?b=Y0hNcnBrbkpxNWZXVHNGdk4za3lqUzo6OVlnWWFzSEYwZkVUVlV2SDJPa2pNQnhCbWI3cE1zRDY=&userId1=hello&something=yoyoyo=&userId=sentfromevent
The code:
![fn-code](https://user-images.githubusercontent.com/8205327/113195552-44234f80-9217-11eb-8a78-aa4f0bf41d7e.png)
The expected results:

![result](https://user-images.githubusercontent.com/8205327/113195557-45547c80-9217-11eb-8540-004d3f1c89f2.png)
something=yoyoyo=
userId=sentfromevent


### Merge timing
This can be merged after the change freeze next week.

This was confusing for customers: 
https://segment.slack.com/archives/CH44TB529/p1617156513076900
