### PR TITLE
Swift/Kotlin no longer in beta

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/android/index.md
@@ -10,7 +10,7 @@ id: wXNairW5xX
 Analytics for Android only supports any Android device running API 14 (Android 4.0) and higher. This includes Amazon Fire devices.
 
 > info "Analytics-Kotlin public beta"
-> The Analytics-Kotlin library is in public beta. You can use Analytics-Kotlin for [mobile](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/) or [server](/docs/connections/sources/catalog/libraries/server/kotlin) applications. If you’d like to migrate to Analytics-Kotlin, see the [migration guide](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/migration/). Segment's [First-Access and Beta terms](https://segment.com/legal/first-access-beta-preview/) govern this library. 
+> The Analytics-Kotlin library is in General Availability. You can use Analytics-Kotlin for [mobile](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/) or [server](/docs/connections/sources/catalog/libraries/server/kotlin) applications. If you’d like to migrate to Analytics-Kotlin, see the [migration guide](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/migration/).
 
 > success ""
 > In addition to the documentation here, you can also [read the Javadocs for all versions of Analytics-Android on Javadoc.io](https://javadoc.io/doc/com.segment.analytics.android/analytics/latest/index.html).

--- a/src/connections/sources/catalog/libraries/mobile/android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/android/index.md
@@ -9,7 +9,7 @@ id: wXNairW5xX
 
 Analytics for Android only supports any Android device running API 14 (Android 4.0) and higher. This includes Amazon Fire devices.
 
-> info "Analytics-Kotlin public beta"
+> info "Analytics-Kotlin"
 > The Analytics-Kotlin library is in General Availability. You can use Analytics-Kotlin for [mobile](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/) or [server](/docs/connections/sources/catalog/libraries/server/kotlin) applications. If you’d like to migrate to Analytics-Kotlin, see the [migration guide](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/migration/).
 
 > success ""

--- a/src/connections/sources/catalog/libraries/mobile/ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/index.md
@@ -14,7 +14,7 @@ With Analytics for iOS, you can send your data to analytics or marketing tool, w
 
 
 > info "Analytics-Swift Public Beta"
-> The [Analytics-Swift](/docs/connections/sources/catalog/libraries/mobile/swift-ios/) library is in public beta. If you’d like to migrate to Analytics-Swift, see the [migration guide](/docs/connections/sources/catalog/libraries/mobile/swift-ios/migration/). Segment's [First-Access and Beta terms](https://segment.com/legal/first-access-beta-preview/) govern this library. 
+> The [Analytics-Swift](/docs/connections/sources/catalog/libraries/mobile/swift-ios/) library is in General Availability. If you’d like to migrate to Analytics-Swift, see the [migration guide](/docs/connections/sources/catalog/libraries/mobile/swift-ios/migration/).
 
 ## Analytics-iOS and Unique Identifiers
 

--- a/src/connections/sources/catalog/libraries/mobile/ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/index.md
@@ -13,7 +13,7 @@ With Analytics for iOS, you can send your data to analytics or marketing tool, w
 > **Note:** Segment does not currently support tracking of watchkit extensions for the Apple Watch. [Email us](https://segment.com/requests/integrations/) if you're interested in a Watchkit SDK. For now we recommend tracking watch interactions using the iPhone app code.
 
 
-> info "Analytics-Swift Public Beta"
+> info "Analytics-Swift"
 > The [Analytics-Swift](/docs/connections/sources/catalog/libraries/mobile/swift-ios/) library is in General Availability. If you’d like to migrate to Analytics-Swift, see the [migration guide](/docs/connections/sources/catalog/libraries/mobile/swift-ios/migration/).
 
 ## Analytics-iOS and Unique Identifiers


### PR DESCRIPTION
### Proposed changes
As our Swift and Kotlin SDKs are in GA we can remove the Beta text.
<img width="694" alt="Screen Shot 2022-03-24 at 15 57 32" src="https://user-images.githubusercontent.com/16934916/159958122-1cf29e48-8b8e-49f8-84f5-0d3c22242647.png">

