### PR TITLE
Remove reference to "action_source = app"

### DIFF
--- a/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
@@ -133,13 +133,12 @@ Beginning February 15th 2021, Facebook requires the `action_source` server event
 
 ### Action Source
 
-`action_source` is set to "website" as a default value. If a mobile library is used then `action_source` defaults to "app".
+`action_source` is set to "website" as a default value.
 
 You can set `action_source` manually by passing it as a property of a Track event. You can use either snake case or camel case to include `action_source` as a property in Track events.
 
 | Action Source Values | Description                                                                                               |
 | -------------------- | --------------------------------------------------------------------------------------------------------- |
-| `app`                | Conversion was made using your app.                                                                       |
 | `chat`               | Conversion was made via a messaging app, SMS, or online messaging feature.                                |
 | `email`              | Conversion happened over email.                                                                           |
 | `other`              | Conversion happened in a way that is not listed.                                                          |


### PR DESCRIPTION
### Proposed changes

"App" used to be a supported value for the Action Source when a customer was using this destination with a mobile library. However, Facebook no longer supports this and we have seen some customers still reference this information off of our docs. I have removed the information stating that action_source will default to "app" if a mobile library is used. I have also removed it from the chart as well. A Jira ticket has been submitted by James Reynolds to engineering so that the integration code no longer sets the action_source parameter to "app". 

See here for Facebook's updated action_source values: https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/server-event#action-source

### Merge timing

ASAP once approved, but no rush on this. 
