### PR TITLE
rename UserLeap destination to Sprig Cloud, edits on Sprig (Actions)

### DIFF
--- a/src/connections/destinations/catalog/actions-sprig-web/index.md
+++ b/src/connections/destinations/catalog/actions-sprig-web/index.md
@@ -18,7 +18,7 @@ Sprig maintains this destination. For any issues with the destination, consult [
 <!-- In the section below, add your destination name where indicated. If you have a classic version of the destination, ensure that its documentation is linked as well. If you don't have a classic version of the destination, remove the second and third sentences. -->
 
 > success ""
-> **Good to know**: This page is about the [Actions-framework](/docs/connections/destinations/actions/) Sprig Segment destination. There's also a page about the [non-Actions Sprig (formerly UserLeap) destination](/docs/connections/destinations/catalog/userleap/). Both of these destinations receive data from Segment.
+> **Good to know**: This page is about the [Actions-framework](/docs/connections/destinations/actions/) Sprig Segment destination. There's also a page about the [non-Actions Sprig Cloud (formerly UserLeap) destination](/docs/connections/destinations/catalog/userleap/). Both of these destinations receive data from Segment.
 
 <!-- In the section below, explain the value of this actions-based destination over the classic version, if applicable. If you don't have a classic version of the destination, remove this section. -->
 
@@ -42,8 +42,6 @@ Sprig (Actions) provides the following benefits over the classic Sprig destinati
 
 <!-- The line below renders a table of connection settings (if applicable), Pre-built Mappings, and available actions. -->
 
-{% include components/actions-fields.html name="sprig-web" connection="true" %}
-
 ## Pre-built subscriptions
 
 By default, a new Sprig (Actions) destination comes with the following subscriptions.
@@ -66,14 +64,10 @@ Combine the supported [triggers](/docs/connections/destinations/actions/#compone
 - [Track Event](#track-event)
 - [Update User ID](#update-user-id)
 
-{% include components/actions-fields.html name="sprig-web" %}
-
 <!-- If applicable, add information regarding the migration from a classic destination to an Actions-based version below -->
 
 ## Migration from the classic Sprig destination
 
-To prevent duplicate events from being tracked, please disable your existing Sprig destination when you enable Sprig (Actions).
+To prevent duplicate events being created in Sprig, ensure that for each Segment source, this destination and the Sprig Cloud destination are not both enabled at the same time.
 
-Follow the table below to map your existing Sprig destination configuration to Sprig (Actions).
 
-{% include components/actions-map-table.html name="sprig" %}

--- a/src/connections/destinations/catalog/userleap/index.md
+++ b/src/connections/destinations/catalog/userleap/index.md
@@ -1,63 +1,20 @@
 ---
-title: UserLeap
+title: Sprig Cloud Destination
 rewrite: true
 ---
 
-[UserLeap](https://userleap.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners) is a microsurvey platform that continuously identifies opportunities to build better experiences. Gain clarity into customer needs and grow faster.
+[Sprig (formerly UserLeap)](https://sprig.com/?&utm_source=segment_2021-10-20&utm_medium=int&utm_campaign=integration) is an in-context user research platform that makes it fast and effortless for product teams to learn from their actual customers in real time, through microsurveys, concept tests, and video questions.
 
-This destination is maintained by UserLeap. For any issues with the destination, contact [the UserLeap support team](mailto:support@userleap.com).
+Sprig maintains this destination. For any issues with the destination, consult [Sprig's documentation](https://docs.sprig.com/docs/segment) or contact [support@sprig.com](mailto:support@sprig.com).
 
+> success ""
+> **Good to know**: This page is about the [non-Actions Sprig (formerly UserLeap) destination](/docs/connections/destinations/catalog/userleap/). There's also a page about the [Actions-framework](/docs/connections/destinations/actions/) Sprig Segment destination. Both of these destinations receive data from Segment.
 ## Getting Started
 
 {% include content/connection-modes.md %}
 
 1. From the Destinations catalog page in the Segment App, click **Add Destination**.
-2. Search for "UserLeap" in the Destinations Catalog, and select the UserLeap destination.
-3. Choose which Source should send data to the UserLeap destination.
-4. Go to the [UserLeap dashboard](https://app.userleap.com/settings/installation), find and copy the **API key**.
-5. Enter the UserLeap API Key that you copied in the UserLeap destination settings in Segment.
-
-**Note**: UserLeap's Segment integration does not support In-Product Surveys
-
-## Identify
-If you aren't familiar with the Segment Spec, take a look at the [Identify method documentation](/docs/connections/spec/identify/) to learn about what it does. An example call would look like:
-
-```js
-analytics.identify('userId123', {
-  firstName: 'Laura',
-  lastName: 'Gibbon'
-})
-```
-
-Use Segment's Identify method to identify your users in UserLeap. Segment `traits` map to UserLeap `attributes`.
-
-**Important:** Only Identify calls can create new users in UserLeap.
-
-## Track
-If you aren't familiar with the Segment Spec, take a look at the [Track method documentation](/docs/connections/spec/track/) to learn about what it does. An example call would look like:
-
-```js
-analytics.track('Button Clicked');
-```
-
-Use Track calls to track events and use them as filtering criteria for your Surveys.
-
-Create Triggered Events in your UserLeap [Events dashboard](https://app.userleap.com/events) and map them to your Segment Track event names before you start sending Segment data to UserLeap.
-
-## Page
-If you aren't familiar with the Segment Spec, take a look at the [Page method documentation](/docs/connections/spec/page/) to learn about what it does. An example call would look like:
-
-```js
-analytics.page()
-```
-
-Segment sends Page calls to UserLeap as a `pageview` which you can use as filtering criteria for your surveys.
-
-Add Page URLs  in your UserLeap [Events dashboard](https://app.userleap.com/events) and map them to your Segment Page call's `properties.url` field before you start sending Segment data to UserLeap.
-
-## Alias
-If you aren't familiar with the Segment Spec, take a look at the [Alias method documentation](/docs/connections/spec/alias/) to learn about what it does. An example call would look like:
-
-```js
-analytics.alias('newUserId');
-```
+2. Search for "Sprig Cloud" in the Destinations Catalog, and select the Sprig Cloud destination.
+3. Choose which Source should send data to the Sprig Cloud destination.
+4. Go to the [Sprig Connect page](https://app.sprig.com/connect), and find and copy the Segment **API key**. Use the Development key for a testing environment, and the Production key for your live environment.
+5. Enter the API Key that you copied in the Sprig Cloud destination settings in Segment.


### PR DESCRIPTION
- Would love to rename the **UserLeap** integration to **Sprig Cloud** now that our company has been renamed, and with "Cloud" to differentiate it from the Sprig (Actions) destination, which is device-mode only (Web only at the moment).
- I would also love to update the destination catalog page, with this content: [Segment Catalog Template - Google Docs](https://docs.google.com/document/d/1uODLxWfup6XKYSrrciiiUhgqlFEKPaTQ-09Rp_ymD04/edit). This document also links to updated screenshots and logo. -- I can open a help ticket for that change if that would be helpful.

### Proposed changes

-- rename userleap integration, update documentation and remove outdated/redundant explanations
-- minor cleanup on the Sprig (Actions) documentation

### Merge timing
- ASAP once approved

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
