### PR TITLE
Update broken links to Customer.io API Docs

### DIFF
--- a/src/connections/destinations/catalog/customer-io/index.md
+++ b/src/connections/destinations/catalog/customer-io/index.md
@@ -129,7 +129,7 @@ For that, you need to make the following calls:
 
 ## Application Installed
 
-[Application Installed](/docs/connections/spec/mobile/#application-installed) events will add or update a device in the person's Customer.io profile using [this](https://customer.io/docs/api/#apitrackcustomersdevices_update) API endpoint. Note, you must pass a device token in your event payload using a `context.device.token` property. See more on Contextual properties [here](/docs/connections/spec/common/#context).
+[Application Installed](/docs/connections/spec/mobile/#application-installed) events will add or update a device in the person's Customer.io profile using [this](https://customer.io/docs/api/#operation/add_device) API endpoint. Note, you must pass a device token in your event payload using a `context.device.token` property. See more on Contextual properties [here](/docs/connections/spec/common/#context).
 
 {% comment %} api-example '{
 "action": "track",
@@ -209,7 +209,7 @@ For that, you need to make the following calls:
 ## Application Uninstalled
 
 
-[Application Uninstalled](/docs/connections/spec/mobile/#application-installed) events will remove the device from the person's Customer.io profile using [this](https://customer.io/docs/api/#apitrackcustomersdevices_delete) API endpoint. Note, you must pass a device token in your event payload using a `context.device.token` property. See more on [Contextual properties](/docs/connections/spec/common/#context).
+[Application Uninstalled](/docs/connections/spec/mobile/#application-installed) events will remove the device from the person's Customer.io profile using [this](https://customer.io/docs/api/#operation/delete_device) API endpoint. Note, you must pass a device token in your event payload using a `context.device.token` property. See more on [Contextual properties](/docs/connections/spec/common/#context).
 
 
 {% comment %} api-example '{
@@ -261,7 +261,7 @@ To enable this feature:
 ## Best Practices
 
 ### Rate Limits
-Customer.io has limits on the data collected by their API. To ensure your events arrive in Customer.io, make sure that you're respecting the limits placed on the [Customer.io API](https://learn.customer.io/api/#api-documentationlimits). If you're using Segment's [HTTP API](/docs/connections/sources/catalog/libraries/server/http/) to send a batch of events to Customer.io at once, make sure you throttle the `import` to 100-200 requests per second.
+Customer.io has limits on the data collected by their API. To ensure your events arrive in Customer.io, make sure that you're respecting the limits placed on the [Customer.io API](https://customer.io/docs/api/#tag/trackLimit). If you're using Segment's [HTTP API](/docs/connections/sources/catalog/libraries/server/http/) to send a batch of events to Customer.io at once, make sure you throttle the `import` to 100-200 requests per second.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Proposed changes
The following links no longer lead to the intended resource on the customer.io side:
https://customer.io/docs/api/#apitrackcustomersdevices_update
https://customer.io/docs/api/#apitrackcustomersdevices_delete
https://learn.customer.io/api/#api-documentationlimits

Using Wayback machine the related contents are now linked to:
https://customer.io/docs/api/#operation/add_device
https://customer.io/docs/api/#operation/delete_device
https://customer.io/docs/api/#tag/trackLimit


### Merge timing
- ASAP once approved?