### PR TITLE
Flag that cloud mode destinations are still supported

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
@@ -8,7 +8,7 @@ id: 9EMcTqiKok
 With Analytics-Kotlin, you can send data using Kotlin applications to any analytics or marketing tool without having to learn, test, or implement a new API every time. Analytics-Kotlin enables you to process and track the history of a payload, while Segment controls the API and prevents unintended operations.
 
 > info ""
-> Segment supports [these destinations](#supported-destinations) in device-mode, with more to follow. Cloud-mode destiantions are also supported. If you don't see your destination, you can [build your own](#build-your-own-destination).
+> Segment supports [these destinations](#supported-destinations) in device-mode, with more to follow. Cloud-mode destinations are also supported. If you don't see your destination, you can [build your own](#build-your-own-destination).
 
 > success ""
 > You can choose to set up your Analytics Kotlin source on [mobile](/docs/connections/sources/catalog/libraries/mobile/kotlin-android) or on the [server](/docs/connections/sources/catalog/libraries/server/kotlin). Segment doesn't support device-mode destinations on the server-side.

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
@@ -8,7 +8,7 @@ id: 9EMcTqiKok
 With Analytics-Kotlin, you can send data using Kotlin applications to any analytics or marketing tool without having to learn, test, or implement a new API every time. Analytics-Kotlin enables you to process and track the history of a payload, while Segment controls the API and prevents unintended operations.
 
 > info ""
-> Segment supports [these destinations](#supported-destinations) with more to come. If you don't see your destination, you can [build your own](#build-your-own-destination).
+> Segment supports [these destinations](#supported-destinations) in device-mode, with more to follow. Cloud-mode destiantions are also supported. If you don't see your destination, you can [build your own](#build-your-own-destination).
 
 > success ""
 > You can choose to set up your Analytics Kotlin source on [mobile](/docs/connections/sources/catalog/libraries/mobile/kotlin-android) or on the [server](/docs/connections/sources/catalog/libraries/server/kotlin). Segment doesn't support device-mode destinations on the server-side.

--- a/src/connections/sources/catalog/libraries/mobile/react-native/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/index.md
@@ -492,7 +492,7 @@ These are the example plugins you can use and alter to meet your tracking needs:
 | IDFA                | `@segment/analytics-react-native-plugin-idfa`                |
 
 ## Supported Destinations
-Segment supports these destinations for Analytics React Native 2.0 with more to come:
+Segment supports these destinations for Analytics React Native 2.0 in device-mode, with more to follow. Cloud-mode destiantions are also supported:
 - [Adjust](https://www.npmjs.com/package/@segment/analytics-react-native-plugin-adjust){:target="_blank"}
 - [Amplitude Session](https://www.npmjs.com/package/@segment/analytics-react-native-plugin-amplitude-session){:target="_blank"}
 - [Appsflyer](https://www.npmjs.com/package/@segment/analytics-react-native-plugin-appsflyer){:target="_blank"}

--- a/src/connections/sources/catalog/libraries/mobile/react-native/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/index.md
@@ -492,7 +492,7 @@ These are the example plugins you can use and alter to meet your tracking needs:
 | IDFA                | `@segment/analytics-react-native-plugin-idfa`                |
 
 ## Supported Destinations
-Segment supports these destinations for Analytics React Native 2.0 in device-mode, with more to follow. Cloud-mode destiantions are also supported:
+Segment supports these destinations for Analytics React Native 2.0 in device-mode, with more to follow. Cloud-mode destinations are also supported:
 - [Adjust](https://www.npmjs.com/package/@segment/analytics-react-native-plugin-adjust){:target="_blank"}
 - [Amplitude Session](https://www.npmjs.com/package/@segment/analytics-react-native-plugin-amplitude-session){:target="_blank"}
 - [Appsflyer](https://www.npmjs.com/package/@segment/analytics-react-native-plugin-appsflyer){:target="_blank"}

--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -10,7 +10,7 @@ With Analytics-Swift, you can send data from iOS, tvOS, iPadOS, WatchOS, macOS a
 If you're migrating to Analytics-Swift from a different mobile library, you can skip to the [migration guide](/docs/connections/sources/catalog/libraries/mobile/swift-ios/migration/).
 
 > info ""
-> Analytics-Swift currently supports [these destinations](#supported-destinations) in device-mode, with more to follow. Cloud-mode destiantions are also supported.
+> Analytics-Swift currently supports [these destinations](#supported-destinations) in device-mode, with more to follow. Cloud-mode destinations are also supported.
 
 
 ## Getting Started

--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -10,7 +10,7 @@ With Analytics-Swift, you can send data from iOS, tvOS, iPadOS, WatchOS, macOS a
 If you're migrating to Analytics-Swift from a different mobile library, you can skip to the [migration guide](/docs/connections/sources/catalog/libraries/mobile/swift-ios/migration/).
 
 > info ""
-> Analytics-Swift currently supports [these destinations](#supported-destinations), with more to follow.
+> Analytics-Swift currently supports [these destinations](#supported-destinations) in device-mode, with more to follow. Cloud-mode destiantions are also supported.
 
 
 ## Getting Started


### PR DESCRIPTION
### Proposed changes
Hey @markzegarelli  get your thoughts on this? I think there's bit of a disconnect with customers on what is supported for our new mobile SDKs. I want to flag that the integrations we list are device mode, but all historical cloud destinations are still supported. 
