### PR TITLE
Describe the required Friendbuy web destination fields.

### DIFF
--- a/src/connections/destinations/catalog/actions-friendbuy/index.md
+++ b/src/connections/destinations/catalog/actions-friendbuy/index.md
@@ -51,7 +51,21 @@ Before you start, you must have Segment's Analytics.js 2.0 installed on your sit
 
 {% include components/actions-fields.html %}
 
-<!-- If applicable, add information regarding the migration from a classic destination to an Actions-based version below -->
+## Required Fields
+
+There are several fields that are required by the Friendbuy actions; these fields are marked by an asterisk in the action's Edit form when you are configuring the action fields. As required fields
+
+* these action fields must be assigned mappings from your analytics events, and
+* the event fields that the action fields are mapped from must be populated with values of the appropriate type in your analytics calls.
+
+If the `analytics.identify` or `analytics.track` event fields are not appropriately populated then the corresponding Friendbuy track call will not be made.
+
+| Track Event        | Required Fields                                   |
+|--------------------|---------------------------------------------------|
+| Track Customer     | `customerId`, `email`                             |
+| Track Purchase     | `orderId`, `amount`, `currency`, `products.price` |
+| Track Sign-Up      | `customerId`, `email`                             |
+| Track Custom Event | `eventType`, `eventProperties`, `customerId`      |
 
 ## Edit Friendbuy mappings
 

--- a/src/connections/destinations/catalog/actions-friendbuy/index.md
+++ b/src/connections/destinations/catalog/actions-friendbuy/index.md
@@ -58,7 +58,7 @@ There are several fields that are required by the Friendbuy actions; these field
 * these action fields must be assigned mappings from your analytics events, and
 * the event fields that the action fields are mapped from must be populated with values of the appropriate type in your analytics calls.
 
-If the `analytics.identify` or `analytics.track` event fields are not appropriately populated then the corresponding Friendbuy track call will not be made.
+If the required event fields are missing or are not appropriately populated in an `analytics.identify` or `analytics.track` call then the corresponding Friendbuy track call will not be made and Friendbuy will not receive the event data for that call.
 
 | Track Event        | Required Fields                                   |
 |--------------------|---------------------------------------------------|
@@ -66,6 +66,8 @@ If the `analytics.identify` or `analytics.track` event fields are not appropriat
 | Track Purchase     | `orderId`, `amount`, `currency`, `products.price` |
 | Track Sign-Up      | `customerId`, `email`                             |
 | Track Custom Event | `eventType`, `eventProperties`, `customerId`      |
+
+When a problem with the event data is detected an error is logged to the browser console.
 
 ## Edit Friendbuy mappings
 


### PR DESCRIPTION
This is a draft request and I will be soliciting Friendbuy feedback before I make it official.

### Proposed changes

Added section describing the required fields for the Friendbuy web destination and the consequence if the required fields are not populated in the analytics calls. We have merchants who are attempting to enable the Friendbuy web destination whose data is not being sent to Friendbuy because they are not populating the required fields.

Currently the list of fields generated by `{% include components/actions-fields.html %}` does not call out the required fields. It would be really cool if it did.

### Merge timing

ASAP once approved
