### PR TITLE
Add a link to the Group spec

### DIFF
--- a/src/connections/destinations/catalog/eloqua/index.md
+++ b/src/connections/destinations/catalog/eloqua/index.md
@@ -64,8 +64,8 @@ the Segment `group` event needs to include the Account's name and groupId. If
 you set up a custom Account field called Company in Eloqua, Segment will
 automatically map the name of the Account to that field.
 
-Follow the Segment spec to ensure proper mapping of these fields from Segment
-`group` traits: https://segment.com/docs/connections/spec/group/#traits.
+Follow [Segment's group spec](https://segment.com/docs/connections/spec/group/#traits) to ensure proper mapping of these fields from Segment
+`group` traits.
 
 In addition, Segment supports mapping custom `group` traits to Eloqua custom
 object fields. To do so, you can set up mappings in the settings for your


### PR DESCRIPTION
Removed written out url and created hyperlink instead.
From:   Segment spec ... : https://segment.com/docs/connections/spec/group/#traits
To:        Segment's group spec

### Proposed changes
Removed written out url and created hyperlink instead.
From:   Segment spec ... : https://segment.com/docs/connections/spec/group/#traits
To:        Segment's group spec

It looked unprofessional to have an entire URL written out when hyperlinks are used throughout the rest of the page.

### Merge timing
Not time sensitive.

### Related issues (optional)
N/A
