### PR TITLE
Remove line about Facebook support

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/facebook-lead-ads/index.md
+++ b/src/connections/sources/catalog/cloud-apps/facebook-lead-ads/index.md
@@ -132,5 +132,3 @@ Destinations that can be used with the Facebook Lead Ads Source:
 - Madkudu
 
 Log into your downstream tools and check that your events are populating, and contain all of the properties you expect. If all your events and properties are not showing up, refer to the [Destination docs](https://segment.com/docs/connections/destinations/) for troubleshooting.
-
-If you experience any issues with how the events arrive in Segment, [contact the Facebook team](https://www.facebook.com/business/resources).


### PR DESCRIPTION
### Proposed changes
Stratconn owns FB Lead Ads so we should not direct customers to FB if they have issues.

### Merge timing
- ASAP once approved

