### PR TITLE
Correcting Page methods name

### DIFF
--- a/src/connections/destinations/methods-compare.md
+++ b/src/connections/destinations/methods-compare.md
@@ -18,11 +18,11 @@ This page lists which [Segment methods](/docs/connections/spec/) each destinatio
   <th> <a href="/docs/connections/spec/alias/">Alias 🏷</a> </th>
 </tr>
 {% for destination in site.data.catalog.destinations.items %}
-{% unless destination.methods.track == false and destination.methods.page_view == false and destination.methods.identify == false and destination.methods.group == false and destination.methods.alias == false %}
+{% unless destination.methods.track == false and destination.methods.page == false and destination.methods.identify == false and destination.methods.group == false and destination.methods.alias == false %}
 <tr>
   <td>{% if destination.status == "PUBLIC_BETA" %}ℹ️ {% endif %}**[{{ destination.display_name }}](/docs/{{ destination.url }})**</td>
   <td>{% if destination.methods.track %}✅{% else %}⬜️{% endif %} </td>
-  <td>{% if destination.methods.page_view %}✅{% else %}⬜️{% endif %} </td>
+  <td>{% if destination.methods.page %}✅{% else %}⬜️{% endif %} </td>
   <td>{% if destination.methods.identify %}✅{% else %}⬜️{% endif %} </td>
   <td>{% if destination.methods.group %}✅{% else %}⬜️{% endif %} </td>
   <td>{% if destination.methods.alias %}✅{% else %}⬜️{% endif %} </td>
@@ -34,7 +34,7 @@ This page lists which [Segment methods](/docs/connections/spec/) each destinatio
 
 #### The following destinations have no method information available:
 {% for destination in site.data.catalog.destinations.items %}
-{% if destination.methods.track == false and destination.methods.page_view == false and destination.methods.identify == false and destination.methods.group == false and destination.methods.alias == false %}
+{% if destination.methods.track == false and destination.methods.page == false and destination.methods.identify == false and destination.methods.group == false and destination.methods.alias == false %}
 - [{{ destination.display_name }}](/docs/{{ destination.url }}){% if destination.status == "PUBLIC_BETA" %} (beta){% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
‘destinations.methods.page_view’ should be ‘destinations.methods.page’ to match the naming convention found in destinations.yml

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

The methods compare page (https://segment.com/docs/connections/destinations/methods-compare/) was not showing any Page calls.  Believe this is due to bad naming conventions, which I tried to fix in these edits.

### Merge timing
ASAP after approval

### Related issues (optional)
https://github.com/segmentio/segment-docs/issues/2669

