### PR TITLE
DOC-403 Adding admonition to Google Universal Analytics docs

### DIFF
--- a/src/connections/destinations/catalog/google-analytics/index.md
+++ b/src/connections/destinations/catalog/google-analytics/index.md
@@ -552,7 +552,7 @@ To use server-side Google Universal Analytics, there are three options with Segm
 Universal Analytics (analytics.js) uses the [`clientId`](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage#analyticsjs) to keep track of unique visitors.
 
 > info " "
-> When you add `Google Universal Analytics` to the `integrations` object, it appears in the Segment debugger as `Google Analytics`. 
+> When you add `Google Universal Analytics` to the `integrations` object, the Google Universal Analytics event appears in the Segment debugger as `Google Analytics`. 
 
 *A Google Analytics Universal cookie will look like this:*
 ```

--- a/src/connections/destinations/catalog/google-analytics/index.md
+++ b/src/connections/destinations/catalog/google-analytics/index.md
@@ -551,6 +551,9 @@ To use server-side Google Universal Analytics, there are three options with Segm
 
 Universal Analytics (analytics.js) uses the [`clientId`](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage#analyticsjs) to keep track of unique visitors.
 
+> info " "
+> When you add `Google Universal Analytics` to the `integrations` object, it appears in the Segment debugger as `Google Analytics`. 
+
 *A Google Analytics Universal cookie will look like this:*
 ```
 _ga=GA1.2.1033501218.1368477899;
@@ -558,7 +561,7 @@ _ga=GA1.2.1033501218.1368477899;
 
 The `clientId` is this part: `1033501218.1368477899`
 
-You can double check that it's your `clientId` by running this script in your javascript console:
+You can double check that it's your `clientId` by running this script in your Javascript console:
 
 ```javascript
 ga(function (tracker) {

--- a/src/connections/destinations/catalog/google-analytics/index.md
+++ b/src/connections/destinations/catalog/google-analytics/index.md
@@ -549,10 +549,11 @@ To use server-side Google Universal Analytics, there are three options with Segm
 
 ### Passing Cookies from Universal Analytics
 
-Universal Analytics (analytics.js) uses the [`clientId`](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage#analyticsjs) to keep track of unique visitors.
-
 > info " "
 > When you add `Google Universal Analytics` to the `integrations` object, the Google Universal Analytics event appears in the Segment debugger as `Google Analytics`. 
+
+Universal Analytics (analytics.js) uses the [`clientId`](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage#analyticsjs) to keep track of unique visitors.
+
 
 *A Google Analytics Universal cookie will look like this:*
 ```

--- a/src/connections/destinations/catalog/google-analytics/index.md
+++ b/src/connections/destinations/catalog/google-analytics/index.md
@@ -561,7 +561,7 @@ _ga=GA1.2.1033501218.1368477899;
 
 The `clientId` is this part: `1033501218.1368477899`
 
-You can double check that it's your `clientId` by running this script in your Javascript console:
+You can double check that it's your `clientId` by running this script in your JavaScript console:
 
 ```javascript
 ga(function (tracker) {


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Added admonition to the Google Universal Analytics documentation explaining that when you add `Google Universal Analytics` to the `integrations` object, the Google Universal Analytics event appears in the Segment debugger as `Google Analytics`.

### Merge timing

ASAP

### Related issues (optional)

[DOC-403](https://segment.atlassian.net/browse/DOC-403)
