### PR TITLE
GA4 destination doc updates

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -49,7 +49,7 @@ sections:
     title: Google Universal Analytics destination
   - path: /connections/destinations/catalog/google-analytics/ga4-plans
     title: Google Analytics 4 destination
-  - path: /connections/destinations/catalog/google-tag-manager
+  - path: /connections/destinations/catalog/actions-google-analytics-4
     title: Google Tag Manager destination
   - path: /connections/destinations/catalog/doubleclick-floodlight
     title: DoubleClick Floodlight destination

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -35,7 +35,7 @@ Before you connect Segment to Google Analytics 4, configure a Google Analytics 4
 2. Search for “Google Analytics 4” in the Destinations Catalog, and select the destination.
 3. Click **Configure Google Analytics 4** in the top-right corner of the screen.
 4. Select the source that will send data to Google Analytics 4 and follow the steps to name your destination.
-5. On the **Settings** tab tab, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} and API Secret associated with your GA4 stream and click **Save**. _Note: To create a new API Secret, navigate in the Google Analytics UI to Admin > Data Streams > choose your stream > Measurement Protocol > Create._
+5. On the **Settings** tab, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} and API Secret associated with your GA4 stream and click **Save**. _Note: To create a new API Secret, navigate in the Google Analytics UI to Admin > Data Streams > choose your stream > Measurement Protocol > Create._
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
 ### Create your first Mapping

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -29,8 +29,6 @@ The Google Analytics 4 destination provides the following benefits:
 
 Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
 
-### Connect Google Analytics 4 to your workspace
-
 1. From the Segment web app, click **Catalog**, then click **Destinations**.
 2. Search for “Google Analytics 4” in the Destinations Catalog, and select the destination.
 3. Click **Configure Google Analytics 4** in the top-right corner of the screen.
@@ -38,7 +36,9 @@ Before you connect Segment to Google Analytics 4, configure a Google Analytics 4
 5. On the **Settings** tab, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} and API Secret associated with your GA4 stream and click **Save**. _Note: To create a new API Secret, navigate in the Google Analytics UI to Admin > Data Streams > choose your stream > Measurement Protocol > Create._
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
-### Create your first Mapping
+{% include components/actions-fields.html %}
+
+## Create your first Mapping
 
 Mappings define which events Segment sends to Google Analytics 4, and the data that they carry. To create a Mapping:
 
@@ -51,26 +51,3 @@ Mappings define which events Segment sends to Google Analytics 4, and the data t
 7. Click **Save**.
 8. Enable the Mapping with the toggle under the **Status** column.
 
