### PR TITLE
[Azure Synapse Destination] provide clarification on dedicated sql pool

### DIFF
--- a/src/connections/storage/catalog/azuresqldw/index.md
+++ b/src/connections/storage/catalog/azuresqldw/index.md
@@ -12,7 +12,7 @@ Azure's [Azure Synapse Analytics](https://azure.microsoft.com/en-us/services/syn
 There are four main steps to get started with Segment:
 
 1. Have an [Azure subscription](https://azure.microsoft.com/en-us/free/)
-2. Provision [SQL Data Warehouse](https://docs.microsoft.com/en-us/azure/sql-data-warehouse/create-data-warehouse-portal)
+2. Provision [SQL Data Warehouse (Dedicated SQL Pool)](https://docs.microsoft.com/en-us/azure/sql-data-warehouse/create-data-warehouse-portal)
 3. Give Segment access to your SQL Data Warehouse
 4. Configure the Destination in Segment
 


### PR DESCRIPTION
### Proposed changes

In the "Getting Started" steps, I changed number 2 to better reflect that you will need to setup a "dedicated sql pool" in order to connect with Segment properly. For Azure Synapse, there are currently two options in setting this up: serverless sql pool, and dedicated sql pool. 

Currently, the only way to know that a dedicated sql pool is necessary to connect with Segment, is if you click into the linked documentation on step 2. I had a customer, who did not do this because he had already provisioned his Synapse Analytics setup with the "serverless sql pool" option. Which resulted in a lot of back in forth before stumbling upon the solution. 

Feel free to do with this request as you will, I just thought it might be worth running it you all to see if this would be worth changing. Thanks!

### Merge timing

No rush.

### Related issues (optional)

N/A
