### PR TITLE
Remove Amazon EventBridge from multi instance support list

### DIFF
--- a/src/connections/destinations/add-destination.md
+++ b/src/connections/destinations/add-destination.md
@@ -187,7 +187,6 @@ For the following destinations, a single source can connect to up to 10 instance
 - [ActiveCampaign](/docs/connections/destinations/catalog/activecampaign/)
 - [Akita](/docs/connections/destinations/catalog/akita/)
 - [All Aboard](/docs/connections/destinations/catalog/all-aboard/)
-- [Amazon EventBridge](/docs/connections/destinations/catalog/amazon-eventbridge/)
 - [Amazon Kinesis](/docs/connections/destinations/catalog/amazon-kinesis/)
 - [Amazon Kinesis Firehose](/docs/connections/destinations/catalog/amazon-kinesis-firehose/)
 - [Amazon Lambda](/docs/connections/destinations/catalog/amazon-lambda/)


### PR DESCRIPTION
### Proposed changes

Amazon EventBridge has some issues when using it in conjunction with multiple destinations. We are removing it from the list of supported destinations so customers aren't misguided.

Related https://github.com/segmentio/control-plane/pull/1453

**Delta of <20 words or ~150 characters? -> Yes**