### PR TITLE
[SD-620] Remove beta mark on DL tile on Data Storage Catalog page.

### DIFF
--- a/src/_data/catalog/warehouse.yml
+++ b/src/_data/catalog/warehouse.yml
@@ -89,7 +89,7 @@ items:
   name: catalog/warehouse/data-lakes
   description: ''
   url: connections/storage/catalog/data-lakes
-  status: PUBLIC_BETA
+  status: PUBLIC
   logo:
     url: 'https://cdn.filepicker.io/api/file/YR7dKXAiQWyYvBiVOZNX'
   mark:


### PR DESCRIPTION
### Proposed changes
Remove the beta mark on Segment Data Lakes tile on Data Storage Catalog page since Data Lakes is now in public stage.
URL: https://segment.com/docs/connections/storage/catalog/

**Before:**
![Screen Shot 2021-07-15 at 11 49 21 AM](https://user-images.githubusercontent.com/85952827/125843064-0d80d9e0-03b1-41ce-8d9e-bde509105a41.png)

**After:**
![Screen Shot 2021-07-15 at 12 00 09 PM](https://user-images.githubusercontent.com/85952827/125843080-7890dd02-53e9-4c3c-87b5-713bc374f8b5.png)

### Merge timing
ASAP once approved

### Related issues
Related PR: [SD-620](https://segment.atlassian.net/browse/SD-620)
