### PR TITLE
Fix Firebase link

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -404,7 +404,7 @@ Segment supports these destinations for Analytics Swift, with more to come:
 * [Amplitude](https://github.com/segment-integrations/analytics-swift-amplitude)
 * [Appsflyer](https://github.com/segment-integrations/analytics-swift-appsflyer)
 * [Facebook App Events](https://github.com/segment-integrations/analytics-swift-facebook-app-events)
-* [Firebase](https://github.com/segment-integrations/analytics-swift-facebook-app-events)
+* [Firebase](https://github.com/segment-integrations/analytics-swift-firebase)
 * [Mixpanel](https://github.com/segment-integrations/analytics-swift-mixpanel)
 
 


### PR DESCRIPTION
### Proposed changes
Incorrect link in our Swift docs for Firebase: https://segment.com/docs/connections/sources/catalog/libraries/mobile/swift-ios/#supported-destinations