### PR TITLE
Update DC floodlight note on other field mapping

### DIFF
--- a/src/connections/destinations/catalog/doubleclick-floodlight/index.md
+++ b/src/connections/destinations/catalog/doubleclick-floodlight/index.md
@@ -53,7 +53,7 @@ https://ad.doubleclick.net/ddm/activity/src=1234567;cat=fghij456;type=abcde123;d
 
 ### Accessing Other Event Properties
 
-By default, the Segment event property you define for each custom variable mapping will be matched against the property values found in the `properties` object of a `track` event. You can, however, use JSON style dot-notation-accessors wrapped in double curly brackets to map to **any** property in the event's raw payload to your custom variables. For example, some acceptable values could be `context.campaign.name`, `context.userAgent`, or `anonymousId` (inside of the double curly brackets). You can find the complete structure of a standard Segment event payload [here](/docs/connections/spec/common/#structure).
+By default, the Segment event property you define for each custom variable mapping will be matched against the property values found in the `properties` object of a `track` event. On device-mode web, you can use JSON style dot-notation-accessors wrapped in double curly brackets to map to other fields in the event's raw payload to your custom variables. For example, some acceptable values could be `{{userId}}`, `{{anonymousId}}`, or `{{context.page.referrer}}`. You can find the complete structure of a standard Segment event payload [here](/docs/connections/spec/common/#structure). Please note that some fields may not be available for mapping, such as fields within the `context.campaign` object.
 
 **Note:** `dc_rdid` and `dc_lat` are automatically collected by our mobile libraries and `ord` is uniquely generated for each event.
 


### PR DESCRIPTION
### Proposed changes
Updating section on accessing other event properties to clarify that this only works for device-mode web. We also have to say that certain fields can't be accessed (due to the nature of client-side libraries and when fields are available).

### Merge timing
- ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/STRATCONN-1082
https://segment.atlassian.net/browse/STRATCONN-637
