### PR TITLE
Update GA4 Docs Session ID and Session Number

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -81,6 +81,20 @@ The Google Analytics 4 reports only display active users who engage with your si
 
 If you choose to integrate with Google Analytics 4 client-side (using Gtag outside of Segment) _and_ also use Segment's Google Analytics 4 destination to send events through the API, you can track sessions server-side. When using Gtag, [Google generates a `session_id` and `session_number` when a session begins](https://support.google.com/analytics/answer/9191807?hl=en){:target='_blank'}. The `session_id` and `session_number` generated on the client can be passed as Event Parameters to stitch events sent through the API with the same session that was collected client-side.
 
+Ripping off that old section we could maybe add this line at the end of the Session section:
+You can double-check your session_id and session_number with the [Google Site Tag function](https://developers.google.com/tag-platform/gtagjs/reference) or by running this script in your JavaScript console and replacing G-xxxxxxxxxx with your GA4 measurement ID:
+```const sessionIdPromise = new Promise(resolve => {
+  gtag('get', 'G-xxxxxxxxxx', 'session_id', resolve)
+});
+const sessionNumPromise = new Promise(resolve => {
+  gtag('get', 'G-xxxxxxxxxx', 'session_number', resolve)
+});
+
+Promise.all([sessionIdPromise, sessionNumPromise]).then(function(session_data) {
+  console.log("session ID: "+session_data[0]);
+  console.log("session Number: "+session_data[1]);
+});```
+
 > info "Session tracking limitations"
 > Session tracking server-side only works if you're also sending data to Google Analytics 4 client-side. This is because the `session_id` must match a value that was previously collected on the client. For events to stitch properly, they must arrive within a 48 hour window of when the client-side events arrived.
 >

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -82,6 +82,7 @@ The Google Analytics 4 reports only display active users who engage with your si
 If you choose to integrate with Google Analytics 4 client-side (using Gtag outside of Segment) _and_ also use Segment's Google Analytics 4 destination to send events through the API, you can track sessions server-side. When using Gtag, [Google generates a `session_id` and `session_number` when a session begins](https://support.google.com/analytics/answer/9191807?hl=en){:target='_blank'}. The `session_id` and `session_number` generated on the client can be passed as Event Parameters to stitch events sent through the API with the same session that was collected client-side.
 
 You can double-check your session_id and session_number with the [Google Site Tag function](https://developers.google.com/tag-platform/gtagjs/reference){:target='_blank'} or by running this script in your JavaScript console and replacing `G-xxxxxxxxxx` with your GA4 measurement ID:
+
 ```java
 const sessionIdPromise = new Promise(resolve => {
   gtag('get', 'G-xxxxxxxxxx', 'session_id', resolve)
@@ -94,6 +95,7 @@ Promise.all([sessionIdPromise, sessionNumPromise]).then(function(session_data) {
   console.log("session ID: "+session_data[0]);
   console.log("session Number: "+session_data[1]);
 });
+```
 
 > info "Session tracking limitations"
 > Session tracking server-side only works if you're also sending data to Google Analytics 4 client-side. This is because the `session_id` must match a value that was previously collected on the client. For events to stitch properly, they must arrive within a 48 hour window of when the client-side events arrived.

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -81,8 +81,8 @@ The Google Analytics 4 reports only display active users who engage with your si
 
 If you choose to integrate with Google Analytics 4 client-side (using Gtag outside of Segment) _and_ also use Segment's Google Analytics 4 destination to send events through the API, you can track sessions server-side. When using Gtag, [Google generates a `session_id` and `session_number` when a session begins](https://support.google.com/analytics/answer/9191807?hl=en){:target='_blank'}. The `session_id` and `session_number` generated on the client can be passed as Event Parameters to stitch events sent through the API with the same session that was collected client-side.
 
-You can double-check your session_id and session_number with the [Google Site Tag function](https://developers.google.com/tag-platform/gtagjs/reference) or by running this script in your JavaScript console and replacing G-xxxxxxxxxx with your GA4 measurement ID:
-```
+You can double-check your session_id and session_number with the [Google Site Tag function](https://developers.google.com/tag-platform/gtagjs/reference){:target='_blank'} or by running this script in your JavaScript console and replacing `G-xxxxxxxxxx` with your GA4 measurement ID:
+```java
 const sessionIdPromise = new Promise(resolve => {
   gtag('get', 'G-xxxxxxxxxx', 'session_id', resolve)
 });
@@ -94,7 +94,6 @@ Promise.all([sessionIdPromise, sessionNumPromise]).then(function(session_data) {
   console.log("session ID: "+session_data[0]);
   console.log("session Number: "+session_data[1]);
 });
-```
 
 > info "Session tracking limitations"
 > Session tracking server-side only works if you're also sending data to Google Analytics 4 client-side. This is because the `session_id` must match a value that was previously collected on the client. For events to stitch properly, they must arrive within a 48 hour window of when the client-side events arrived.

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -93,7 +93,8 @@ const sessionNumPromise = new Promise(resolve => {
 Promise.all([sessionIdPromise, sessionNumPromise]).then(function(session_data) {
   console.log("session ID: "+session_data[0]);
   console.log("session Number: "+session_data[1]);
-});```
+});
+```
 
 > info "Session tracking limitations"
 > Session tracking server-side only works if you're also sending data to Google Analytics 4 client-side. This is because the `session_id` must match a value that was previously collected on the client. For events to stitch properly, they must arrive within a 48 hour window of when the client-side events arrived.

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -82,7 +82,8 @@ The Google Analytics 4 reports only display active users who engage with your si
 If you choose to integrate with Google Analytics 4 client-side (using Gtag outside of Segment) _and_ also use Segment's Google Analytics 4 destination to send events through the API, you can track sessions server-side. When using Gtag, [Google generates a `session_id` and `session_number` when a session begins](https://support.google.com/analytics/answer/9191807?hl=en){:target='_blank'}. The `session_id` and `session_number` generated on the client can be passed as Event Parameters to stitch events sent through the API with the same session that was collected client-side.
 
 You can double-check your session_id and session_number with the [Google Site Tag function](https://developers.google.com/tag-platform/gtagjs/reference) or by running this script in your JavaScript console and replacing G-xxxxxxxxxx with your GA4 measurement ID:
-```const sessionIdPromise = new Promise(resolve => {
+```
+const sessionIdPromise = new Promise(resolve => {
   gtag('get', 'G-xxxxxxxxxx', 'session_id', resolve)
 });
 const sessionNumPromise = new Promise(resolve => {

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -81,7 +81,6 @@ The Google Analytics 4 reports only display active users who engage with your si
 
 If you choose to integrate with Google Analytics 4 client-side (using Gtag outside of Segment) _and_ also use Segment's Google Analytics 4 destination to send events through the API, you can track sessions server-side. When using Gtag, [Google generates a `session_id` and `session_number` when a session begins](https://support.google.com/analytics/answer/9191807?hl=en){:target='_blank'}. The `session_id` and `session_number` generated on the client can be passed as Event Parameters to stitch events sent through the API with the same session that was collected client-side.
 
-Ripping off that old section we could maybe add this line at the end of the Session section:
 You can double-check your session_id and session_number with the [Google Site Tag function](https://developers.google.com/tag-platform/gtagjs/reference) or by running this script in your JavaScript console and replacing G-xxxxxxxxxx with your GA4 measurement ID:
 ```const sessionIdPromise = new Promise(resolve => {
   gtag('get', 'G-xxxxxxxxxx', 'session_id', resolve)


### PR DESCRIPTION
### Proposed changes
With the latest changes to the Google Measurement API, session data can now be sent to GA4 once the session_id and session_number are sent in the payload. Finding this data can be difficult for customers given that retrieving these values is not explicitly linked to the GA4 docs anywhere. This addition to our docs includes a working code example of how to retrieve these values from a site using gtag.

To test this code, I used the following GA4 property:
![image](https://user-images.githubusercontent.com/89840737/169301841-7ed62444-136a-430f-bb10-bad01ba04ff6.png)
Installed the property on a locally hosted webpage:
<img width="669" alt="image" src="https://user-images.githubusercontent.com/89840737/169302049-18d4eaf2-d0dc-47e5-823f-34febddb760d.png">
Running the code in the console resulted in this output:
<img width="567" alt="image" src="https://user-images.githubusercontent.com/89840737/169303833-d23fb583-5c1a-447c-9ff8-f759444fc3a2.png">

Matching the session ID and Number for the session_start event in the GA4 real-time report:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/89840737/169303624-1cb19545-3030-438b-ba12-4a6b825f24e0.png">
<img width="371" alt="image" src="https://user-images.githubusercontent.com/89840737/169303745-b85656e5-e4d5-4b84-a974-abc31269c0f6.png">



### Merge timing
- ASAP once approved

