### PR TITLE
changed redirect links for kotlin/swift 

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
@@ -1,6 +1,8 @@
 ---
 title: Analytics for Kotlin (Android)
 strat: kotlin
+redirect_from:
+  - '/connections/sources/catalog/cloud-apps/kotlin-android/'
 ---
 
 With Analytics-Kotlin, you can send data using Kotlin applications to any analytics or marketing tool without having to learn, test, or implement a new API every time. Analytics-Kotlin enables you to process and track the history of a payload, while Segment controls the API and prevents unintended operations.

--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -1,6 +1,8 @@
 ---
 title: 'Analytics for Swift'
 strat: swift
+redirect_from:
+  - '/connections/sources/catalog/cloud-apps/swift/'
 ---
 
 With Analytics-Swift, you can send data from iOS, tvOS, iPadOS, WatchOS, macOS and Linux applications to any analytics or marketing tool without having to learn, test, or implement a new API every time. Analytics-Swift enables you to process and track the history of a payload, while Segment controls the API and prevents unintended operations. Analytics-Swift also offers default implementations to help you maintain destinations and integrations.

--- a/src/connections/sources/catalog/libraries/server/kotlin/index.md
+++ b/src/connections/sources/catalog/libraries/server/kotlin/index.md
@@ -1,5 +1,7 @@
 ---
 title: Analytics for Kotlin (Server)
+redirect_from:
+  - '/connections/sources/catalog/cloud-apps/kotlin/'
 ---
 
 With Analytics-Kotlin, you can send data using Kotlin applications to any analytics or marketing tool without having to learn, test, or implement a new API every time. Analytics-Kotlin enables you to process and track the history of a payload, while Segment controls the API and prevents unintended operations.


### PR DESCRIPTION
changed the redirect links for kotlin and swift as the links from the integrations page for [kotlin](https://segment.com/catalog/integrations/kotlin/) and [swift](https://segment.com/catalog/integrations/swift/) were leading to  404 pages
