### PR TITLE
Replace possessive with plural (ID's to IDs)

### DIFF
--- a/src/_includes/content/spec-identities.md
+++ b/src/_includes/content/spec-identities.md
@@ -2,4 +2,4 @@ The User ID is a unique identifier for the user performing the actions. Check ou
 
 The Anonymous ID can be any pseudo-unique identifier, for cases where you don't know who the user is, but you still want to tie them to an event. Check out the [Anonymous ID docs](/docs/connections/spec/identify#anonymous-id) for more detail.
 
-**Note: In our browser and mobile libraries a User ID is automatically added** from the state stored by a previous [`identify`](/docs/connections/spec/identify/) call, so you do not need to add it yourself. They will also automatically handle Anonymous ID's under the covers.
+**Note: In our browser and mobile libraries a User ID is automatically added** from the state stored by a previous [`identify`](/docs/connections/spec/identify/) call, so you do not need to add it yourself. They will also automatically handle Anonymous IDs under the covers.


### PR DESCRIPTION
It's a small change, but wanted to give editing the Segment docs a go!

### Proposed changes
Found a minor typo where a possessive `'s` was used when a plural `s` was intended. Very minor, I am more just wrapping my head around the open source Segment docs workflow!

### Merge timing
Whenever anyone has a chance.
