### PR TITLE
Salesforce Integration: Update doc to include sandbox name at the end of account email

### DIFF
--- a/src/connections/destinations/catalog/salesforce/index.md
+++ b/src/connections/destinations/catalog/salesforce/index.md
@@ -179,7 +179,10 @@ To create resources of other types, such as Accounts or custom objects, Segment 
 
 ### Sandbox Mode
 
-To enable an integration with a Salesforce Sandbox instance, toggle the Sandbox setting to true.
+To enable an integration with a Salesforce Sandbox instance follow the following steps;
+1. Toggle the Sandbox setting to true
+2. Include the sandbox name at the end of the account email followed by a `.` (fullstop) 
+   - i.e. `name@work.com` -> `name@work.com.sandboxname`
 
 ### API Call Limits
 

--- a/src/connections/destinations/catalog/salesforce/index.md
+++ b/src/connections/destinations/catalog/salesforce/index.md
@@ -180,7 +180,7 @@ To create resources of other types, such as Accounts or custom objects, Segment 
 ### Sandbox Mode
 
 To enable an integration with a Salesforce Sandbox instance:
-1. Toggle the Sandbox setting to true in Salesforce.
+1. Toggle the Sandbox setting to  `true` in the Salesforce Destination settings.
 2. Append the sandbox name to the account email, as shown below:
    - `name@work.com` -> `name@work.com.sandboxname` where `sandboxname` is the name of your sandbox.
 

--- a/src/connections/destinations/catalog/salesforce/index.md
+++ b/src/connections/destinations/catalog/salesforce/index.md
@@ -179,10 +179,10 @@ To create resources of other types, such as Accounts or custom objects, Segment 
 
 ### Sandbox Mode
 
-To enable an integration with a Salesforce Sandbox instance follow the following steps;
-1. Toggle the Sandbox setting to true
-2. Include the sandbox name at the end of the account email followed by a `.` (fullstop) 
-   - i.e. `name@work.com` -> `name@work.com.sandboxname`
+To enable an integration with a Salesforce Sandbox instance:
+1. Toggle the Sandbox setting to true in Salesforce.
+2. Append the sandbox name to the account email, as shown below:
+   - `name@work.com` -> `name@work.com.sandboxname` where `sandboxname` is the name of your sandbox.
 
 ### API Call Limits
 


### PR DESCRIPTION
### Proposed changes 📝 
- The current salesforce integration doc doesn't include sufficient information about how to integrate a Salesforce Sandbox to segment
- It was lacking one vital information where you had to include sandbox naming at the end of the account email
   i.e. account email should be `name@work.com.sandboxname` otherwise salesforce would throw an unauthorized error ⚠️ 
- None of the docs suggest this.. therefore this would help someone who went through the same struggles as us fix it.

### Merge timing
- ASAP once approved 

### Related issues (optional)
- None 
