### PR TITLE
Updated Amazon S3 Docs with supported regions warning

### DIFF
--- a/src/connections/storage/catalog/amazon-s3/index.md
+++ b/src/connections/storage/catalog/amazon-s3/index.md
@@ -167,7 +167,7 @@ Segment recommends doing this as a best practice. The following policy strictly 
 ## Region
 
 > warning ""
-> The Amazon S3 destination only supports workspaces in the US region. Workspaces outside of the US can't connect to this destination. If you wish to connect to a different region use Segment's new [AWS S3](https://segment.com/docs/connections/storage/catalog/aws-s3/) destination instead.
+> The Amazon S3 destination only supports workspaces in the US region. Workspaces outside of the US can't connect to this destination. If you wish to connect to a different region use Segment's new [AWS S3 destination](https://segment.com/docs/connections/storage/catalog/aws-s3/) instead.
 
 Segment infers the region of your bucket when data is copied to it, so you don't need to specify a bucket region in your configuration. If you're using VPC Endpoints for your S3 bucket, make sure you configure the endpoint in the same region as your bucket. You can find more information on this in the AWS S3 docs [here](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-endpoints-s3.html).
 


### PR DESCRIPTION
### Proposed changes

This PR updates the Amazon S3 Docs with a warning that it only supports workspaces based in the US. 

![image](https://user-images.githubusercontent.com/89420099/138525857-e315df48-0399-4379-bb15-52c2287b5ea0.png)


### Merge timing
<!-- When should this get merged/published?

- Once it is approved and no more blocks from sev0. 

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
