### PR TITLE
Update RN docs to specify version

### DIFF
--- a/src/_includes/content/react-dest.md
+++ b/src/_includes/content/react-dest.md
@@ -14,7 +14,7 @@ The {{thisDestName}} device-mode destination SDK is only available for {{thisDes
 </p></div></div>
 {%endif%}
 
-To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project:
+To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using our `1.5.1≤` release:
 1. Navigate to the root folder of your project, and run a `yarn add @segment/analytics-react-native-{{thisDestName | downcase | replace: " ", "-" }}{% if thisDestRNspecific %}-{{thisDestRNspecific}}{%endif%}` command to add the destination SDK to your project.
 2. Add an `import` statement to your project, as in the example below.
    ```js

--- a/src/_includes/content/react-dest.md
+++ b/src/_includes/content/react-dest.md
@@ -14,7 +14,7 @@ The {{thisDestName}} device-mode destination SDK is only available for {{thisDes
 </p></div></div>
 {%endif%}
 
-To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using our `1.5.1≤` release:
+To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using Segment's `1.5.1≤` release:
 1. Navigate to the root folder of your project, and run a `yarn add @segment/analytics-react-native-{{thisDestName | downcase | replace: " ", "-" }}{% if thisDestRNspecific %}-{{thisDestRNspecific}}{%endif%}` command to add the destination SDK to your project.
 2. Add an `import` statement to your project, as in the example below.
    ```js

--- a/src/connections/destinations/catalog/branch-metrics/index.md
+++ b/src/connections/destinations/catalog/branch-metrics/index.md
@@ -33,7 +33,7 @@ This destination is maintained by Branch. For any issues with the destination, [
 
 <!-- LR, Mar2021: this should be a `react-dest` include but Branch changed their name from Branch-Metrics-->
 
-To add the Branch device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using our `1.5.1≤` release:
+To add the Branch device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using Segment's `1.5.1≤` release:
 1. Navigate to the root folder of your project, and run a `yarn add branch` command to add the destination SDK to your project.
 2. Add an `import` statement to your project, as in the example below.
    ```js

--- a/src/connections/destinations/catalog/branch-metrics/index.md
+++ b/src/connections/destinations/catalog/branch-metrics/index.md
@@ -33,7 +33,7 @@ This destination is maintained by Branch. For any issues with the destination, [
 
 <!-- LR, Mar2021: this should be a `react-dest` include but Branch changed their name from Branch-Metrics-->
 
-To add the Branch device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project:
+To add the Branch device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using our `1.5.1≤` release:
 1. Navigate to the root folder of your project, and run a `yarn add branch` command to add the destination SDK to your project.
 2. Add an `import` statement to your project, as in the example below.
    ```js

--- a/src/connections/destinations/catalog/braze/index.md
+++ b/src/connections/destinations/catalog/braze/index.md
@@ -102,7 +102,7 @@ To use the latest Braze SDK to collect IDFAs you must do the following:
 
 <!-- LR, Mar2021: this should be a `react-dest` include but Braze was originally called Appboy-->
 
-To add the Braze device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using our `1.5.1≤` release:
+To add the Braze device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using Segment's `1.5.1≤` release:
 1. Navigate to the root folder of your project, and run a `yarn add appboy` command to add the destination SDK to your project.
 2. Add an `import` statement to your project, as in the example below.
    ```js

--- a/src/connections/destinations/catalog/braze/index.md
+++ b/src/connections/destinations/catalog/braze/index.md
@@ -102,7 +102,7 @@ To use the latest Braze SDK to collect IDFAs you must do the following:
 
 <!-- LR, Mar2021: this should be a `react-dest` include but Braze was originally called Appboy-->
 
-To add the Braze device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project:
+To add the Braze device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using our `1.5.1≤` release:
 1. Navigate to the root folder of your project, and run a `yarn add appboy` command to add the destination SDK to your project.
 2. Add an `import` statement to your project, as in the example below.
    ```js


### PR DESCRIPTION
### Proposed changes
Due to the release of our 2.X.X React Native SDK these docs are misleading, as this is not how you integrate with the new version of our SDK. Details on implementing via device mode for 2.X.X can be found here: https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/#destination-plugins