### PR TITLE
Updated Bing Ads Destination docs to include additional parameters

### DIFF
--- a/src/connections/destinations/catalog/bing-ads/index.md
+++ b/src/connections/destinations/catalog/bing-ads/index.md
@@ -68,6 +68,7 @@ analytics.track('Order Completed', {
 
 **Category**: `category` property
 
+**Action**: always sent with value of `track`
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Proposed changes
adding, **Action**: always sent with value of `track`, as our integration always sets this to 'track'
https://github.com/segmentio/analytics.js-integrations/blob/0c0f9eb070e61f1f43c014062d3c5df1ccfd12e4/integrations/bing-ads/lib/index.js#L78

### Merge timing
ASAP
### Related issues (optional)

