### PR TITLE
Update add-destination.md

### DIFF
--- a/src/connections/destinations/add-destination.md
+++ b/src/connections/destinations/add-destination.md
@@ -131,7 +131,7 @@ You can add multiple instances of a destination using the Segment Config API. Se
 - **Mobile sources, and the legacy Project source, cannot connect to multiple instances of a destination.**
     - **Warning**: If you bundle one instance of a destination in a mobile source but have other instances of that destination connected to that source you might see unexpected and inconsistent data.
 - **You can connect a source to up to 10 instances of a destination if all of the instances use cloud-mode.** Destinations using cloud-mode receive data directly from the Segment servers.
-- **Non-mobile sources can only connect to one *device-mode* instance of a destination, in addition to unlimited cloud-mode instances.** A web browser device-mode instance of a destination receives data directly from the user’s browser (instead of through the Segment servers), by bundling a copy of destination’s code with the Segment SDK. Segment can’t bundle multiple copies of the destination SDK and so it can’t send data to multiple instances of the destination from the browser.
+- **Non-mobile sources can only connect to one *device-mode* instance of a destination, in addition to up to 10 cloud-mode instances.** A web browser device-mode instance of a destination receives data directly from the user’s browser (instead of through the Segment servers), by bundling a copy of destination’s code with the Segment SDK. Segment can’t bundle multiple copies of the destination SDK and so it can’t send data to multiple instances of the destination from the browser.
 - **You cannot connect a source to more than one instance of a destination that operates in device-mode only**. These destinations can only accept data from code directly on the user’s device, and Segment cannot include duplicates of that code for a single source.
 
 For more information see [the compatible destination lists below](#multi-instance-compatible-destinations).
@@ -169,7 +169,7 @@ In this example:
 The sections below list the most popular multi-instance Segment destinations. This list is not exhaustive. If you don’t see your favorite destination in these lists, [contact Segment Customer Success](https://segment.com/help/contact/).
 
 ##### Cloud-mode and device-mode
-The following destinations can receive data from an unlimited number of sources in cloud-mode, and **up to one device-mode connection**.
+For the following destinations, a single source can connect to up to 10 instances of the destination in cloud-mode, and **up to one instance in device-mode**.
 
 - [Adobe Analytics](/docs/connections/destinations/catalog/adobe-analytics/)
 - [Amplitude](/docs/connections/destinations/catalog/amplitude/)
@@ -183,7 +183,7 @@ The following destinations can receive data from an unlimited number of sources 
 
 ##### Cloud-mode only
 
-The following destinations can receive data from an unlimited number of sources in cloud-mode, but do not support device-mode connections at all.
+For the following destinations, a single source can connect to up to 10 instances of the destination in cloud-mode, but these destinations do not support a device-mode connection at all.
 
 - [ActiveCampaign](/docs/connections/destinations/catalog/activecampaign/)
 - [Akita](/docs/connections/destinations/catalog/akita/)


### PR DESCRIPTION
Clarify that a source can connect to up to 1 cloud-mode instances - not unlimited cloud-mode instances - of a destination.

### Proposed changes

Previously we enabled customers to connect to unlimited number of cloud-mode instances - we limited this to 10.
Also I fixed some wording that was confusing and made it seem like you could connect unlimited sources - rather, you can connect up to 10 cloud-mode instances to a single source. 

### Merge timing
ASAP once approved