### PR TITLE
Remove broken links for multi-instance destination page

### DIFF
--- a/src/connections/destinations/add-destination.md
+++ b/src/connections/destinations/add-destination.md
@@ -122,13 +122,10 @@ You can add multiple instances of a destination using the Segment Config API. Se
 ### Multi-instance destinations and Device-mode
 
 - **You can connect a source to up to 25 instances of a destination if all of the instances use cloud-mode.** Destinations using cloud-mode receive data directly from the Segment servers.
-- **Mobile sources, and the legacy Project source, can connect to multiple instances of cloud-mode only destinations.** See the list of [cloud-mode only destinations](#cloud-mode-only). Mobile and Project sources cannot connect to multiple instances of [cloud-mode and device-mode destinations](#cloud-mode-and-device-mode).
+- **Mobile sources, and the legacy Project source, can connect to multiple instances of cloud-mode only destinations.** Mobile and Project sources cannot connect to multiple instances of cloud-mode and device-mode destinations.
     - **Warning**: If you bundle one instance of a destination in a mobile source but have other instances of that destination connected to that source you might see unexpected and inconsistent data.
 - **Non-mobile sources can only connect to one *device-mode* instance of a destination, in addition to up to 25 cloud-mode instances.** A web browser sending to a destination in device-mode sends data directly from the user’s browser (instead of through the Segment servers), by bundling a copy of destination’s code with the Segment SDK. Segment can’t bundle multiple copies of the destination SDK and so it can’t send data to multiple instances of the destination from the browser.
 - **You cannot connect a source to more than one instance of a destination that operates in device-mode only**. These destinations can only accept data from code directly on the user’s device, and Segment cannot include duplicates of that code for a single source.
-
-For more information see [the compatible destination lists below](#multi-instance-compatible-destinations).
-
 
 
 ### Other multi-instance destination considerations


### PR DESCRIPTION
### Proposed changes

There are some broken links on the multi-instance destination page. This commit removes them since the content is no longer relevant. 

### Merge timing
- Once approved

Slack convo for context: https://segment.slack.com/archives/C012UJ8LRGE/p1632849643018000
