### PR TITLE
Updated Retry Policy FAQ

### DIFF
--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -382,7 +382,7 @@ Copy and paste this URL into the upstream tool or service to send data to this s
 
 ##### What is the retry policy for a webhook payload?
 
-The webhook payload retries up to 6 times with an exponential backoff for the function in the event of a failure with the function. After 6 attempts, the message is dropped.
+The webhook payload retries up to six times with an exponential backoff for the function in the event of a failure with the function. After six attempts, the message is dropped.
 
 ##### What is the maximum payload size for the incoming webhook?
 

--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -382,7 +382,7 @@ Copy and paste this URL into the upstream tool or service to send data to this s
 
 ##### What is the retry policy for a webhook payload?
 
-The webhook payload retries up to 5 times with an exponential backoff for the function in the event of a failure with the function. After 5 attempts, the message is dropped.
+The webhook payload retries up to 6 times with an exponential backoff for the function in the event of a failure with the function. After 6 attempts, the message is dropped.
 
 ##### What is the maximum payload size for the incoming webhook?
 


### PR DESCRIPTION

### Proposed changes

Previously, In the Source Functions FAQs -> Retry Policy it was mentioned that message is retried **5** times which is not correct. We retry a message for **6** times before dropping it.

[Reference](https://github.com/segmentio/terracode-infra/blob/master/production/us-west-2/core/functions/kubeapply.tf#L75)

### Merge timing

- ASAP once approved.
