### PR TITLE
Functions use Node v14

### DIFF
--- a/src/_includes/content/functions/runtime.md
+++ b/src/_includes/content/functions/runtime.md
@@ -1,4 +1,4 @@
-Functions use Node.js 10.x.
+Functions use Node.js 14.x.
 
 Functions do not currently support importing dependencies, but you can [contact Segment Support](https://segment.com/help/contact/) to request that one be added.
 


### PR DESCRIPTION
### Proposed changes

Functions are no longer on the node v10 runtime. All functions were migrated to v14 last month.

### Merge timing

When should this get merged/published?
- ASAP once approved