### PR TITLE
Remove multi-instance destinations public beta note

### DIFF
--- a/src/connections/destinations/add-destination.md
+++ b/src/connections/destinations/add-destination.md
@@ -88,14 +88,8 @@ Each destination can also have destination settings. These control how Segment t
 
 ## Connecting one source to multiple instances of a destination
 
-<!-- LR: 03/04/21 - hiding this for now since it's in limited rollout.
 > note ""
 > Multiple-destination support is available for all Segment customers on all plan tiers.
--->
-
-
-> info ""
-> Support for connecting to multiple instances of a destination is in public preview. To use this, you must agree to the [(1) Segment First Access](https://segment.com/legal/first-access-beta-preview/) and Beta Terms and Conditions and [(2) Segment Acceptable Use Policy](https://segment.com/legal/acceptable-use-policy/). The feature is being released to different tiers over time. If you see an error message that you can’t connect to multiple instances of the same destination, it is not available yet in your workspace but is coming soon.
 
 Segment allows you to connect a source to multiple instances of a destination. You can use this to set up a single Segment source that sends data into different instances of your analytics and other tools.
 


### PR DESCRIPTION
Remove note that multi-instance destinations is in public beta; replace with note (which was already in there and was commented out) that it is available to all customers

### Merge timing
ASAP once approved