### PR TITLE
Update page to remove appsflyer from the swift supported destinations list

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -402,7 +402,6 @@ analytics.add(plugin: idfaPlugin)
 ## Supported Destinations
 Segment supports these destinations for Analytics Swift, with more to come:
 * [Amplitude](https://github.com/segment-integrations/analytics-swift-amplitude)
-* [Appsflyer](https://github.com/segment-integrations/analytics-swift-appsflyer)
 * [Facebook App Events](https://github.com/segment-integrations/analytics-swift-facebook-app-events)
 * [Firebase](https://github.com/segment-integrations/analytics-swift-facebook-app-events)
 * [Mixpanel](https://github.com/segment-integrations/analytics-swift-mixpanel)


### PR DESCRIPTION
Removing appsflyer from the swift supported destinations list

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
