### PR TITLE
Fix typo in URL

### DIFF
--- a/src/connections/destinations/catalog/mouseflow/index.md
+++ b/src/connections/destinations/catalog/mouseflow/index.md
@@ -3,7 +3,7 @@ rewrite: true
 title: Mouseflow Destination
 id: 54521fd925e721e32a72eeda
 ---
-[Mouseflow](https://mouseflow.com/) is a session replay and heatmap tool that shows how visitors click, move, scroll, browse, and pay attention on websites. It helps clients simplify their analytics to make decisions that matter. The `analytics.js` Mouseflow Destination is open-source. You can browse the code [on GitHub](hhttps://github.com/segment-integrations/analytics.js-integration-mouseflow).
+[Mouseflow](https://mouseflow.com/) is a session replay and heatmap tool that shows how visitors click, move, scroll, browse, and pay attention on websites. It helps clients simplify their analytics to make decisions that matter. The `analytics.js` Mouseflow Destination is open-source. You can browse the code [on GitHub](https://github.com/segment-integrations/analytics.js-integration-mouseflow).
 
 ## Getting Started
 


### PR DESCRIPTION
Updated the URL to the Mouseflow destination Github repo because it had a typo `hhtps`.

### Proposed changes

This PR fixes a typo in the URL of the Mouseflow destination Github repo in the Segment docs.

### Merge timing

- ASAP once approved
