### PR TITLE
Removing date associated with shared service account section of BigQuery docs

### DIFF
--- a/src/connections/storage/catalog/bigquery/index.md
+++ b/src/connections/storage/catalog/bigquery/index.md
@@ -107,7 +107,7 @@ with credentials, access was granted to a shared Service Account
 (`connector@segment-1119.iam.gserviceaccount.com`). While convenient for early
 adopters, this presented potential security risks.
 
-As of **March 2019**, Segment requires BigQuery customers to
+Segment now requires BigQuery customers to
 create their own Service Accounts and provide the app with those credentials instead.
 In addition, any attempts to update warehouse connection settings will also
 require these credentials. This effectively deprecates the shared Service


### PR DESCRIPTION
### Proposed changes

As per discussion in today's BigQuery EOL Monthly check-in, removed the date from the shared service account note in the BigQuery documentation as this date didn't adequately reflect the cutoff for customers creating shared service accounts. 

### Merge timing
With the next regular docs release!

### Related issues (optional)
#2506 
