### PR TITLE
fix(content): clarify marketo static list sync details

### DIFF
--- a/src/connections/destinations/catalog/marketo-static-lists/index.md
+++ b/src/connections/destinations/catalog/marketo-static-lists/index.md
@@ -47,7 +47,7 @@ Every time you create an audience in Personas and connect it to Marketo Static L
 1. Creates a list with the same name as the Personas audience in the folder designated for Personas.
 2. Adds any users to that list who both fit the audience definition and have an email address.
 3. If a user has multiple email addresses on their identity graph, each email address becomes a unique entry on the list.
-4. After the audience is configured, Segment checks which users still fit the audience definition, and adds or removes users from the audience, once every hour.
+4. After the audience is configured, Segment checks which users still fit the audience definition, and adds or removes users from the audience.
 {% include content/sync-frequency-note.md %}
 
 ## Configuring Marketo Static Lists


### PR DESCRIPTION
### Proposed changes
- [Clarifications based on Slack thread with Personas team](https://segment.slack.com/archives/C7F3N3RV4/p1645832290653749?thread_ts=1643117377.166500&cid=C7F3N3RV4)
- removed "once every hour" which is inaccurate (2-3 hours is expected)
- add clarification about sync frequency vs. initial sync

### Merge timing
- ASAP once approved?
