### PR TITLE
Add note about event tag data types.md

### DIFF
--- a/src/connections/destinations/catalog/optimizely-full-stack/index.md
+++ b/src/connections/destinations/catalog/optimizely-full-stack/index.md
@@ -60,8 +60,8 @@ Segment also handles the following mapping:
 
 `revenue` values should be passed as a Segment `property`. The value should be an integer and represent the value in cents, so, for example, $1 should be represented by `100`.
 
-> note ""
-> **Note:** [Custom Event Tags](https://docs.developers.optimizely.com/full-stack/docs/include-event-tags) in Optimizely, which include all Event Tags except `revenue` and `value`, are not displayed on the Optimizely results page, however they are available in a [Data Export](https://docs.developers.optimizely.com/web/docs/data-export) report. Event Tags can be strings, integers, floating point numbers, or boolean values. Optimizely will reject events with any other data types (e.g. arrays).
+> note "Note:"
+> [Custom Event Tags](https://docs.developers.optimizely.com/full-stack/docs/include-event-tags) in Optimizely, which include all Event Tags except `revenue` and `value`, are not displayed on the Optimizely results page, however they are available in a [Data Export](https://docs.developers.optimizely.com/web/docs/data-export) report. Event Tags can be strings, integers, floating point numbers, or boolean values. Optimizely rejects events with any other data types (for example, arrays).
 
 Segment defaults to identifying users with their `anonymousId`. Enabling the "Use User ID" setting in your Segment settings means that only `track` events triggered by identified users are passed downstream to Optimizely. You may optionally fall back to `anonymousId` when `userId` is unavailable by setting `fallbackToAnonymousId` to `true`.
 


### PR DESCRIPTION
### Proposed changes

- Added a note about accepted data types for eventTags. We recently ran into an issue where most-all of Fox's data was being rejected to Optimizely Full Stack, but Event Delivery did not say why. After working with Optimizely support, they told us that eventTags cannot be arrays so we had to use a Destination Filter to strip any array properties out and that resolved the issue. This adds a note to let customers know this could be a possible reason for message rejections. See note in Optimizely docs here: https://docs.developers.optimizely.com/full-stack/docs/include-event-tags#section-implement-tags

### Merge timing
- ASAP once approved
