### PR TITLE
remove salesforce DMP from salesforce list

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -80,8 +80,8 @@ sections:
   #   title: Salesforce Live Agent destination
   - path: /connections/destinations/catalog/salesforce-marketing-cloud
     title: Salesforce Marketing Cloud destination
-  - path: /connections/destinations/catalog/salesforce-dmp
-    title: Salesforce DMP destination (beta)
+  # - path: /connections/destinations/catalog/salesforce-dmp
+  #   title: Salesforce DMP destination (beta)
   - path: /connections/destinations/catalog/pardot
     title: Salesforce Pardot destination
   - path: /connections/sources/catalog/cloud-apps/salesforce

--- a/src/connections/destinations/catalog/salesforce-dmp/index.md
+++ b/src/connections/destinations/catalog/salesforce-dmp/index.md
@@ -1,6 +1,5 @@
 ---
 title: Salesforce DMP Destination
-strat: salesforce
 rewrite: true
 beta: true
 hidden: true


### PR DESCRIPTION
### Proposed changes
Salesforce DMP is in private beta, and was built 4+ years ago for Fox specifically. No customers should be using this destination, and StratConn is investigating deprecating it. In the meantime, I would like to remove it from the Salesforce nav in our docs, so customers cannot find the doc. It is already hidden but is still appear in the left-hand column:

![Screen Shot 2022-02-03 at 1 17 50 PM](https://user-images.githubusercontent.com/49517136/152430329-42ccec72-a3ff-407b-b962-ca95ea174413.png)

I think this is because the strat = salesforce. If there's another reason it is still appearing, please update this PR to remove that. I don't see it when I'm searching so I think it is unindexed already.

### Merge timing
- ASAP once approved

### Related issues (optional)

