### PR TITLE
Add note to classic FB CAPI destination doc

### DIFF
--- a/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
@@ -14,6 +14,9 @@ hide-dossier: true
 > warning "Server Event Parameter Requirements"
 > On February 15th 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that do not meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements)
 
+> success ""
+> **Good to know**: This page is about the classic Facebook Conversions API Segment destination. There's also a page about the new [Facebook Conversions API (Actions) destination](/docs/connections/destinations/catalog/actions-facebook-conversions-api/). Both of these destinations are in Public Beta and receive data _from_ Segment. We recommend using the new Facebook Conversions API (Actions) destination for additional functionality and flexibility.
+
 > info "Destination name change"
 > Facebook Conversions API was renamed from Facebook Pixel Server-Side.
 


### PR DESCRIPTION
### Proposed changes
Add note to classic FB CAPI doc pointing to actions-version to start getting customers to migrate over to the new version

### Merge timing
Tues, Dec 14 due to FB CAPI (Actions) Public Beta beginning

### JIRA
https://segment.atlassian.net/browse/DOC-398
