### PR TITLE
Salesforce Adobe Target Actions Public Beta Changes

### DIFF
--- a/src/connections/destinations/catalog/actions-adobe-target-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-adobe-target-cloud/index.md
@@ -2,8 +2,7 @@
 title: Adobe Target Cloud Mode Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-beta: true
+strat: adobe
 id: 61aa712b857e8c85c3b5a849
 ---
 Adobe Target is the A/B testing and personalization component of Adobe Experience Cloud. Segment’s Adobe Target integration enables customers to send data from Segment to Adobe Target to create and update user profiles. You can leverage these profiles in Adobe Target to construct audiences and personalize onsite visitor experiences.
@@ -11,6 +10,9 @@ Adobe Target is the A/B testing and personalization component of Adobe Experienc
 Segment offers two destinations for Adobe Target:
 - [Adobe Target Web](/docs/connections/destinations/catalog/actions-adobe-target-web/)
 - [Adobe Target Cloud Mode](/docs/connections/destinations/catalog/actions-adobe-target-cloud/)
+
+> info ""
+> This document is about a feature which is in beta. This means that the Adobe Target Cloud Mode destination is in active development, and some functionality may change before it becomes generally available.
 
 > success ""
 > **Good to know**: This page is about Segment's Adobe Target Cloud Mode destination. There's also a page about Segment's [Adobe Target Web destination](/docs/connections/destinations/catalog/actions-adobe-target-web/). **In order to use Adobe Target Cloud Mode, you must have a parallel web integration with Adobe Target as profiles can only be created by the Adobe Target `at.js` web script.**
@@ -53,10 +55,10 @@ This scenario assumes that your users authenticate and have a `userId` upon arri
 If the same known user visits on a different device, assuming they authenticate immediately, they will have the same `userId` and therefore the same `mbox3rdPartyId`. This means you can target known users across devices.
 
 #### Scenario 3. Anonymous user becomes a known user.
-When an anonymous user first arrives on your website, one Adobe Target profile will be created and the `mbox3rdPartyId` will be equal to the Segment `anonymousId`. However, once the user is identified, they will be assigned a new `mbox3rdPartyId` equal to the Segment `userId`. There will be two profiles in Adobe Target; both will be available for targeting.
+When an anonymous user arrives on your website, one Adobe Target profile will be created and the `mbox3rdPartyId` will be equal to the Segment `anonymousId`. However, once the user is identified, they will be assigned a new `mbox3rdPartyId` equal to the Segment `userId`. There will be two profiles in Adobe Target; both will be available for targeting.
 
 ### How to use Adobe Target with Personas
