### PR TITLE
Update Order Completed event mapping

### DIFF
--- a/src/connections/destinations/catalog/firebase/index.md
+++ b/src/connections/destinations/catalog/firebase/index.md
@@ -212,7 +212,7 @@ Segment adheres to Firebase's semantic event specification and maps the followin
 | [Checkout Started](/docs/connections/spec/ecommerce/v2/#checkout-started) | begin_checkout |
 | [Promotion Viewed](/docs/connections/spec/ecommerce/v2/#promotion-viewed) | present_offer |
 | [Payment Info Entered](/docs/connections/spec/ecommerce/v2/#payment-info-entered) | add_payment_info |
-| [Order Completed](/docs/connections/spec/ecommerce/v2/#order-completed) | ecommerce_purchase |
+| [Order Completed](/docs/connections/spec/ecommerce/v2/#order-completed) | purchase |
 | [Order Refunded](/docs/connections/spec/ecommerce/v2/#order-refunded) | purchase_refund |
 
 ### Property Mappings


### PR DESCRIPTION
From looking at the source code here:

- iOS: https://github.com/segment-integrations/analytics-ios-integration-firebase/blob/b859d556db2403aa8c459485dac7e5a01a61dab0/Segment-Firebase/Classes/SEGFirebaseIntegration.m#L123
- Android: https://github.com/segment-integrations/analytics-android-integration-firebase/blob/253f630653c5635bb8a747f191a2a7c42bb4a1a6/src/main/java/com/segment/analytics/android/integrations/firebase/FirebaseIntegration.java#L76

"Order Completed" is no longer mapped to the deprecated "ecommerce_purchase" but rather to "purchase"