### PR TITLE
added bullets to redirect links

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/android/index.md
@@ -2,8 +2,9 @@
 title: 'Analytics for Android'
 strat: android
 repo: analytics-android
-redirect_from: '/connections/sources/catalog/cloud-apps/kotlin-android/'
-redirect_from: '/connections/sources/catalog/cloud-apps/kotlin/'
+redirect_from:
+  - '/connections/sources/catalog/cloud-apps/kotlin-android/'
+  - '/connections/sources/catalog/cloud-apps/kotlin/'
 ---
 
 


### PR DESCRIPTION
made a list of redirect links as previously without the list, the first link was getting overridden by the second so one of the buttons on the external integrations page was still going to a 404
