### PR TITLE
update incorrect description of a few fields

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/zendesk/index.md
+++ b/src/connections/sources/catalog/cloud-apps/zendesk/index.md
@@ -483,19 +483,19 @@ In your warehouse, each collection gets its own table. Find below a list of the 
    </tr>
    <tr>
      <td>requester_wait_time_in_minutes_calendar</td>
-     <td> Number of minutes the requester spent waiting during business hours.</td>
-   </tr>
-   <tr>
-     <td>requester_wait_time_in_minutes_business</td>
      <td> Number of minutes the requester spent waiting outside of business hours.</td>
    </tr>
    <tr>
+     <td>requester_wait_time_in_minutes_business</td>
+     <td> Number of minutes the requester spent waiting during business hours.</td>
+   </tr>
+   <tr>
      <td>on_hold_time_in_minutes_calendar</td>
-     <td> Number of minutes the ticket was on hold during business hours.</td>
+     <td> Number of minutes the ticket was on hold outside of business hours.</td>
    </tr>
    <tr>
      <td>on_hold_time_in_minutes_business</td>
-     <td> Number of minutes the ticket was on hold outside of business hours.</td>
+     <td> Number of minutes the ticket was on hold during business hours.</td>
    </tr>
    <tr>
      <td>created_at</td>


### PR DESCRIPTION
The description of a few fields were incorrect, the description of the business hours were switched with out-of-business hours:
requester_wait_time_in_minutes_calendar
requester_wait_time_in_minutes_business
on_hold_time_in_minutes_calendar
on_hold_time_in_minutes_business
This was confirmed by looking at the examples here : https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_metrics/

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
