### PR TITLE
Fix classification info.md

### DIFF
--- a/src/connections/destinations/catalog/comscore/index.md
+++ b/src/connections/destinations/catalog/comscore/index.md
@@ -209,11 +209,10 @@ Classification types are how comScore differentiates between an Ad and Content. 
 
 #### Ad Classification Type
 
-You can pass in a value for `adClassificationType` as an integratino specific option. Segment defaults to value `aa00` on all Ad related video tracking events. The values you may dynamically pass in are described by comScore below.
+You can pass in a value for `adClassificationType` as an integration specific option. Segment defaults to value `va00` on all Ad related video tracking events. The values you may dynamically pass in are described by comScore below.
 
 **LINEAR - VIDEO ON DEMAND**
 Linear advertisements delivered into a media player and presented before, in the middle of, or after video content is consumed by the user. The advertisement completely takes over the full view of the media player.
-
 
 |                  | video + audio |
 | ---------------- | ------------- |
@@ -225,18 +224,21 @@ Linear advertisements delivered into a media player and presented before, in the
 **LINEAR - LIVE**
 Linear advertisements delivered before, in the middle of, or after a live stream of content. The advertisement completely takes over the full view of the media player.
 
-`va21`
+|                  | video + audio |
+| ---------------- | ------------- |
+| Linear Live      | va21          |
+
 
 **BRANDED ENTERTAINMENT**
 Media that a user may intentionally view (like content), or it may be served to a user during an ad break (like an advertisement).
 
-
-| During Linear Pre-Roll  | va31 |
-| ----------------------- | ---- |
-| During Linear Mid-Roll  | va32 |
-| During Linear Post-Roll | va33 |
-| As Content              | va34 |
-| During Live Streaming   | va35 |
+|                         | video + audio |
+| ----------------------- | ------------- |
+| During Linear Pre-Roll  | va31          |
+| During Linear Mid-Roll  | va32          |
+| During Linear Post-Roll | va33          |
+| As Content              | va34          |
+| During Live Streaming   | va35          |
 
 
 
@@ -266,7 +268,9 @@ Content with little-to-no brand equity or brand recognition. User-generated cont
 **BUMPERS**
 Bumpers - also known as billboards or slates - are static promotional items which usually run before content and usually last less than 5 seconds.
 
-`vc99`
+|                  | video + audio |
+| ---------------- | ------------- |
+| Bumpers          | vc99          |
 
 
 ## FAQ


### PR DESCRIPTION
### Proposed changes

Fix typo on default ad classification type. The default is `va00` not `aa00`. See integration code: https://github.com/segment-integrations/analytics-android-integration-comscore/blob/master/src/main/java/com/segment/analytics/android/integrations/comscore/ComScoreIntegration.java#L188

Also reformatting and cleaned up tables in the same section.

### Merge timing
- ASAP once approved

