### PR TITLE
fix(ShareASale): Corrects subtotal documentation

### DIFF
--- a/src/_data/catalog/destinations.yml
+++ b/src/_data/catalog/destinations.yml
@@ -27320,7 +27320,7 @@ items:
     type: boolean
     defaultValue: false
     description: >-
-      By default, we set the `amount` as the subtotal without the discount, but
+      By default, we set the `amount` as the subtotal (equal to the order total after discounts but before taxes and shipping), but
       this might cause problems for sources like Shopify. If you need to provide
       the amount in the total property directly, enable this setting.
     required: false

--- a/src/_data/catalog/destinations_capi.yml
+++ b/src/_data/catalog/destinations_capi.yml
@@ -21858,7 +21858,7 @@ items:
     deprecated: false
     required: false
     description: >-
-      By default, we set the `amount` as the subtotal without the discount, but
+      By default, we set the `amount` as the subtotal (equal to the order total after discounts but before taxes and shipping), but
       this might cause problems for sources like Shopify. If you need to provide
       the amount in the total property directly, enable this setting.
     settings: []


### PR DESCRIPTION
### Proposed changes

Corrects the Share a Sale subtotal documentation to match with the fix in this PR: https://github.com/segmentio/analytics.js-integrations/pull/654

### Merge timing

This should be merged once the fix in the above PR is merged.

### Related issues (optional)

https://github.com/segmentio/analytics.js-integrations/pull/654