### PR TITLE
Fix HubSpot Integrations Object name

### DIFF
--- a/src/_data/catalog/overrides.yml
+++ b/src/_data/catalog/overrides.yml
@@ -3,6 +3,8 @@
 items:
 - slug: hubspot
   display_name: HubSpot
+  previous_names:
+  - HubSpot
   components:
   - type: WEB
   - type: CLOUD


### PR DESCRIPTION

### Proposed changes
Fixed the "If you reference it in the Integrations object..." portion of the HubSpot docs.

### Merge timing
Standard

### Related issues (optional)

Closes #2031
