### PR TITLE
Update sample code in IDFA tracking section

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/index.md
@@ -763,7 +763,7 @@ configuration.enableAdvertisingTracking = true
 // Set the block to be called when the advertisingID is needed
 // NOTE: In iOS 14, you'll need to manually do authorization elsewhere and only when it has been authorized, return the advertisingIdentifier to segment via the block below
 configuration.adSupportBlock = { () -> String in
-    return ASIdentifierManager.shared().advertisingIdentifier
+    return ASIdentifierManager.shared().advertisingIdentifier.uuidString
 }
 
 Analytics.setup(with: configuration)


### PR DESCRIPTION
### Proposed changes
Need to return `uuidstring` for `adSupportBlock` as it is looking for `String` and not `UUID` type.