### PR TITLE
Remove partner owned sections for integrations we own

### DIFF
--- a/src/connections/destinations/catalog/attribution/index.md
+++ b/src/connections/destinations/catalog/attribution/index.md
@@ -5,9 +5,6 @@ id: 54521fd525e721e32a72ee96
 ---
 [Attribution](http://attributionapp.com/) is an easy to use one stop dashboard for multi-touch attribution across all marketing channels. Attribution prides itself on high-fidelity and allows marketers to trace every visit, conversion or revenue dollar to the source. Marketers can easily integrate Attribution and Segment to begin measuring the effectiveness of their campaigns today.
 
-This destination is maintained by Attribution. For any issues with the destination, [contact the Attribution App Support team](mailto:support@attribtutionapp.com).
-
-
 ## Getting Started
 
 {% include content/connection-modes.md %}

--- a/src/connections/destinations/catalog/clearbit-reveal/index.md
+++ b/src/connections/destinations/catalog/clearbit-reveal/index.md
@@ -5,8 +5,6 @@ id: 57e0726680412f644ff36883
 ---
 [Clearbit Reveal](https://clearbit.com/segment) helps customers instantly match IP addresses with company names, and see full profiles for all site visitors. It turns your anonymous web traffic into a full company profile — complete with industry, employee count, funding details, and much more. You can find a list of the different attributes you can collect with Clearbit [here](https://clearbit.com/attributes).
 
-This destination is maintained by Clearbit. For any issues with the destination, [contact the Clearbit Support team](mailto:support@clearbit.com)
-
 ## Getting Started
 
 {% include content/connection-modes.md %}

--- a/src/connections/destinations/catalog/natero/index.md
+++ b/src/connections/destinations/catalog/natero/index.md
@@ -5,8 +5,6 @@ id: 54bee265db31d978f14a7e21
 ---
 [Natero, also known as Freshdesk Customer Success](https://urldefense.com/v3/__https://freshsuccess.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners__;!!NCc8flgU!JByOjJz8hK4AJQxY6Rqzqe0ZcUCB3UJBtbn1bQrxTh6SxjM-uHPST7abmfD3cRc$){:target="_blank"} helps customer success managers better understand their customers by integrating all of your customer data in one place and leveraging it to help with prioritization and context.  By reaching out to customers in the right way at the right time, CSMs can reduce churn, increase upsell and create advocates for your business.  For more details on how the segment integration for Natero works, visit the [Natero developer site](https://urldefense.com/v3/__https://developer.freshsuccess.com/api/segmentapi.html__;!!NCc8flgU!JByOjJz8hK4AJQxY6Rqzqe0ZcUCB3UJBtbn1bQrxTh6SxjM-uHPST7abnKQ8GJ4$){:target="_blank"}.
 
-This destination is maintained by Freshworks. For any issues with the destination, [contact the Natero Support team](mailto:support@freshsuccess.com).
-
 ## Getting Started
 
 {% include content/connection-modes.md %}


### PR DESCRIPTION
### Proposed changes
As per here: https://segment.slack.com/archives/CC97A542H/p1647355455520369
Some destinations are marked as partner owned, however upon investigation they appear to be owned by us. @nielst confirmed by DM that we do own these. 