### PR TITLE
DOC-341 Fix HubSpot integration object reference

### DIFF
--- a/src/_data/catalog/overrides.yml
+++ b/src/_data/catalog/overrides.yml
@@ -3,6 +3,8 @@
 items:
 - slug: hubspot
   display_name: HubSpot
+  previous_names:
+  - HubSpot
   components:
   - type: WEB
   - type: CLOUD


### PR DESCRIPTION

### Proposed changes
Fixed a null value in the quick info related to the integration object.

### Merge timing
Standard

### Related issues (optional)

DOC-341
