### PR TITLE
Remove outdated section in Salesforce docs

### DIFF
--- a/src/connections/destinations/catalog/salesforce/index.md
+++ b/src/connections/destinations/catalog/salesforce/index.md
@@ -170,13 +170,6 @@ In this example, creating or updating a Contact in Salesforce based on whether o
 
 ## Troubleshooting
 
-### Creating Other Resources
-
-To reduce the complexity of the API, the Salesforce destination intentionally only supports creating leads using the `identify` call.
-
-To create resources of other types, such as Accounts or custom objects, Segment recommends that you integrate with Salesforce directly
-
-
 ### Sandbox Mode
 
 To enable an integration with a Salesforce Sandbox instance:


### PR DESCRIPTION
### Proposed changes
There is a section in the Troubleshooting part of our Salesforce docs that is outdated so I am removing it.

### Merge timing
- ASAP once approved


### Related issues (optional)
https://segment.slack.com/archives/CC97A542H/p1643067285057300