-Adobe Target Cloud Mode operates as an [Event Destination](/docs/personas/using-personas-data/#personas-destination-types-event-vs-list/). This means Personas sends computed traits and audiences as traits in `identify` calls or properties in `track`  calls. Please see [this example](/docs/personas/using-personas-data/#audience-generated-events/) of the payload Personas would send to Adobe Target.
+Adobe Target Cloud Mode operates as an [Event Destination](/docs/personas/using-personas-data/#personas-destination-types-event-vs-list). This means Personas sends computed traits and audiences as traits in `identify` calls or properties in `track`  calls. Please see [this example](/docs/personas/using-personas-data/#what-do-the-payloads-look-like-for-personas-data) of the payload Personas would send to Adobe Target.
 
 When you connect Adobe Target Cloud Mode to a Personas space, you will need to set up a mapping for Update Profile. Within the Update Profile mapping, please ensure you have something mapped to Profile Attributes. If you plan to send multiple Personas computed traits and/or audiences to Adobe Target, you can click **Edit Object** and set Profile Attributes to the entire `traits` object. This ensures any audience Personas generates sends to Adobe Target.
 
@@ -68,15 +70,15 @@ You can use Profile Attributes in the Adobe Target Audience builder to construct
 ## Viewing Segment data in Adobe Target
 To view and use your Segment data in Adobe Target, navigate to **Adobe Target > Audiences > Create Audience > Add Rule**.
 
-- Profile Attributes appear under the **Visitor Profile** attributes.
+- Profile Attributes appear under **Visitor Profile** attributes.
 - Page Parameters appear under **Custom** attributes. Fields have `page.` prepended to the key.
 
-Audiences can then be used in Adobe Target Activities, such as A/B Testing and Experience Targeting. Please note that while Standard and Premium Adobe Target packages allow access to the SDK and API, certain personalization functionality may only be available with Adobe Target Premium. 
+Adobe Target Audiences can be used in Activities, such as A/B Testing and Experience Targeting. Please note that while Standard and Premium Adobe Target packages allow access to the SDK and API, certain personalization functionality may only be available with Adobe Target Premium. 
 
 ## FAQ
 ### Why am I getting a `Profile Not Found` error?
-The Adobe Target API can only be used for profile updates. Profiles must be created on the web first, either using Segment’s [Adobe Target Web destination](/docs/connections/destinations/catalog/actions-adobe-target-web/) or a native implementation of `at.js`. Please ensure you are creating profiles via `at.js` first.
+The Adobe Target API can only be used for profile updates. Profiles must be created on the web first, either using Segment’s [Adobe Target Web destination](/docs/connections/destinations/catalog/actions-adobe-target-web/) or a native implementation of `at.js`. Please ensure you are creating profiles on the web first.
 
-Segment’s Adobe Target Web destination sends data in realtime, but it may take up to 1-hour for a user to be available via the Adobe Target API. This means you may see delivery errors for `Profile Not Found` in Adobe Target Cloud until the profile is available for API updates.
+Segment’s Adobe Target Web destination sends data in realtime, but it may take up to 1-hour for a user to be available via the Adobe Target API. This means you may see delivery errors for `Profile Not Found` in Adobe Target Cloud Mode until the profile is available for API updates.
 
 In addition, Adobe Target visitor profiles expire after 14 days. [Profile lifetime](https://experienceleague.adobe.com/docs/target/using/audiences/visitor-profiles/visitor-profile-lifetime.html){:target="_blank"} could be another reason a profile is not found.

--- a/src/connections/destinations/catalog/actions-adobe-target-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-adobe-target-cloud/index.md
@@ -12,7 +12,7 @@ Segment offers two destinations for Adobe Target:
 - [Adobe Target Cloud Mode](/docs/connections/destinations/catalog/actions-adobe-target-cloud/)
 
 > info ""
-> This document is about a feature which is in beta. This means that the Adobe Target Cloud Mode destination is in active development, and some functionality may change before it becomes generally available.
+> The Adobe Target Cloud Mode destination is in beta and is in active development. Some functionality may change before it becomes generally available.
 
 > success ""
 > **Good to know**: This page is about Segment's Adobe Target Cloud Mode destination. There's also a page about Segment's [Adobe Target Web destination](/docs/connections/destinations/catalog/actions-adobe-target-web/). **In order to use Adobe Target Cloud Mode, you must have a parallel web integration with Adobe Target as profiles can only be created by the Adobe Target `at.js` web script.**

--- a/src/connections/destinations/catalog/actions-adobe-target-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-adobe-target-cloud/index.md
@@ -14,8 +14,8 @@ Segment offers two destinations for Adobe Target:
 > info ""
 > The Adobe Target Cloud Mode destination is in beta and is in active development. Some functionality may change before it becomes generally available.
 
-> success ""
-> **Good to know**: This page is about Segment's Adobe Target Cloud Mode destination. There's also a page about Segment's [Adobe Target Web destination](/docs/connections/destinations/catalog/actions-adobe-target-web/). **In order to use Adobe Target Cloud Mode, you must have a parallel web integration with Adobe Target as profiles can only be created by the Adobe Target `at.js` web script.**
+> success "Good to know"
+> This page is about Segment's Adobe Target Cloud Mode destination. There's also a page about Segment's [Adobe Target Web destination](/docs/connections/destinations/catalog/actions-adobe-target-web/). **In order to use Adobe Target Cloud Mode, you must have a parallel web integration with Adobe Target as profiles can only be created by the Adobe Target `at.js` web script.**
 
 ## Getting started
 
@@ -77,7 +77,7 @@ Adobe Target Audiences can be used in Activities, such as A/B Testing and Experi
 
 ## FAQ
 ### Why am I getting a `Profile Not Found` error?
-The Adobe Target API can only be used for profile updates. Profiles must be created on the web first, either using Segment’s [Adobe Target Web destination](/docs/connections/destinations/catalog/actions-adobe-target-web/) or a native implementation of `at.js`. Please ensure you are creating profiles on the web first.
+The Adobe Target API can only be used for profile updates. You must first create profiles on the web by using either Segment’s [Adobe Target Web destination](/docs/connections/destinations/catalog/actions-adobe-target-web/) or a native implementation of `at.js`. Please ensure you create profiles on the web first.
 
 Segment’s Adobe Target Web destination sends data in realtime, but it may take up to 1-hour for a user to be available via the Adobe Target API. This means you may see delivery errors for `Profile Not Found` in Adobe Target Cloud Mode until the profile is available for API updates.
 

--- a/src/connections/destinations/catalog/actions-adobe-target-web/index.md
+++ b/src/connections/destinations/catalog/actions-adobe-target-web/index.md
@@ -2,15 +2,17 @@
 title: Adobe Target Web Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-beta: true
+strat: adobe
 id: 61fc2ffcc76fb3e73d85c89d
 ---
-Adobe Target is a personalization solution that makes it easy to identify your best content through tests that are easy to execute. So you can deliver the right experience to the right customer. When you have Segment installed, you can make efficient use of your existing tracking implementation by using Segment to fulfill your data collection needs across all your tools that integrate with Segment, including Adobe Target.
+Adobe Target is the A/B testing and personalization component of Adobe Experience Cloud. Segment’s Adobe Target integration enables customers to send data from Segment to Adobe Target to create and update user profiles. You can leverage these profiles in Adobe Target to construct audiences and personalize onsite visitor experiences.
 
 Segment offers two destinations for Adobe Target:
 - [Adobe Target Web](/docs/connections/destinations/catalog/actions-adobe-target-web/)
 - [Adobe Target Cloud Mode](/docs/connections/destinations/catalog/actions-adobe-target-cloud/)
+
+> info ""
+> This document is about a feature which is in beta. This means that the Adobe Target Web destination is in active development, and some functionality may change before it becomes generally available.
 
 > success ""
 > **Good to know**: This page is about Segment's Adobe Target Web destination. There's also a page about Segment's [Adobe Target Cloud Mode destination](/docs/connections/destinations/catalog/actions-adobe-target-cloud/).
@@ -20,12 +22,12 @@ Segment offers two destinations for Adobe Target:
 The Adobe Target Web destination loads Adobe's `at.js` script for you in order to upsert user profiles, trigger views and track events. 
 
 1. From the Segment web app, click **Catalog**, then click **Destinations**.
-2. Search for "Adobe Target Web" in the Destinations Catalog, and select the destination.
+2. Search for **Adobe Target Web** in the Destinations Catalog, and select the destination.
 3. Click **Configure Adobe Target Web** in the top-right corner of the screen.
 4. Select the web source that will send data to Adobe Target Web and follow the steps to name your destination. The web source chosen must use [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/).
 5. On the **Settings** tab, input your Adobe Target destination settings.
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
-7. Enable the Destination and configured Mappings.
+7. Enable the destination and configured mappings.
 
 {% include components/actions-fields.html %}
 
@@ -33,35 +35,35 @@ The Adobe Target Web destination loads Adobe's `at.js` script for you in order t
 
 Adobe Target is unique because you must have a web integration with Adobe Target in order to utilize the Target server-side API for profile updates. This is because Adobe Target only allows creation of user profiles via client-side web. 
 
-To support this, we provide an Adobe Target Web destination for user profile creation, updates, and page/event tracking and an [Adobe Target Cloud Mode destination](/docs/connections/destinations/catalog/actions-adobe-target-cloud/) for additional profile updates. The cloud mode destination is especially useful if you would like to send Personas data to Adobe Target as profile parameters.
+To support this, Segment provides an Adobe Target Web destination for user profile creation, updates, and page/event tracking and an [Adobe Target Cloud Mode destination](/docs/connections/destinations/catalog/actions-adobe-target-cloud/) for additional profile updates. The cloud mode destination is useful if you would like to send Personas data to Adobe Target as profile parameters.
 
 ### How does it work?
-Adobe Target’s `at.js` script identifies each visitor uniquely through a `PCID`, which is auto-generated in the visitor’s cookies. Since we do not expect you to pass the `PCID` to Segment, Segment will update profiles using the `mbox3rdPartyId`. 
+Adobe Target’s `at.js` script identifies each visitor uniquely through a `PCID`, which is auto-generated in the visitor’s cookies. Since Segment doesn't expect you to include the `PCID` on your Segment events, Segment updates profiles using the `mbox3rdPartyId` instead.
 
-Segment recommends setting the `mbox3rdPartyId` to `userId` (falling back on `anonymousId`) and we set this as the default for your implementation. This allows for a common identifier that can be used to tie server-side data back to the original profile that was created on the web.
+Segment recommends setting the `mbox3rdPartyId` to `userId` (falling back on `anonymousId`) and sets this as the default for your implementation. This allows for a common identifier that can be used to tie server-side data back to the original profile that was created on the web.
 
-Depending on your users’ typical journey, a few scenarios can occur when using web and cloud mode together.
+Depending on your user's typical journey, a few scenarios can occur when using web and cloud mode together.
 
-#### Scenario 1. Anonymous user always, never becomes known.
-When the user arrives on your website, one Adobe Target profile will be created and the `mbox3rdPartyId` will be equal to the Segment `anonymousId`.
+#### Scenario 1. Anonymous user never becomes known.
+When an anonymous user arrives on your website, one Adobe Target profile will be created and the `mbox3rdPartyId` will be equal to the Segment `anonymousId`.
 
-If the same user visits on a different device, they will have a new `anonymousId` and therefore a different `mbox3rdPartyId`, and a separate Adobe Target profile will be created. This is in line with how Adobe’s `PCID` behavior works too.
+If the same anonymous user visits on a different device, they will have a new `anonymousId` and therefore a different `mbox3rdPartyId`, and a separate Adobe Target profile will be created. This is in line with how Adobe’s `PCID` behavior works too.
 
-#### Scenario 2. Known user always, from first point of contact.
+#### Scenario 2. The user is known from the first point of contact.
 This scenario assumes that your users authenticate and have a `userId` upon arriving on your website. When the user arrives on your website, one Adobe Target profile will be created and the `mbox3rdPartyId` will be equal to the Segment `userId`.
 
 If the same known user visits on a different device, assuming they authenticate immediately, they will have the same `userId` and therefore the same `mbox3rdPartyId`. This means you can target known users across devices.
 
 #### Scenario 3. Anonymous user becomes a known user.
-When the user first arrives on your website, one Adobe Target profile will be created and the `mbox3rdPartyId` will be equal to the Segment `anonymousId`. However, once the user is identified, they will be assigned a new `mbox3rdPartyId` equal to the Segment `userId`. There will be two profiles in Adobe Target; both will be available for targeting.
+When an anonymous user arrives on your website, one Adobe Target profile will be created and the `mbox3rdPartyId` will be equal to the Segment `anonymousId`. However, once the user is identified, they will be assigned a new `mbox3rdPartyId` equal to the Segment `userId`. There will be two profiles in Adobe Target; both will be available for targeting.
 
 ### How to use Adobe Target with Personas
-For information on how to use Adobe Target with Personas, please see [Adobe Target Cloud Mode destination](/docs/connections/destinations/catalog/actions-adobe-target-cloud/).
+For information on how to use Adobe Target with Personas, please see [Adobe Target Cloud Mode destination](/docs/connections/destinations/catalog/actions-adobe-target-cloud/#how-to-use-adobe-target-with-personas).
 
 ## Viewing Segment data in Adobe Target
 To view and use your Segment data in Adobe Target, navigate to **Adobe Target > Audiences > Create Audience > Add Rule**.
 
-- Profile Attributes will appear under the “Visitor Profile” attributes.
-- Page Parameters will appear under “Custom” attributes. Fields will have `page.` prepended to the key.
+- Profile Attributes appear under **Visitor Profile** attributes.
+- Page Parameters appear under **Custom** attributes. Fields have `page.` prepended to the key.
 
-Audiences can then be used in Adobe Target **Activities**, such as A/B Testing and Experience Targeting. Please note that while Standard and Premium Adobe Target packages allow access to the SDK and API, certain personalization functionality may only be available with Adobe Target Premium. 
+Adobe Target Audiences can be used in Activities, such as A/B Testing and Experience Targeting. Please note that while Standard and Premium Adobe Target packages allow access to the SDK and API, certain personalization functionality may only be available with Adobe Target Premium. 

--- a/src/connections/destinations/catalog/actions-adobe-target-web/index.md
+++ b/src/connections/destinations/catalog/actions-adobe-target-web/index.md
@@ -14,8 +14,8 @@ Segment offers two destinations for Adobe Target:
 > info ""
 > The Adobe Target Web destination is in beta and is in active development. Some functionality may change before it becomes generally available.
 
-> success ""
-> **Good to know**: This page is about Segment's Adobe Target Web destination. There's also a page about Segment's [Adobe Target Cloud Mode destination](/docs/connections/destinations/catalog/actions-adobe-target-cloud/).
+> success "Good to know"
+> This page is about Segment's Adobe Target Web destination. There's also a page about Segment's [Adobe Target Cloud Mode destination](/docs/connections/destinations/catalog/actions-adobe-target-cloud/).
 
 ## Getting started
 

--- a/src/connections/destinations/catalog/actions-adobe-target-web/index.md
+++ b/src/connections/destinations/catalog/actions-adobe-target-web/index.md
@@ -12,7 +12,7 @@ Segment offers two destinations for Adobe Target:
 - [Adobe Target Cloud Mode](/docs/connections/destinations/catalog/actions-adobe-target-cloud/)
 
 > info ""
-> This document is about a feature which is in beta. This means that the Adobe Target Web destination is in active development, and some functionality may change before it becomes generally available.
+> The Adobe Target Web destination is in beta and is in active development. Some functionality may change before it becomes generally available.
 
 > success ""
 > **Good to know**: This page is about Segment's Adobe Target Web destination. There's also a page about Segment's [Adobe Target Cloud Mode destination](/docs/connections/destinations/catalog/actions-adobe-target-cloud/).

--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -8,7 +8,7 @@ id: 61957755c4d820be968457de
 Segment’s Salesforce (Actions) destination allows you to create, update or upsert records for any object type. Segment sends data to the [Salesforce REST API](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_rest.htm){:target="_blank"}. 
 
 > info ""
-> This document is about a feature which is in beta. This means that the Salesforce (Actions) destination is in active development, and some functionality may change before it becomes generally available.
+> The Salesforce (Actions) destination is in beta and is in active development. Some functionality may change before it becomes generally available.
 
 > success ""
 > **Good to know**: This page is about the [Actions-framework](/docs/connections/destinations/actions/) Salesforce destination. There's also a page about the [non-Actions Salesforce destination](/docs/connections/destinations/catalog/salesforce/). Both of these destinations receive data _from_ Segment.

--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -10,8 +10,8 @@ Segment’s Salesforce (Actions) destination allows you to create, update or ups
 > info ""
 > The Salesforce (Actions) destination is in beta and is in active development. Some functionality may change before it becomes generally available.
 
-> success ""
-> **Good to know**: This page is about the [Actions-framework](/docs/connections/destinations/actions/) Salesforce destination. There's also a page about the [non-Actions Salesforce destination](/docs/connections/destinations/catalog/salesforce/). Both of these destinations receive data _from_ Segment.
+> success "Good to know"
+> This page is about the [Actions-framework](/docs/connections/destinations/actions/) Salesforce destination. There's also a page about the [non-Actions Salesforce destination](/docs/connections/destinations/catalog/salesforce/). Both of these destinations receive data _from_ Segment.
 
 ## Benefits of Salesforce (Actions) Destination vs Salesforce Destination Classic
 

--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -2,12 +2,13 @@
 title: Salesforce (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-
-beta: true
+strat: salesforce
 id: 61957755c4d820be968457de
 ---
 Segment’s Salesforce (Actions) destination allows you to create, update or upsert records for any object type. Segment sends data to the [Salesforce REST API](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_rest.htm){:target="_blank"}. 
+
+> info ""
+> This document is about a feature which is in beta. This means that the Salesforce (Actions) destination is in active development, and some functionality may change before it becomes generally available.
 
 > success ""
 > **Good to know**: This page is about the [Actions-framework](/docs/connections/destinations/actions/) Salesforce destination. There's also a page about the [non-Actions Salesforce destination](/docs/connections/destinations/catalog/salesforce/). Both of these destinations receive data _from_ Segment.
@@ -25,12 +26,12 @@ The Salesforce (Actions) destination provides the following benefits over the cl
 Before you connect Segment to Salesforce, please ensure you have a Salesforce account with REST API access.
 
 1. From the Segment web app, click **Catalog**, then click **Destinations**.
-2. Search for "Salesforce (Actions)" in the Destinations Catalog, and select the destination.
+2. Search for **Salesforce (Actions)** in the Destinations Catalog, and select the destination.
 3. Click **Configure Salesforce (Actions)** in the top-right corner of the screen.
 4. Select the source that will send data to Salesforce (Actions) and follow the steps to name your destination.
 5. On the **Settings** tab, authenticate with Salesforce using OAuth.
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings). You must select which Event Types and/or Event Names will trigger each mapping.
-7. Enable the Destination and configured Mappings.
+7. Enable the destination and configured mappings.
 
 {% include components/actions-fields.html %}
 
@@ -54,7 +55,7 @@ When using the `update` and `upsert` operations, you must specify the match key(
 - **Standard fields**. To map a standard field, the Salesforce API name should match what is in Salesforce for the given field, for example `Email`.
 - **Custom fields**. To map a custom field, the field needs to be predefined in Salesforce and the Salesforce API name should have `__c` appended to it. 
 
-If multiple field are provided in the Record Matchers object, Segment uses an "OR" operator to query Salesforce for a record. If multiple records are returned upon query, no updates will be made. Segment will instead record a 300 error status for the request, and the request will not be retried. **Please use fields that result in unique records**.
+If multiple fields are provided in the Record Matchers object, Segment uses an "OR" operator to query Salesforce for a record. If multiple records are returned upon query, no updates will be made. Segment will instead record a 300 error status for the request, and the request will not be retried. **Please use fields that result in unique records**.
 
 Please note Salesforce only allows querying on fields that have the "Filter" property. For example, we cannot query on the Case `Description` because it is not a filterable property. You can lookup the standard field properties in [Salesforce’s API documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_rest.htm){:target="_blank"} to determine if a field is available for querying.
 

--- a/src/connections/destinations/catalog/salesforce/index.md
+++ b/src/connections/destinations/catalog/salesforce/index.md
@@ -3,10 +3,14 @@ title: Salesforce Destination
 strat: salesforce
 id: 54521fda25e721e32a72eeef
 ---
-> info ""
-> Segment is aware of Salesforce's plans to enforce multi-factor authentication in 2022, and is evaluating solutions to ensure uninterrupted connectivity with your Salesforce account.
 
 Segment's Salesforce destination allows you to identify leads without using SOAP APIs.
+
+> info ""
+> Segment is aware of Salesforce's plans to enforce multi-factor authentication in 2022, and advises migrating to our new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/) which supports OAuth 2.0.
+
+> success ""
+> **Good to know**: This page is about the classic Salesforce Segment destination. There's also a page about the new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/). Both of these destinations receive data _from_ Segment. We recommend using the new Salesforce (Actions) destination for additional functionality and flexibility.
 
 ### API Access
 

--- a/src/connections/destinations/catalog/salesforce/index.md
+++ b/src/connections/destinations/catalog/salesforce/index.md
@@ -10,7 +10,7 @@ Segment's Salesforce destination allows you to identify leads without using SOAP
 > Segment is aware of Salesforce's plans to enforce multi-factor authentication in 2022, and advises migrating to our new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/) which supports OAuth 2.0.
 
 > success "Good to know"
-> This page is about the classic Salesforce Segment destination. There's also a page about the new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/). Both of these destinations receive data _from_ Segment. We recommend using the new Salesforce (Actions) destination for additional functionality and flexibility.
+> This page is about the classic Salesforce Segment destination. There's also a page about the new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/). Both of these destinations receive data _from_ Segment. Use the new Salesforce (Actions) destination for additional functionality and flexibility.
 
 ### API Access
 

--- a/src/connections/destinations/catalog/salesforce/index.md
+++ b/src/connections/destinations/catalog/salesforce/index.md
@@ -9,8 +9,8 @@ Segment's Salesforce destination allows you to identify leads without using SOAP
 > info ""
 > Segment is aware of Salesforce's plans to enforce multi-factor authentication in 2022, and advises migrating to our new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/) which supports OAuth 2.0.
 
-> success ""
-> **Good to know**: This page is about the classic Salesforce Segment destination. There's also a page about the new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/). Both of these destinations receive data _from_ Segment. We recommend using the new Salesforce (Actions) destination for additional functionality and flexibility.
+> success "Good to know"
+> This page is about the classic Salesforce Segment destination. There's also a page about the new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/). Both of these destinations receive data _from_ Segment. We recommend using the new Salesforce (Actions) destination for additional functionality and flexibility.
 
 ### API Access
 


### PR DESCRIPTION
### Proposed changes
Prepping changes ahead of Public Beta of Salesforce (Actions), Adobe Target Web and Adobe Target Cloud Mode. Public Beta will be 4/26 so we would like these deployed on the Tues, 4/26 deploy. Thanks!

### Merge timing
- On a specific date: April 26

