### PR TITLE
StratConn GA Launch Docs Updates

### DIFF
--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -78,7 +78,7 @@ With the Facebook Conversions API (Actions) destination, you can choose any fiel
 
 ![the coalesce function](images/image1.png)
 
-You can send additional User Data to increase the match rate for events from a server source. Collect other fields from the browser, like User Agent, IP Address, and [Facebook's cookie parameters (fbp, fbc)](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc){:target="_blank"}, pass them to the server, and map them in the User Data object. See [Facebook's Customer Information Parameters](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters) for more information on User Data fields, and [Facebook’s Best Practices for Conversions API](https://www.facebook.com/business/help/308855623839366?id=818859032317965) for match rate best practices.
+You can send additional User Data to increase the match rate for events from a server source. Collect other fields from the browser, like User Agent, IP Address, and [Facebook's cookie parameters (fbp, fbc)](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc){:target="_blank"}, pass them to the server, and map them in the User Data object. See [Facebook's Customer Information Parameters](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters){:target="_blank"} for more information on User Data fields, and [Facebook’s Best Practices for Conversions API](https://www.facebook.com/business/help/308855623839366?id=818859032317965){:target="_blank"} for match rate best practices.
 
 ![the user data object](images/image2.png)
 
@@ -102,7 +102,7 @@ With the Facebook Conversions API (Actions) destination, you can choose any fiel
 
 ![the coalesce function](images/image1.png)
 
-You can send additional User Data to increase the match rate for events from a server source. Collect other fields from the browser, like User Agent, IP Address, and [Facebook's cookie parameters (fbp, fbc)](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc){:target="_blank"}, pass them to the server, and map them in the User Data object. See [Facebook's Customer Information Parameters](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters) for more information on User Data fields, and [Facebook’s Best Practices for Conversions API](https://www.facebook.com/business/help/308855623839366?id=818859032317965) for match rate best practices.
+You can send additional User Data to increase the match rate for events from a server source. Collect other fields from the browser, like User Agent, IP Address, and [Facebook's cookie parameters (fbp, fbc)](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc){:target="_blank"}, pass them to the server, and map them in the User Data object. See [Facebook's Customer Information Parameters](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters){:target="_blank"} for more information on User Data fields, and [Facebook’s Best Practices for Conversions API](https://www.facebook.com/business/help/308855623839366?id=818859032317965){:target="_blank"} for match rate best practices.
 
 ![the user data object](images/image2.png)
 
@@ -149,7 +149,7 @@ If you use Facebook Pixel, the Pixel library also hashes the External ID. This m
 
 ### Server Event Parameter Requirements
 
-Facebook requires the `action_source` server event parameter for all events sent to the Facebook Conversions API. This parameter is used to specify where the conversions occurred. If `action_source` is set to 'website' then the `client_user_agent` and the `event_source_url` parameters are also required. Events sent to the Conversions API that do not meet the requirements may not be available for optimization, targeting, or measurement.
+Facebook requires the `action_source` server event parameter for all events sent to the Facebook Conversions API. This parameter specifies where the conversions occur. If `action_source` is set to **website**, then the `client_user_agent` and the `event_source_url` parameters are also required. Events sent to the Conversions API that don't meet the requirements may not be available for optimization, targeting, or measurement.
 
 ### Verify Events in Facebook
 

--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -7,12 +7,6 @@ hide-dossier: false
 
 Facebook Conversions API (Actions) enables advertisers to send events from their servers directly to Facebook. Server-side events link to Facebook Pixel events, and process like browser pixel events. This means that server-side events are used in measurement, reporting, and optimization, just like browser pixel events.
 
-> info ""
-> This document is about a feature which is in beta. This means that the Facebook Conversions API (Actions) destination is in active development, and some functionality may change before it becomes generally available.
-
-> success ""
-> **Good to know**: This page is about the [Actions-framework](/docs/connections/destinations/actions/) Facebook Conversions API Segment destination. There's also a page about the [non-Actions Facebook Conversions API destination](/docs/connections/destinations/catalog/facebook-pixel-server-side/). Both of these destinations receive data _from_ Segment.
-
 ## Benefits of Facebook Conversions API (Actions) vs Facebook Conversions API Classic
 
 The Facebook Conversions API (Actions) destination provides the following benefits over the classic Facebook Conversions API destination:
@@ -23,6 +17,18 @@ The Facebook Conversions API (Actions) destination provides the following benefi
 - **Support for identify calls**. Identify calls can be sent to Facebook as a standard or custom event.
 - **Support for multi-product arrays**. Product data nested within arrays, like the `products` array in the [Order Completed](/docs/connections/spec/ecommerce/v2/#order-completed) event, can be sent to Facebook.
 - **Data normalization**. Data is normalized before it is hashed to ensure the hashed value matches Facebook Pixel (browser).
+
+## Other Facebook Destinations Supported by Segment
+This page is about the **Facebook Conversions API**. For documentation on other Facebook destinations, see the pages linked below.
+
+| **Facebook Destination**                                                                                    | Supported by Personas |
+| ----------------------------------------------------------------------------------------------------------- | --------------------- |
+| **[Facebook App Events](/docs/connections/destinations/catalog/facebook-app-events/)**                      | Yes                   |
+| **[Facebook Offline Conversions](/docs/connections/destinations/catalog/facebook-offline-conversions/)**    | Yes                   |
+| **[Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/)**                                | No                    |
+| **[Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/)** | Yes                   |
+| **[Facebook Conversions API](/docs/connections/destinations/catalog/actions-facebook-conversions-api/)**    | Yes                   |
+
 
 ## Getting started
 
@@ -55,15 +61,6 @@ Set up your Pixel to work with the Facebook Conversions API (Actions) destinatio
 
 {% include components/actions-fields.html %}
 
-## Server Event Parameter Requirements
-
-Facebook requires the `action_source` server event parameter for all events sent to the Conversions API. This parameter is used to specify where the conversions occurred. If `action_source` is set to 'website' then the `client_user_agent` and the `event_source_url` parameters are also required. Events sent to the Conversions API that do not meet the requirements may not be available for optimization, targeting, or measurement.
-
-| Server Event Parameter | Requirement                                 | Implementation                 p                                                                      |
-| ---------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `action_source`        | Always required                             | It is set automatically but it can be set manually.                                                  |
-| `client_user_agent`    | Only required if `action_source` = "website" | It must be set manually if using a server library. It is set automatically if using the Segment web library. |
-| `event_source_url`     | Only required if `action_source` = "website" | It must be set manually if using a server library. It is set automatically if using the Segment web library. |
 ## Configuration options
 
 The Facebook Conversions API (Actions) destination gives you several ways to implement your conversion tracking. You can use it with [Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/), or as a stand-alone alternative. You can read more about implementation options below and in [Facebook documentation](https://developers.facebook.com/docs/marketing-api/conversions-api/guides/end-to-end-implementation#pick-your-integration-type){:target="_blank"}.
@@ -81,7 +78,7 @@ With the Facebook Conversions API (Actions) destination, you can choose any fiel
 
 ![the coalesce function](images/image1.png)
 
-You can send additional User Data to increase the match rate for events from a server source. Collect other fields from the browser, like User Agent, IP Address, and [Facebook's cookie parameters (fbp, fbc)](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc){:target="_blank"}, pass them to the server, and map them in the User Data object. See [Facebook's Customer Information Parameters](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters) for more information on User Data fields.
+You can send additional User Data to increase the match rate for events from a server source. Collect other fields from the browser, like User Agent, IP Address, and [Facebook's cookie parameters (fbp, fbc)](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc){:target="_blank"}, pass them to the server, and map them in the User Data object. See [Facebook's Customer Information Parameters](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters) for more information on User Data fields, and [Facebook’s Best Practices for Conversions API](https://www.facebook.com/business/help/308855623839366?id=818859032317965) for match rate best practices.
 
 ![the user data object](images/image2.png)
 
@@ -105,7 +102,7 @@ With the Facebook Conversions API (Actions) destination, you can choose any fiel
 
 ![the coalesce function](images/image1.png)
 
-You can send additional User Data to increase the match rate for events from a server source. Collect other fields from the browser, like User Agent, IP Address, and [Facebook's cookie parameters (fbp, fbc)](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc){:target="_blank"}, pass them to the server, and map them in the User Data object. See [Facebook's Customer Information Parameters](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters) for more information on User Data fields.
+You can send additional User Data to increase the match rate for events from a server source. Collect other fields from the browser, like User Agent, IP Address, and [Facebook's cookie parameters (fbp, fbc)](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/fbp-and-fbc){:target="_blank"}, pass them to the server, and map them in the User Data object. See [Facebook's Customer Information Parameters](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters) for more information on User Data fields, and [Facebook’s Best Practices for Conversions API](https://www.facebook.com/business/help/308855623839366?id=818859032317965) for match rate best practices.
 
 ![the user data object](images/image2.png)
 
@@ -135,7 +132,7 @@ If you want to send a [Facebook standard event](https://developers.facebook.com/
 
 ### PII Hashing
 
-Segment creates a SHA-256 hash of the following fields:
+Segment creates a SHA-256 hash of the following fields before sending to Facebook:
 - External ID
 - Email
 - Phone
@@ -149,6 +146,10 @@ Segment creates a SHA-256 hash of the following fields:
 - Country
 
 If you use Facebook Pixel, the Pixel library also hashes the External ID. This means External IDs will match across Facebook Pixel and Facebook Conversions API if they use the External ID for [deduplication](https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events/#fbp-or-external-id){:target="_blank"}.
+
+### Server Event Parameter Requirements
+
+Facebook requires the `action_source` server event parameter for all events sent to the Facebook Conversions API. This parameter is used to specify where the conversions occurred. If `action_source` is set to 'website' then the `client_user_agent` and the `event_source_url` parameters are also required. Events sent to the Conversions API that do not meet the requirements may not be available for optimization, targeting, or measurement.
 
 ### Verify Events in Facebook
 

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -9,10 +9,6 @@ hide-dossier: false
 
 When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. Segment will send your data server-side to [Google's Measurement Protocol API](https://developers.google.com/analytics/devguides/collection/protocol/ga4).
 
-> info ""
-> This document is about a feature which is in beta. This means that the Destination Actions are in active development, and some functionality may change before it becomes generally available
-
-
 > success ""
 > **Good to know**: This page is about the [Actions-framework](/docs/connections/destinations/actions/) Google Analytics 4 destination. There's also a page about the [non-Actions Google Universal Analytics destination](/docs/connections/destinations/catalog/google-analytics/). Both of these destinations receive data _from_ Segment.
 

--- a/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
@@ -25,7 +25,7 @@ The Google Enhanced Conversions destination enables you to improve the accuracy 
 7. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
 > info
-> The Conversion ID is a global setting because it is an account-level ID that is the same for all conversion actions in your Google Ads account. The Conversion Label is unique to each conversion action, and is therefore configured per Mapping.
+> The Conversion ID is a global setting because it's an account-level ID that's the same for all conversion actions in your Google Ads account. The Conversion Label is unique to each conversion action and is therefore configured per Mapping.
 
 {% include components/actions-fields.html content1=conv_label section1="postConversion" content2=test_mapping section2="postConversion" %}
 

--- a/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
@@ -5,18 +5,12 @@ hide-boilerplate: true
 hide-dossier: false
 ---
 
-> info ""
-> This document is about a feature that is in beta. This means that the destination is in active development, and some functionality may change before it becomes generally available.
-
-> success ""
-> **Good to know**: This page is about the [Actions-framework](/docs/connections/destinations/actions/) Google Enhanced Conversions Segment destination. 
-
 The Google Enhanced Conversions destination enables you to improve the accuracy of your conversion measurement. You can supplement existing conversion tags by sending first-party customer conversion data from your website, such as email address, to Google Ads. Segment hashes this data and sends it in a privacy-safe way. Google matches hashed data with signed-in Google accounts to attribute the conversion to ad events, such as clicks or views. To learn more about Google Enhanced Conversions, see Google's documentation [About enhanced conversions](https://support.google.com/google-ads/answer/9888656?hl=en-GB){:target="_blank"}.
 
 > warning "Before you begin"
 > Enable Enhanced Conversions in your Google Ads account. For each Conversion, specify in the settings that you will use the Enhanced Conversions API:
 > 1.  When you log in to Google Ads, make sure you are in [Expert Mode](https://support.google.com/google-ads/answer/9520605?hl=en){:target="_blank"}.
-> 2. Click **Tools & Settings** in the top bar, and select **Conversions** from the dropdown. Select the **Conversion Action** you want Segment to log to.
+> 2. Click **Tools & Settings** in the top bar, and select **Conversions** from the dropdown. Select the website **Conversion Action** you want Segment to log to.
 > 3. Expand the tab for **Enhanced conversions**. Enable **Turn on enhanced conversions**. Under "To start, select how you want to set up enhanced conversions", select **API**.
 > 
 > When you authenticate your Segment workspace with your Google Account, use a Google Account that is a member of your Google Ads account.
@@ -26,52 +20,12 @@ The Google Enhanced Conversions destination enables you to improve the accuracy 
 2. Search for “Google Enhanced Conversions” in the Destinations Catalog, and select the destination.
 3. Click **Configure Google Enhanced Conversions** in the top-right corner of the screen.
 4. Select the source that will send data to Google Enhanced Conversions and follow the steps to name your destination.
-5. On the **Settings** tab, enter the Conversion ID and click **Save**. Find the Conversion ID in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en){:target="_blank"}. When you log in to Google Ads, enable [Expert Mode](https://support.google.com/google-ads/answer/9520605?hl=en){:target="_blank"}. You'll follow these same instructions to get the Conversion Label, which you'll need when you set up your first Mapping, below.
+5. On the **Settings** tab, enter the Conversion ID and click **Save**. Find the Conversion ID in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en){:target="_blank"}. You'll follow these same instructions to get the Conversion Label, which you'll need when you set up your first Mapping.
 6. On the **Settings** tab, authenticate with Google using OAuth. Click **Connect to Google Enhanced Conversions**. Follow the prompts to authenticate using OAuth, with a Google login that is a member of the Google Ads account with Enhanced Conversions enabled.
 7. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
-
-{% capture conv_label %}
-#### Find the Conversions Label
-Enter the Conversion Label. Find the Conversion Label using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en){:target="_blank"}.
-{% endcapture %}
-
-{% capture test_mapping %}
-#### Test the Mapping
-To test your mapping:
-1. Expand the **Test event trigger** section. Segment searches for recent events that match the trigger conditions. If there are no recent events that match the criteria, click **manually enter an event**, and replace the default event data with the following:
-```json
-{
-  "messageId": "segment-test-message-hkz2b",
-  "timestamp": "2021-08-27T17:32:12.781Z",
-  "context" : {
-    "userAgent": "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1"
-  },
-  "type": "track",
-  "properties": {
-    "email": "test@example.org",
-    "orderId": "123",
-    "firstName": "Bob John",
-    "lastName": "Smith",
-    "phone": "14150000000",
-    "address": {
-      "street": "123 Market Street",
-      "city": "San Francisco",
-      "state": "CA",
-      "postalCode": "94000",
-      "country": "USA"
-    }
-  },
-  "userId": "test-user-j75yud",
-  "event": "Order Completed"
-}
-```
-8. Click **Test Event**.
-9. Scroll down and expand the **Send a test event** section, and click **Test Action**.
-10. The section displays the test result and the payload that Google Enhanced Conversions returns to Segment.
-11. Click **Save**.
-12. Enable the Mapping with the toggle under the **Status** column.
-{% endcapture %}
+> info
+> The Conversion ID is a global setting because it is an account-level ID that is the same for all conversion actions in your Google Ads account. The Conversion Label is unique to each conversion action, and is therefore configured per Mapping.
 
 {% include components/actions-fields.html content1=conv_label section1="postConversion" content2=test_mapping section2="postConversion" %}
 

--- a/src/connections/destinations/catalog/facebook-app-events/index.md
+++ b/src/connections/destinations/catalog/facebook-app-events/index.md
@@ -16,8 +16,7 @@ This page is about the **Facebook App Events**. For documentation on other Faceb
 | **[Facebook Offline Conversions](/docs/connections/destinations/catalog/facebook-offline-conversions/)**    | Yes                   |
 | **[Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/)**                                | No                    |
 | **[Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/)** | Yes                   |
-| **Facebook Custom Audiences Website**                                                                       | Yes                   |
-
+| **[Facebook Conversions API](/docs/connections/destinations/catalog/actions-facebook-conversions-api/)**    | Yes                   |
 
 
 ## Getting Started

--- a/src/connections/destinations/catalog/facebook-offline-conversions/index.md
+++ b/src/connections/destinations/catalog/facebook-offline-conversions/index.md
@@ -10,13 +10,13 @@ strat: facebook
 ## Other Facebook Destinations Supported by Segment
 This page is about the **Facebook Offline Conversions**. For documentation on other Facebook destinations, see the pages linked below.
 
-| **Facebook Destination**   | Supported by Personas |
-| ---------------------- | --------------------- |
-| **[Facebook App Events](/docs/connections/destinations/catalog/facebook-app-events/)**                  | Yes                   |
-| **[Facebook Offline Conversions](/docs/connections/destinations/catalog/facebook-offline-conversions/)** | Yes                   |
-| **[Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/)**                             | No                    |
-| **[Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/)**      | Yes                   |
-| **Facebook Custom Audiences Website**    | Yes                   |
+| **Facebook Destination**                                                                                    | Supported by Personas |
+| ----------------------------------------------------------------------------------------------------------- | --------------------- |
+| **[Facebook App Events](/docs/connections/destinations/catalog/facebook-app-events/)**                      | Yes                   |
+| **[Facebook Offline Conversions](/docs/connections/destinations/catalog/facebook-offline-conversions/)**    | Yes                   |
+| **[Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/)**                                | No                    |
+| **[Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/)** | Yes                   |
+| **[Facebook Conversions API](/docs/connections/destinations/catalog/actions-facebook-conversions-api/)**    | Yes                   |
 
 
 ## Getting Started

--- a/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
@@ -1,8 +1,8 @@
 ---
 title: Facebook Conversions API destination
 rewrite: true
+maintenance: true
 beta: true
-strat: facebook
 redirect_from: '/connections/destinations/catalog/facebook-conversions-api/'
 hide-dossier: true
 ---
@@ -11,11 +11,8 @@ hide-dossier: true
 
 [Facebook Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api) allows advertisers to send events from their servers directly to Facebook. Server-Side events are linked to a pixel and are processed like browser pixel events. This means that Server-Side events are used in measurement, reporting, and optimization in the same way as browser pixel events.
 
-> warning "Server Event Parameter Requirements"
+> info "Server Event Parameter Requirements"
 > On February 15th 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that do not meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements)
-
-> success ""
-> **Good to know**: This page is about the classic Facebook Conversions API Segment destination. There's also a page about the new [Facebook Conversions API (Actions) destination](/docs/connections/destinations/catalog/actions-facebook-conversions-api/). Both of these destinations are in Public Beta and receive data _from_ Segment. Segment recommends the new Facebook Conversions API (Actions) destination for additional functionality and flexibility.
 
 > info "Destination name change"
 > Facebook Conversions API was renamed from Facebook Pixel Server-Side.

--- a/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
@@ -12,7 +12,7 @@ hide-dossier: true
 [Facebook Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api) allows advertisers to send events from their servers directly to Facebook. Server-Side events are linked to a pixel and are processed like browser pixel events. This means that Server-Side events are used in measurement, reporting, and optimization in the same way as browser pixel events.
 
 > info "Server Event Parameter Requirements"
-> On February 15th 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that do not meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements)
+> On February 15th, 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that do not meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements)
 
 > info "Destination name change"
 > Facebook Conversions API was renamed from Facebook Pixel Server-Side.

--- a/src/connections/destinations/catalog/facebook-pixel/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel/index.md
@@ -19,13 +19,13 @@ strat: facebook
 ## Other Facebook Destinations Supported by Segment
 This page is about the **Facebook Pixel**. For documentation on other Facebook destinations, see the pages linked below.
 
-| **Facebook Destination**   | Supported by Personas |
-| ---------------------- | --------------------- |
-| **[Facebook App Events](/docs/connections/destinations/catalog/facebook-app-events/)**                  | Yes                   |
-| **[Facebook Offline Conversions](/docs/connections/destinations/catalog/facebook-offline-conversions/)** | Yes                   |
-| **[Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/)**                             | No                    |
-| **[Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/)**      | Yes                   |
-| **Facebook Custom Audiences Website**    | Yes                   |
+| **Facebook Destination**                                                                                    | Supported by Personas |
+| ----------------------------------------------------------------------------------------------------------- | --------------------- |
+| **[Facebook App Events](/docs/connections/destinations/catalog/facebook-app-events/)**                      | Yes                   |
+| **[Facebook Offline Conversions](/docs/connections/destinations/catalog/facebook-offline-conversions/)**    | Yes                   |
+| **[Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/)**                                | No                    |
+| **[Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/)** | Yes                   |
+| **[Facebook Conversions API](/docs/connections/destinations/catalog/actions-facebook-conversions-api/)**    | Yes                   |
 
 
 ## Getting Started

--- a/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
+++ b/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
@@ -22,13 +22,13 @@ This allows you to run advertising campaigns in Facebook without having to manua
 ## Other Facebook Destinations Supported by Segment
 This page is about the **Facebook Custom Audiences** destination developed specifically for use with **Segment Personas**. For documentation on other Facebook destinations, see the pages linked below.
 
-| **Facebook Destination**   | Supported by Personas |
-| ---------------------- | --------------------- |
-| **[Facebook App Events](/docs/connections/destinations/catalog/facebook-app-events/)**                  | Yes                   |
-| **[Facebook Offline Conversions](/docs/connections/destinations/catalog/facebook-offline-conversions/)** | Yes                   |
-| **[Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/)**                             | No                    |
-| **[Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/)**      | Yes                   |
-
+| **Facebook Destination**                                                                                    | Supported by Personas |
+| ----------------------------------------------------------------------------------------------------------- | --------------------- |
+| **[Facebook App Events](/docs/connections/destinations/catalog/facebook-app-events/)**                      | Yes                   |
+| **[Facebook Offline Conversions](/docs/connections/destinations/catalog/facebook-offline-conversions/)**    | Yes                   |
+| **[Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/)**                                | No                    |
+| **[Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/)** | Yes                   |
+| **[Facebook Conversions API](/docs/connections/destinations/catalog/actions-facebook-conversions-api/)**    | Yes                   |
 
 ## Details
 

--- a/src/connections/destinations/catalog/tiktok-conversions/index.md
+++ b/src/connections/destinations/catalog/tiktok-conversions/index.md
@@ -6,7 +6,7 @@ hide-dossier: true
 
 {% include content/plan-grid.md name="actions" %}
 
-The TikTok Conversions Destination enables advertisers to send Segment events to directly to TikTok. Data shared can power TikTok solutions like dynamic product ads, custom targeting, campaign optimization and attribution. Advertisers will be able to see their event data in TikTok Events Manager.
+The TikTok Conversions Destination enables advertisers to send Segment events directly to TikTok. Data shared can power TikTok solutions like dynamic product ads, custom targeting, campaign optimization and attribution. Advertisers can see their event data in TikTok Events Manager.
 
 ## Benefits of TikTok Conversions
 The TikTok Conversions destination provides the following benefits:

--- a/src/connections/destinations/catalog/tiktok-conversions/index.md
+++ b/src/connections/destinations/catalog/tiktok-conversions/index.md
@@ -6,63 +6,48 @@ hide-dossier: true
 
 {% include content/plan-grid.md name="actions" %}
 
-The TikTok Conversions Destination enables advertisers to send Segment events to report events directly to TikTok. Data shared can power TikTok solutions like dynamic product ads, custom targeting, campaign optimization and attribution.
+The TikTok Conversions Destination enables advertisers to send Segment events to directly to TikTok. Data shared can power TikTok solutions like dynamic product ads, custom targeting, campaign optimization and attribution. Advertisers will be able to see their event data in TikTok Events Manager.
 
-Reporting web events allows advertisers to send user data directly to TikTok for downstream targeting and optimization. Advertisers will be able to see their event data in TikTok Events Manager.
+## Benefits of TikTok Conversions
+The TikTok Conversions destination provides the following benefits:
 
-> info ""
-> This document is about a feature which is in beta. This means that the Destination Actions are in active development, and some functionality may change before it becomes generally available
-
-> success ""
-> **Good to know**: This page is about the [Actions-framework](/docs/connections/destinations/actions/) TikTok Conversions Segment Destination.
-
-## Benefits
-
-1. **Streamlined stability and security**: Integrate and iterate without client-side limitations, like network connectivity or ad blocker issues.
-2. **Configurable privacy controls**: Stay compliant with rapidly evolving requirements with flexible privacy controls that let you adapt what data you share and when you share it.
-3. **Maximum event measurement**: Capture more events with improved accuracy across different browsers, apps and devices to get a unified view of your customer's journey from page view to purchase.
+1. **Clear mapping of data.** Actions-based destinations enable you to define the mapping between the data Segment receives from your source and the data Segment sends to TikTok.
+2. **Prebuilt mappings.** Mappings for TikTok Standard Events, like `PlaceAnOrder`, are prebuilt with the prescribed parameters and available for customization.
+3. **Streamlined stability and security.** Integrate and iterate without client-side limitations, like network connectivity or ad blocker issues.
+4. **Privacy-focused**: Stay compliant with rapidly evolving requirements with automatic PII hashing and flexible controls that let you adapt what data you share.
+5. **Maximum event measurement**: Capture more events with improved accuracy across different browsers, apps and devices to get a unified view of your customer's journey from page view to purchase.
 
 ## Getting started
 
-Follow the instructions below to enable your TikTok ads account, and add the TikTok Conversions Destination to your Segment workspace.
+Follow the instructions below to enable your TikTok ads account, and add the TikTok Conversions destination to your Segment workspace.
 
 ### TikTok Requirements
 
-The TikTok Conversions destination is configured to use the TikTok Events API. To generate the Pixel ID and Access token:
+The TikTok Conversions destination is configured to use the TikTok Events API. To generate a TikTok Access Token and Pixel Code:
 
 1. [Create a TikTok For Business account](https://ads.tiktok.com/marketing_api/docs?id=1702715936951297){:target="_blank"}.
 2. Follow instructions for [Authorization](https://ads.tiktok.com/marketing_api/docs?rid=959icq5stjr&id=1701890979375106){:target="_blank"} and generate a long term access token.
 
-### Configuring TikTok Conversions in Segment
+### Connect TikTok Conversions to your workspace
 
 1. From the Segment web app, click **Catalog**, then click **Destinations**.
-2. Find the Destinations Actions item in the left navigation, and click it.
+2. Search for “TikTok Conversions” in the Destinations Catalog, and select the destination.
 3. Click **Configure TikTok Conversions**.
-4. Select an existing Source to connect to TikTok Conversions.
-5. On the next page enter your TikTok Access Token, and Pixel Code. Click Verify credentials.
-
+4. Select the source that will send data to TikTok Conversions and follow the steps to name your destination.
+5. On the Settings tab, enter in your TikTok Access Token and Pixel Code and click **Save**.
+6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
 {% include components/actions-fields.html %}
 
+## FAQ & Troubleshooting
 
+### Other Standard Events
 
+If you want to send a [TikTok standard event](https://ads.tiktok.com/marketing_api/docs?id=1701890979375106){:target="_blank"} that Segment does not have a prebuilt mapping for, you can use the [Report Web Event action](/docs/connections/destinations/catalog/tiktok-conversions/#report-web-event) to send the standard event. For example, if you want to send a `CompleteRegistration` event, create a mapping for Report Web Event, set up your Event Trigger criteria for completed registrations, and input a literal string of "CompleteRegistration" as the Event Name.
 
+### PII Hashing
 
-## Segment event names to TikTok events
-The table below shows the mapping of the Segment semantic [ecommerce](/docs/connections/spec/ecommerce/v2/) or custom event names to the TikTok semantic conversion event names in the pre-built mappings.
-
-| Segment Event Name   | TikTok Semantic Conversion Event Name |
-| -------------------- | ------------------------------------- |
-| Checkout Started     | InitiateCheckout                      |
-| Products Searched    | Search                                |
-| Payment Info Entered | AddPaymentInfo                        |
-| Order Completed      | PlaceAnOrder                            |
-
-| Segment Event Type         | TikTok Semantic Conversion Event Name |
-| -------------------------- | ------------------------------------- |
-| All **Segment Page Calls** | ViewContent                           |
-
-<!-- The section below provides reference tables for the actions defined in your destination. Create the unordered list. The Segment Docs team will assist with populating the data file referenced by this include. -->
-
-
-
+Segment creates a SHA-256 hash of the following fields before sending to TikTok:
+- External ID
+- Email
+- Phone Number

--- a/src/connections/destinations/catalog/tiktok-conversions/index.md
+++ b/src/connections/destinations/catalog/tiktok-conversions/index.md
@@ -15,7 +15,7 @@ The TikTok Conversions destination provides the following benefits:
 2. **Prebuilt mappings.** Mappings for TikTok Standard Events, like `PlaceAnOrder`, are prebuilt with the prescribed parameters and available for customization.
 3. **Streamlined stability and security.** Integrate and iterate without client-side limitations, like network connectivity or ad blocker issues.
 4. **Privacy-focused**: Stay compliant with rapidly evolving requirements with automatic PII hashing and flexible controls that let you adapt what data you share.
-5. **Maximum event measurement**: Capture more events with improved accuracy across different browsers, apps and devices to get a unified view of your customer's journey from page view to purchase.
+5. **Maximum event measurement**: Capture more events with improved accuracy across different browsers, apps, and devices to get a unified view of your customer's journey from page view to purchase.
 
 ## Getting started
 

--- a/src/connections/destinations/catalog/tiktok-conversions/index.md
+++ b/src/connections/destinations/catalog/tiktok-conversions/index.md
@@ -6,7 +6,9 @@ hide-dossier: true
 
 {% include content/plan-grid.md name="actions" %}
 
-The TikTok Conversions Destination enables advertisers to send Segment events directly to TikTok. Data shared can power TikTok solutions like dynamic product ads, custom targeting, campaign optimization and attribution. Advertisers can see their event data in TikTok Events Manager.
+The TikTok Conversions destination is a server-to-server integration with the TikTok Events API that allows advertisers to share website visitor events from Segment directly to TikTok. Data that is shared via the Events API is processed similarly to information shared via the TikTok pixel and TikTok SDK business tools. Advertisers can leverage events data to power solutions like dynamic showcase ads (DSA), custom targeting, campaign optimization and attribution. Advertisers can see their event data in TikTok Events Manager.
+
+The TikTok Conversions destination is owned and maintained by the TikTok team.
 
 ## Benefits of TikTok Conversions
 The TikTok Conversions destination provides the following benefits:
@@ -23,10 +25,11 @@ Follow the instructions below to enable your TikTok ads account, and add the Tik
 
 ### TikTok Requirements
 
-The TikTok Conversions destination is configured to use the TikTok Events API. To generate a TikTok Access Token and Pixel Code:
+The TikTok Conversions destination is configured to use the TikTok Events API. To generate a TikTok Pixel Code and Access Token:
 
 1. [Create a TikTok For Business account](https://ads.tiktok.com/marketing_api/docs?id=1702715936951297){:target="_blank"}.
-2. Follow instructions for [Authorization](https://ads.tiktok.com/marketing_api/docs?rid=959icq5stjr&id=1701890979375106){:target="_blank"} and generate a long term access token.
+2. [Create a TikTok Pixel](https://ads.tiktok.com/help/article?aid=10021){:target="_blank"} in Developer Mode to obtain a Pixel Code. For more information about Developer Mode, please review the [TikTok developer documentation](https://ads.tiktok.com/marketing_api/docs?rid=5ipocbxyw8v&id=1701890973258754){:target="_blank"}.
+3. Follow instructions for [Authorization](https://ads.tiktok.com/marketing_api/docs?rid=959icq5stjr&id=1701890979375106){:target="_blank"} and generate a long term Access Token.
 
 ### Connect TikTok Conversions to your workspace
 
@@ -41,6 +44,16 @@ The TikTok Conversions destination is configured to use the TikTok Events API. T
 
 ## FAQ & Troubleshooting
 
+### Match Keys
+
+To increase the probability of matching website visitor events with TikTok ads, please send one or more of the following match keys and identifiers when possible:
+- TikTok Click ID
+- External ID
+- Phone Number
+- Email
+- IP Address
+- User Agent
+
 ### Other Standard Events
 
 If you want to send a [TikTok standard event](https://ads.tiktok.com/marketing_api/docs?id=1701890979375106){:target="_blank"} that Segment doesn't have a prebuilt mapping for, you can use the [Report Web Event action](/docs/connections/destinations/catalog/tiktok-conversions/#report-web-event) to send the standard event. For example, if you want to send a `CompleteRegistration` event: 
@@ -48,10 +61,18 @@ If you want to send a [TikTok standard event](https://ads.tiktok.com/marketing_a
 2. Set up your Event Trigger criteria for completed registrations. 
 3. Input a literal string of "CompleteRegistration" as the Event Name.
 
-
 ### PII Hashing
 
 Segment creates a SHA-256 hash of the following fields before sending to TikTok:
 - External ID
 - Email
 - Phone Number
+
+### Web Diagnostics
+
+You can check whether the integration is working, test events in real-time, and troubleshoot common issues in TikTok’s Web Diagnostics Suite. Please see the [TikTok Pixel Web Diagnostics documentation](https://ads.tiktok.com/help/article?aid=10000360){:target="_blank"} for more information.
+
+## Support
+
+- For general Segment questions, including issues with event data not being sent to TikTok Events Manager, please contact [Segment support](https://segment.com/help/){:target="_blank"}.
+- For questions regarding campaign setup and performance, web tracking, or additional API functionality, please contact your TikTok representative.

--- a/src/connections/destinations/catalog/tiktok-conversions/index.md
+++ b/src/connections/destinations/catalog/tiktok-conversions/index.md
@@ -43,7 +43,11 @@ The TikTok Conversions destination is configured to use the TikTok Events API. T
 
 ### Other Standard Events
 
-If you want to send a [TikTok standard event](https://ads.tiktok.com/marketing_api/docs?id=1701890979375106){:target="_blank"} that Segment doesn't have a prebuilt mapping for, you can use the [Report Web Event action](/docs/connections/destinations/catalog/tiktok-conversions/#report-web-event) to send the standard event. For example, if you want to send a `CompleteRegistration` event, create a mapping for Report Web Event, set up your Event Trigger criteria for completed registrations, and input a literal string of "CompleteRegistration" as the Event Name.
+If you want to send a [TikTok standard event](https://ads.tiktok.com/marketing_api/docs?id=1701890979375106){:target="_blank"} that Segment doesn't have a prebuilt mapping for, you can use the [Report Web Event action](/docs/connections/destinations/catalog/tiktok-conversions/#report-web-event) to send the standard event. For example, if you want to send a `CompleteRegistration` event: 
+1. Create a mapping for Report Web Event. 
+2. Set up your Event Trigger criteria for completed registrations. 
+3. Input a literal string of "CompleteRegistration" as the Event Name.
+
 
 ### PII Hashing
 

--- a/src/connections/destinations/catalog/tiktok-conversions/index.md
+++ b/src/connections/destinations/catalog/tiktok-conversions/index.md
@@ -6,7 +6,7 @@ hide-dossier: true
 
 {% include content/plan-grid.md name="actions" %}
 
-The TikTok Conversions destination is a server-to-server integration with the TikTok Events API that allows advertisers to share website visitor events from Segment directly to TikTok. Data that is shared via the Events API is processed similarly to information shared via the TikTok pixel and TikTok SDK business tools. Advertisers can leverage events data to power solutions like dynamic showcase ads (DSA), custom targeting, campaign optimization and attribution. Advertisers can see their event data in TikTok Events Manager.
+The TikTok Conversions destination is a server-to-server integration with the TikTok Events API that allows advertisers to share website visitor events from Segment directly to TikTok. Data shared through the Events API is processed similarly to information shared through the TikTok pixel and TikTok SDK business tools. Advertisers can use events data to power solutions like dynamic showcase ads (DSA), custom targeting, campaign optimization and attribution. Advertisers can see their event data in TikTok Events Manager.
 
 The TikTok Conversions destination is owned and maintained by the TikTok team.
 

--- a/src/connections/destinations/catalog/tiktok-conversions/index.md
+++ b/src/connections/destinations/catalog/tiktok-conversions/index.md
@@ -43,7 +43,7 @@ The TikTok Conversions destination is configured to use the TikTok Events API. T
 
 ### Other Standard Events
 
-If you want to send a [TikTok standard event](https://ads.tiktok.com/marketing_api/docs?id=1701890979375106){:target="_blank"} that Segment does not have a prebuilt mapping for, you can use the [Report Web Event action](/docs/connections/destinations/catalog/tiktok-conversions/#report-web-event) to send the standard event. For example, if you want to send a `CompleteRegistration` event, create a mapping for Report Web Event, set up your Event Trigger criteria for completed registrations, and input a literal string of "CompleteRegistration" as the Event Name.
+If you want to send a [TikTok standard event](https://ads.tiktok.com/marketing_api/docs?id=1701890979375106){:target="_blank"} that Segment doesn't have a prebuilt mapping for, you can use the [Report Web Event action](/docs/connections/destinations/catalog/tiktok-conversions/#report-web-event) to send the standard event. For example, if you want to send a `CompleteRegistration` event, create a mapping for Report Web Event, set up your Event Trigger criteria for completed registrations, and input a literal string of "CompleteRegistration" as the Event Name.
 
 ### PII Hashing
 


### PR DESCRIPTION
### Proposed changes
StratConn is launching 4 destinations to GA so these changes remove beta mentions, clean up docs, etc. Please reach out to me if you have any questions about my changes! There might be a few more incoming changes for TikTok Conversions in the FAQ section that I will add by Monday EOD at the latest. 

I made some edits to the FB Destination table on our FB docs as well - is there a way to confirm this table renders correctly? There was a [recent change made to FB Conversions API (Actions)](https://github.com/segmentio/segment-docs/commit/0742c98580f1b21c4537a626f9e69b5ebf11bede) that resulted in a malformed table in our public docs: https://segment.com/docs/connections/destinations/catalog/actions-facebook-conversions-api/#server-event-parameter-requirements. I've moved this section around because I don't think it needs to be it's own section in the docs, but hoping to avoid the same thing with any tables I've edited. Thanks!

### Merge timing
- On a specific date: These destinations go to GA on Tues, March 8 so we would like these changes to go live then.

### Related issues (optional)
- Epic: https://segment.atlassian.net/browse/STRATCONN-1079
- JIRA for launch activities: https://segment.atlassian.net/browse/STRATCONN-1165
