### PR TITLE
Adding verbiage to the upgrade doc for a.js 2.0

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2.md
@@ -3,7 +3,7 @@ title: Upgrade to Analytics.js 2.0
 strat: ajs
 ---
 
-Analytics.js 2.0 is fully backward compatible with Analytics.js Classic. To upgrade your sources, follow the manual upgrade steps below, or see the schedule for automatic migration. As with all upgrades, Segment recommends that you start development on a non-production source to test the upgrade process and outcome, prior to upgrading your production sources.
+Analytics.js 2.0 is fully backward compatible with Analytics.js Classic when using the default Segment snippet. To upgrade your sources, follow the manual upgrade steps below, or see the schedule for automatic migration. As with all upgrades, Segment recommends that you start development on a non-production source to test the upgrade process and outcome, prior to upgrading your production sources.
 
 ## Manual upgrade
 


### PR DESCRIPTION
Adding more specific verbiage to the upgrade doc to make it clear that Analytics.js 2.0 is fully backward compatible with Ajs Classic when customers are using Segment default snippet.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
