### PR TITLE
Niall/kinesis base64 remove

### DIFF
--- a/src/connections/destinations/catalog/amazon-kinesis/index.md
+++ b/src/connections/destinations/catalog/amazon-kinesis/index.md
@@ -1,6 +1,7 @@
 ---
 rewrite: true
 title: Amazon Kinesis Destination
+id: 57da359580412f644ff33fb9
 ---
 [Amazon Kinesis](https://aws.amazon.com/kinesis/) enables you to build custom applications that process or analyze streaming data for specialized needs. Amazon Kinesis Streams can continuously capture and store terabytes of data per hour from hundreds of thousands of sources such as website clickstreams, financial transactions, social media feeds, IT logs, and location-tracking events.
 
@@ -92,17 +93,15 @@ Let's say you're connecting your Segment customer data stream to Kinesis Stream 
 
 The Segment Kinesis destination issues a `PutRecord` request with the following parameters:
 ```js
-kinesis.putRecord({
-  Data: new Buffer(JSON.stringify(msg)).toString('base64')
-  PartitionKey: msg.userId() || msg.anonymousId(),
-  StreamName: 'stream-name'
-});
+const payload = {
+  Data: JSON.stringify(msg.json()),
+  StreamName: this.settings.stream,
+  PartitionKey: this.settings.useMessageId ? msg.field('messageId') : msg.userId() || msg.anonymousId()
+}
+const request = kinesis.putRecord(payload)
 ```
 
-Segment uses the the `userId || anonymousId` as the `PartitionKey`. The partition key is used by Amazon Kinesis to distribute data across shards. Amazon Kinesis segregates the data records that belong to a stream into multiple shards, using the partition key associated with each data record to determine which shard a given data record belongs to.
-
-> note ""
-> **NOTE:** The JSON payload is base64 stringified.
+Segment uses the `messageId` or the `userId || anonymousId` as the `PartitionKey`. The partition key is used by Amazon Kinesis to distribute data across shards. Amazon Kinesis segregates the data records that belong to a stream into multiple shards, using the partition key associated with each data record to determine which shard a given data record belongs to.
 
 ## Group
 If you're not familiar with the Segment Specs, take a look to understand what the [Group method](/docs/connections/spec/group/) does.

--- a/src/connections/destinations/catalog/amazon-kinesis/index.md
+++ b/src/connections/destinations/catalog/amazon-kinesis/index.md
@@ -1,7 +1,6 @@
 ---
 rewrite: true
 title: Amazon Kinesis Destination
-id: 57da359580412f644ff33fb9
 ---
 [Amazon Kinesis](https://aws.amazon.com/kinesis/) enables you to build custom applications that process or analyze streaming data for specialized needs. Amazon Kinesis Streams can continuously capture and store terabytes of data per hour from hundreds of thousands of sources such as website clickstreams, financial transactions, social media feeds, IT logs, and location-tracking events.
 


### PR DESCRIPTION
### Proposed changes
A customer wrote in about the base 64 encoding, and observed the payloads were not base 64 encoded. Checking out the code I do not see nay logic around base 64 encoding, and our code in the docs was also incorrect.
https://github.com/segmentio/integrations/blob/master/integrations/amazon-kinesis/lib/index.js#L96

Removing references to base 64 encoding. 
