### PR TITLE
Add note that A.js 2.0 is available as an open-source project.

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/index.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/index.md
@@ -11,7 +11,7 @@ strat: ajs
 Analytics.js 2.0, the latest version of Segment's JavaScript source, enables you to send your data to any tool without having to learn, test, or use a new API every time.
 
 > note ""
-> Analytics.js 2.0 is now available as an [open-source project](https://github.com/segmentio/analytics-next/).
+> Analytics.js 2.0 is available as an [open-source project](https://github.com/segmentio/analytics-next/){:target="_blank"}.
 
 
 ## Benefits of Analytics.js 2.0


### PR DESCRIPTION
Changed text to show that Analytics.js 2.0 is now open sourced.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
