### PR TITLE
Fix typo in implementation-guide.md

### DIFF
--- a/src/getting-started/implementation-guide.md
+++ b/src/getting-started/implementation-guide.md
@@ -11,7 +11,7 @@ The guide is broken into three categories of tasks:
 - [Optimization](#optimization): These tasks guide you to expand your data coverage and optimize your workspace.
 
 ## Basics
-The tasks included in Basics help you send and debug your very first data from a [Source](/docs/connections/sources/) (a library that sends data to Segnent), and into a [Destination](/docs/connections/destinations/) (tools you use to analyze or act on your data).
+The tasks included in Basics help you send and debug your very first data from a [Source](/docs/connections/sources/) (a library that sends data to Segment), and into a [Destination](/docs/connections/destinations/) (tools you use to analyze or act on your data).
 
 The Basic tasks include:
 


### PR DESCRIPTION
Fixed typo on line 14 of implementation-guide.md from "Segnent" to "Segment".

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