-## Available Google Analytics 4 Actions
-
-Combine the supported [triggers](docs/connections/destinations/actions/#components-of-a-destination-action) with the following Google Analytics 4-supported actions:
-
-* Page View
-* Search
-* Select Item
-* View Item
-* View Item List
-* Add to Wishlist
-* Add to Cart
-* Remove from Cart
-* View Cart
-* Select Promotion
-* View Promotion
-* Begin Checkout
-* Add Payment Info
-* Purchase
-* Refund
-* Generate Lead
-* Sign Up
-* Login
-* Custom Event

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -1,11 +1,13 @@
 ---
 title: Google Analytics 4 Destination
+strat: google
 hide-boilerplate: true
 hide-dossier: true
-hidden: true
 ---
 
-[Google Analytics 4](https://support.google.com/analytics/answer/10089681){:target="_blank"} is Google's new Analytics property, which you can use for both websites and applications. Google Analytics 4 has machine learning at its core to help surface insights and give you a more complete understanding of your customers across devices and platforms. When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4.
+[Google Analytics 4](https://support.google.com/analytics/answer/10089681){:target="_blank"} is Google's new Analytics property, which you can use for both websites and applications. Google Analytics 4 has machine learning at its core to help surface insights and give you a more complete understanding of your customers across devices and platforms. 
+
+When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. Segment will send your data server-side to Google's [Measurement Protocol API](https://developers.google.com/analytics/devguides/collection/protocol/ga4).
 
 > info ""
 > This document is about a feature which is in beta. This means that the Destination Actions are in active development, and some functionality may change before it becomes generally available
@@ -20,23 +22,36 @@ The Google Analytics 4 destination provides the following benefits:
 
 - **Fewer settings**. Data mapping for actions-based destinations happens during configuration, which eliminates the need for most settings.
 - **Clearer mapping of data**. Actions-based destinations enable you to define the mapping between the data Segment receives from your source and the data Segment sends to Google Analytics 4.
+- **Prebuilt mappings**. Mappings for recommended Google Analytics 4 events, like `Purchase`, are prebuilt with the prescribed parameters and available for customization.
 - **Support for multi-product arrays**. Products nested within arrays, like the `products` array in the [Order Completed](/docs/connections/spec/ecommerce/v2/#order-completed) event, can be sent to Google Analytics 4.
-- **Multi-platform support**. You can use a Google Analytics 4 property for a website, an app, or both a website and app together.
 
 ## Getting started
 
 Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
 
-The Google Analytics 4 destination is in Private Beta and does not appear in the Destinations catalog.
+### Connect Google Analytics 4 to your workspace
 
-1. To access the destination, navigate to this URL: `https://app.segment.com/<workspace_slug>/destinations/catalog/actions-google-analytics-4`. Replace `<workspace_slug>` with your workspace slug.
-2. Click **Configure Google Analytics 4** in the top-right corner of the screen.
-3. Choose which of your sources to connect the destination to. (You can connect more sources to the destination later.)
-4. Click **Configure Actions** and follow the set up steps to **Create Destination**.
-5. On the Settings tab, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} and API Secret associated with your GA4 stream and click **Save**. _Note: To create a new API Secret, navigate in the Google Analytics UI to Admin > Data Streams > choose your stream > Measurement Protocol > Create._
+1. From the Segment web app, click **Catalog**, then click **Destinations**.
+2. Search for “Google Analytics 4” in the Destinations Catalog, and select the destination.
+3. Click **Configure Google Analytics 4** in the top-right corner of the screen.
+4. Select the source that will send data to Google Analytics 4 and follow the steps to name your destination.
+5. On the **Settings** tab tab, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} and API Secret associated with your GA4 stream and click **Save**. _Note: To create a new API Secret, navigate in the Google Analytics UI to Admin > Data Streams > choose your stream > Measurement Protocol > Create._
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
-## Available Google Analytics 4 actions
+### Create your first Mapping
+
+Mappings define which events Segment sends to Google Analytics 4, and the data that they carry. To create a Mapping:
+
+1. Navigate to the **Mappings** tab on the destination.
+2. Click **Add Mapping**, and select one of the prebuilt actions.
+3. Configure the **Event Trigger**. For example, you can trigger the action whenever the source sends an event named `Order Completed`. 
+4. Click **Continue** to choose a test event and configure the action fields. 
+5. When you're finished editing the action fields, click **Continue**. 
+6. To test your mapping, expand the **Send a test event** section, and click **Test Action**. This section displays the test result and the payload that Google Analytics 4 returns to Segment.
+7. Click **Save**.
+8. Enable the Mapping with the toggle under the **Status** column.
+
+## Available Google Analytics 4 Actions
 
 Combine the supported [triggers](docs/connections/destinations/actions/#components-of-a-destination-action) with the following Google Analytics 4-supported actions:
 

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -7,7 +7,7 @@ hide-dossier: true
 
 [Google Analytics 4](https://support.google.com/analytics/answer/10089681){:target="_blank"} is Google's new Analytics property, which you can use for both websites and applications. Google Analytics 4 has machine learning at its core to help surface insights and give you a more complete understanding of your customers across devices and platforms. 
 
-When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. Segment will send your data server-side to Google's [Measurement Protocol API](https://developers.google.com/analytics/devguides/collection/protocol/ga4).
+When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. Segment will send your data server-side to [Google's Measurement Protocol API](https://developers.google.com/analytics/devguides/collection/protocol/ga4).
 
 > info ""
 > This document is about a feature which is in beta. This means that the Destination Actions are in active development, and some functionality may change before it becomes generally available

--- a/src/connections/destinations/catalog/google-tag-manager/index.md
+++ b/src/connections/destinations/catalog/google-tag-manager/index.md
@@ -2,6 +2,7 @@
 title: Google Tag Manager Destination
 hide-cmodes: true
 strat: google
+published: false
 ---
 
 [Google Tag Manager](https://support.google.com/tagmanager) (GTM) is a tag management system that allows you to quickly and easily update tags and code snippets on your website or mobile apps. Once you add the Tag Manager snippet to your website or mobile app, you can configure tags using a web-based user interface without having to alter and deploy additional code. This reduces errors and frees you from having to involve a developer whenever you need to make changes. The Google Tag Manager Destination is open-source. You can browse the code [on GitHub](https://github.com/segment-integrations/analytics.js-integration-google-tag-manager).


### PR DESCRIPTION
### Proposed changes
Updates to GA4 docs ahead of Public Beta on 12/14:
* Unhide GA4 doc
* Add GA4 doc to "strat: google"
* Remove private beta instructions
* Add more details to the docs

**Can we also add the automated action and field mappings to the bottom of this doc? And if we do this, should we remove the section I manually added previously called “Available Google Analytics 4 actions”?**

### Merge timing
Tues, Dec 14 due to Public Beta beginning

### JIRA
https://segment.atlassian.net/browse/DOC-397