### PR TITLE
Remove info stating that Braze does not support nested data

### DIFF
--- a/src/connections/destinations/catalog/braze/index.md
+++ b/src/connections/destinations/catalog/braze/index.md
@@ -184,7 +184,7 @@ analytics.track('Purchased Item', {
     name: 'bag'
 })
 ```
-When you `track` an event, Segment sends that event to Braze as a custom event. Braze does not support arrays or nested objects for custom track event properties.
+When you `track` an event, Segment sends that event to Braze as a custom event.
 
 > note ""
 > Braze requires that you include a `userId` or `braze_id` for all calls made in cloud-mode. Segment sends a `braze_id` if `userId` is missing. When you use a device-mode connection, Braze automatically tracks anonymous activity using the `braze_id` if a `userId` is missing.


### PR DESCRIPTION
### Proposed changes

Our Lighthouse account GoodRx reached out asking that we clear up our public-facing docs, with regards to Braze. On June 29, 2021, Braze released an update that supports nested custom event data. This change conflicts with what we currently have on our public-facing docs.

I did some testing and can confirm that nested data in the properties object is received by Braze just fine after this change. 

For reference, here is Braze's documentation on this change: https://www.braze.com/docs/user_guide/data_and_analytics/custom_data/nested_object_support/

### Merge timing

- ASAP once approved

