### PR TITLE
Adding different IAM roles according to the regions

### DIFF
--- a/src/connections/storage/data-lakes/data-lakes-manual-setup.md
+++ b/src/connections/storage/data-lakes/data-lakes-manual-setup.md
@@ -66,7 +66,7 @@ The following steps provide examples of the IAM Role and IAM Policy.
 
 ### IAM Role
 
-###### 1. For `us-west-2` region:
+###### 1. For DataLake created in US workspaces:
 
 Create a `segment-data-lake-role` role for Segment to assume. Attach the following trust relationship document to the role:
 
@@ -96,7 +96,7 @@ Create a `segment-data-lake-role` role for Segment to assume. Attach the followi
   ]
 }
 ```
-###### 2. For `eu-west-1` region:
+###### 2. For DataLake created in EU workspaces:
 
 Create a `segment-data-lake-role` role for Segment to assume. Attach the following trust relationship document to the role:
 

--- a/src/connections/storage/data-lakes/data-lakes-manual-setup.md
+++ b/src/connections/storage/data-lakes/data-lakes-manual-setup.md
@@ -66,9 +66,11 @@ The following steps provide examples of the IAM Role and IAM Policy.
 
 ### IAM Role
 
-###### 1. For DataLake created in US workspaces:
+Create a `segment-data-lake-role` for Segment to assume. The trust relationship document you attach to the role will be different depending on your workspace region. 
 
-Create a `segment-data-lake-role` role for Segment to assume. Attach the following trust relationship document to the role:
+#### IAM Role for Data Lakes created in US workspaces:
+
+Attach the following trust relationship document to the role to create a `segment-data-lake-role` role for Segment:
 
 ```json
 {
@@ -96,9 +98,16 @@ Create a `segment-data-lake-role` role for Segment to assume. Attach the followi
   ]
 }
 ```
-###### 2. For DataLake created in EU workspaces:
 
-Create a `segment-data-lake-role` role for Segment to assume. Attach the following trust relationship document to the role:
+> note ""
+> **NOTE:** Replace the `ExternalID` list with the Segment `WorkspaceID` that contains the sources to sync to the Data Lake.
+
+#### IAM Role for Data Lakes created in EU workspaces:
+
+> info ""
+> EU workspaces are currently in beta. If you would like to learn more about the beta, please contact your account manager. 
+
+Attach the following trust relationship document to the role to create a `segment-data-lake-role` role for Segment.
 
 ```json
 {

--- a/src/connections/storage/data-lakes/data-lakes-manual-setup.md
+++ b/src/connections/storage/data-lakes/data-lakes-manual-setup.md
@@ -66,6 +66,8 @@ The following steps provide examples of the IAM Role and IAM Policy.
 
 ### IAM Role
 
+###### 1. For `us-west-2` region:
+
 Create a `segment-data-lake-role` role for Segment to assume. Attach the following trust relationship document to the role:
 
 ```json
@@ -80,6 +82,34 @@ Create a `segment-data-lake-role` role for Segment to assume. Attach the followi
           "arn:aws:iam::294048959147:role/customer-datalakes-prod-admin",
           "arn:aws:iam::294048959147:role/datalakes-aws-worker",
           "arn:aws:iam::294048959147:role/datalakes-customer-service"
+        ]
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": [
+            "WORKSPACE_ID"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+###### 2. For other regions:
+
+Create a `segment-data-lake-role` role for Segment to assume. Attach the following trust relationship document to the role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::595280932656:role/segment-datalakes-production-access",
         ]
       },
       "Action": "sts:AssumeRole",

--- a/src/connections/storage/data-lakes/data-lakes-manual-setup.md
+++ b/src/connections/storage/data-lakes/data-lakes-manual-setup.md
@@ -96,7 +96,7 @@ Create a `segment-data-lake-role` role for Segment to assume. Attach the followi
   ]
 }
 ```
-###### 2. For other regions:
+###### 2. For `eu-west-1` region:
 
 Create a `segment-data-lake-role` role for Segment to assume. Attach the following trust relationship document to the role:
 


### PR DESCRIPTION
### Proposed changes

Adding a different IAM role setting according to the region in which the customer is setting up the datalakes destination.

### Merge timing
Once approved.
