### PR TITLE
update add-destination.md

### DIFF
--- a/src/connections/destinations/add-destination.md
+++ b/src/connections/destinations/add-destination.md
@@ -239,7 +239,6 @@ For the following destinations, a single source can connect to up to 10 instance
 - [Promoter](/docs/connections/destinations/catalog/promoter.io/)
 - [RadiumOne Connect](/docs/connections/destinations/catalog/radiumone-connect/)
 - [Relay](/docs/connections/destinations/catalog/relay/)
-- [Repeater](/docs/connections/destinations/catalog/repeater/)
 - [Responsys](/docs/connections/destinations/catalog/responsys/)
 - [Sailthru](/docs/connections/destinations/catalog/sailthru/)
 - [Salesforce](/docs/connections/destinations/catalog/salesforce/)


### PR DESCRIPTION
Removed the Repeater from the list of demux-able destinations - it should not have been on the list. 
### Merge timing
ASAP once approved