### PR TITLE
Update the context table in the common spec

### DIFF
--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -245,13 +245,13 @@ Other libraries only collect `context.library`, any other context variables must
 | campaign.medium          |     √        |               |                   |
 | campaign.term            |     √        |               |                   |
 | campaign.content         |     √        |               |                   |
-| device.type              |              |               |      √            |
+| device.type              |              |     √         |      √            |
 | device.id                |              |     √         |      √            |
 | device.advertisingId     |              |     √         |      √            |
 | device.adTrackingEnabled |              |     √         |      √            |
 | device.manufacturer      |              |     √         |      √            |
 | device.model             |              |     √         |      √            |
-| device.name              |              |               |      √            |
+| device.name              |              |     √         |      √            |
 | library.name             |     √        |     √         |      √            |
 | library.version          |     √        |     √         |      √            |
 | ip*                      |     √        |     √         |      √            |


### PR DESCRIPTION
### Proposed changes
Updating the Context Fields Automatically Collected table to confirm that `device.type `& `device.name` are collected on analytics-ios.

Ref:
https://github.com/segmentio/analytics-ios/blob/16368799b097c81c1efde1d9c0a90470faae76c2/Analytics/Classes/Internal/SEGSegmentIntegration.m#L167-L181

### Merge timing
- ASAP once approved


