### PR TITLE
Add note on track category used for UA

### DIFF
--- a/src/connections/destinations/catalog/google-analytics/index.md
+++ b/src/connections/destinations/catalog/google-analytics/index.md
@@ -196,7 +196,7 @@ For this example these event attributes are sent to Google Universal Analytics:
 | **Event Action**   | Logged In |
 
 > info ""
-> **Note**: In device-mode only, if you pass `category` to the [`page`](https://segment.com/docs/connections/destinations/catalog/google-analytics/#page-and-screen) call, we will use the `category` from `page` instead of setting default **Event Category** to `All`.
+> **Note**: In device-mode only, if you pass `category` to the [`page`](https://segment.com/docs/connections/destinations/catalog/google-analytics/#page-and-screen) call, Segment will use the `category` from `page` instead of setting default **Event Category** to `All`.
 
 And another Track call example, this time with all Google Universal Analytics event parameters:
 

--- a/src/connections/destinations/catalog/google-analytics/index.md
+++ b/src/connections/destinations/catalog/google-analytics/index.md
@@ -195,6 +195,8 @@ For this example these event attributes are sent to Google Universal Analytics:
 | **Event Category** | All       |
 | **Event Action**   | Logged In |
 
+> info ""
+> **Note**: In device-mode only, if you pass `category` to the [`page`](https://segment.com/docs/connections/destinations/catalog/google-analytics/#page-and-screen) call, we will use the `category` from `page` instead of setting default **Event Category** to `All`.
 
 And another Track call example, this time with all Google Universal Analytics event parameters:
 

--- a/src/connections/destinations/catalog/google-analytics/index.md
+++ b/src/connections/destinations/catalog/google-analytics/index.md
@@ -196,7 +196,7 @@ For this example these event attributes are sent to Google Universal Analytics:
 | **Event Action**   | Logged In |
 
 > info ""
-> **Note**: In device-mode only, if you pass `category` to the [`page`](https://segment.com/docs/connections/destinations/catalog/google-analytics/#page-and-screen) call, Segment will use the `category` from `page` instead of setting default **Event Category** to `All`.
+> **Note**: In device-mode only, if you pass `category` to the [`page`](/docs/connections/destinations/catalog/google-analytics/#page-and-screen) call, Segment will use the `category` from `page` instead of setting default **Event Category** to `All`.
 
 And another Track call example, this time with all Google Universal Analytics event parameters:
 


### PR DESCRIPTION
### Proposed changes
Adds a note about the device-mode logic for setting category to track calls for Google Analytics UA.

This note is required because there is no parity between device-mode and cloud-mode on this logic.

**[Device mode](https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/google-analytics/lib/index.js#L313)**: `track.category() || this._category || 'All'`
**[Cloud mode](https://github.com/segmentio/integrations/blob/master/integrations/google-analytics/lib/universal/mapper.js#L100)**: `track.category() || 'All'`

See [slack](https://segment.slack.com/archives/CQ1F92KUG/p1645198986403829) for more info.

### Merge timing
- ASAP once approved?
