### PR TITLE
Add note to hubspot docs about event tester

### DIFF
--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -8,7 +8,7 @@ cmode-override: true
 [HubSpot](https://www.hubspot.com/) is an inbound marketing and sales platform that helps companies attract visitors, convert leads, and close customers. The `analytics.js` HubSpot Destination is open-source. You can browse the code [on GitHub](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/hubspot).
 
 > warning ""
-> The HubSpot destination does not work with Segment's Event Tester due to how identify and group calls must be sent in order. The Event Tester should not be used for troubleshooting the HubSpot destination.
+> The HubSpot destination is not compatible with the Segment Event Tester. As result, Segment recommends using other tools to troubleshoot the HubSpot destination.
 
 
 ## Getting Started

--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -7,6 +7,9 @@ cmode-override: true
 
 [HubSpot](https://www.hubspot.com/) is an inbound marketing and sales platform that helps companies attract visitors, convert leads, and close customers. The `analytics.js` HubSpot Destination is open-source. You can browse the code [on GitHub](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/hubspot).
 
+> warning ""
+> The HubSpot destination does not work with Segment's Event Tester due to how identify and group calls must be sent in order. The Event Tester should not be used for troubleshooting the HubSpot destination.
+
 
 ## Getting Started
 
@@ -214,7 +217,6 @@ analytics.ready(function(){
   });
 })
 ```
-
 
 ## Using HubSpot with Personas
 


### PR DESCRIPTION
### Proposed changes
We've been getting a lot of tickets about the Hubspot event tester not working which is expected due to how identify calls and group calls need to be sent together and in order, otherwise group calls fail. A docs update will help clarify this to customers.

### Merge timing
- ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/DEST-3601