### PR TITLE
[index.md] update Bucket destination copy

### DIFF
--- a/src/connections/destinations/catalog/bucket/index.md
+++ b/src/connections/destinations/catalog/bucket/index.md
@@ -3,9 +3,10 @@ title: Bucket Destination
 rewrite: true
 id: 5fabc0b00f88248bbce4db48
 ---
-[Bucket](https://bucket.so/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners) features analytics for SaaS companies.
 
-This destination is maintained by Bucket. For any issues with the destination, [contact the Bucket Support team](mailto:support@bucket.so).
+[Bucket](https://bucket.co/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners) is feature-focused analytics. Bucket empowers software teams with a repeatable approach to shipping features that customers crave.
+
+This destination is maintained by Bucket. For any issues with the destination, [contact the Bucket Support team](mailto:support@bucket.co).
 
 ## Getting Started
 
@@ -14,17 +15,17 @@ This destination is maintained by Bucket. For any issues with the destination, [
 1. From the Destinations catalog page in the Segment App, click **Add Destination**.
 2. Search for "Bucket" in the Destinations Catalog, and select the Bucket destination.
 3. Choose which Source should send data to the Bucket destination.
-4. Go to [Bucket's Settings](https://bucket.so) and find and copy the "App ID".
-5. Enter the App ID as "API Key" in the "Bucket" destination settings in Segment.
+4. Go to [Bucket's Settings](https://bucket.co) and find and copy the "Tracking Key" under Settings.
+5. Enter the "Tracking Key" as "API Key" in the "Bucket" destination settings in Segment.
 
 ## Identify
 
 If you aren't familiar with the Segment Spec, take a look at the [Identify method documentation](/docs/connections/spec/identify/) to learn about what it does. An example call would look like:
 
 ```js
-analytics.identify('userId123', {
-  name: 'John Doe',
-  email: 'john.doe@example.com'
+analytics.identify("userId123", {
+  name: "John Doe",
+  email: "john.doe@example.com",
 });
 ```
 
@@ -35,8 +36,8 @@ Segment sends Identify calls to Bucket as an `identify` event which updates User
 If you aren't familiar with the Segment Spec, take a look at the [Group method documentation](/docs/connections/spec/group/) to learn about what it does. An example call would look like:
 
 ```js
-analytics.identify('groupId123', {
-  name: 'Acme, Inc',
+analytics.identify("groupId123", {
+  name: "Acme, Inc",
 });
 ```
 
@@ -47,8 +48,7 @@ Segment sends Group calls to Bucket as a `group` event which updates Company pro
 If you aren't familiar with the Segment Spec, take a look at the [Track method documentation](/docs/connections/spec/track/) to learn about what it does. An example call would look like:
 
 ```js
-analytics.track('Login Button Clicked', {
-})
+analytics.track("Login Button Clicked", {});
 ```
 
 Segment sends Track calls to Bucket as a `track` event which updates the Features page.


### PR DESCRIPTION
### Proposed changes

Updated bucket copy per partner request. 

There is one part of the docs that they wanted to update, that is not included in the index.md file. 

The description in the settings display:
<img width="733" alt="Screen Shot 2022-03-17 at 4 59 08 PM" src="https://user-images.githubusercontent.com/64277654/158894252-29bcccc0-0715-4ea9-b5b6-5aa29b3e3a05.png">

They want it updated from:

- string. The API key is your App ID. Find it under Settings (cog wheel) when logged in.

To 

+ string. The API key is your app’s Tracking Key. Locate it under Settings when signed in.

This is now [mapped correctly in the partner portal](https://app.segment.com/partner-portal/integration/bucket/settings), so I am guessing this will be included in the next build?

### Merge timing
asap



