### PR TITLE
Fix Path to integration name for RN

### DIFF
--- a/src/_includes/content/react-dest.md
+++ b/src/_includes/content/react-dest.md
@@ -15,10 +15,10 @@ The {{thisDestName}} device-mode destination SDK is only available for {{thisDes
 {%endif%}
 
 To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project:
-1. Navigate to the root folder of your project, and run a `yarn add {{thisDestName | downcase | replace: " ", "-" }}{% if thisDestRNspecific %}-{{thisDestRNspecific}}{%endif%}` command to add the destination SDK to your project.
+1. Navigate to the root folder of your project, and run a `yarn add @segment/analytics-react-native-{{thisDestName | downcase | replace: " ", "-" }}{% if thisDestRNspecific %}-{{thisDestRNspecific}}{%endif%}` command to add the destination SDK to your project.
 2. Add an `import` statement to your project, as in the example below.
    ```js
-   import {{thisDestName | replace: " ", "" }} from '@segment/analytics-react-native-{{thisDestName | downcase | replace: " ", "" }}{% if thisDestRNspecific %}-{{thisDestRNspecific}}{%endif%}'
+   import {{thisDestName | replace: " ", "" }} from '@segment/analytics-react-native-{{thisDestName | downcase | replace: " ", "-" }}{% if thisDestRNspecific %}-{{thisDestRNspecific}}{%endif%}'
    ```
 3. In the same project file, add the destination to the `using` list in the `await` command.
    ```js


### PR DESCRIPTION
### Proposed changes
The path for the integrations in this RN partial are incorrect. For example, this doc: https://segment.com/docs/connections/destinations/catalog/facebook-app-events/#using-facebook-app-events-with-react-native-device-mode

The package name in the above doc is listed as: 
```yarn add facebook-app-events-ios```

This is incorrect as per here: https://github.com/segmentio/analytics-react-native#supported-device-mode-destinations

And should be:
```yarn add @segment/analytics-react-native-facebook-app-events-ios```

The below change fixes this:
![Screen Shot 2021-08-19 at 15 16 53](https://user-images.githubusercontent.com/16934916/130084684-a51fb606-a6cf-4054-9201-4c08a257b326.png)

### Related issues (optional)
Customer ticket on issue: https://segment.zendesk.com/agent/tickets/436023

