### PR TITLE
Update Salesforce docs ahead of Salesforce (Actions) GA Launch 6/15

### DIFF
--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -7,9 +7,6 @@ id: 61957755c4d820be968457de
 ---
 Segment’s Salesforce (Actions) destination allows you to create, update or upsert records for any object type. Segment sends data to the [Salesforce REST API](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_rest.htm){:target="_blank"}. 
 
-> info ""
-> The Salesforce (Actions) destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 > success "Good to know"
 > This page is about the [Actions-framework](/docs/connections/destinations/actions/) Salesforce destination. There's also a page about the [non-Actions Salesforce destination](/docs/connections/destinations/catalog/salesforce/). Both of these destinations receive data _from_ Segment.
 

--- a/src/connections/destinations/catalog/salesforce/index.md
+++ b/src/connections/destinations/catalog/salesforce/index.md
@@ -2,15 +2,13 @@
 title: Salesforce Destination
 strat: salesforce
 id: 54521fda25e721e32a72eeef
+maintenance: true
 ---
 
-Segment's Salesforce destination allows you to identify leads without using SOAP APIs.
+Segment's Salesforce destination allows you to create and store leads and records for other objects in Salesforce Sales Cloud.
 
 > info ""
 > Segment is aware of Salesforce's plans to enforce multi-factor authentication in 2022, and advises migrating to our new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/) which supports OAuth 2.0.
-
-> success "Good to know"
-> This page is about the classic Salesforce Segment destination. There's also a page about the new [Salesforce (Actions) destination](/docs/connections/destinations/catalog/actions-salesforce/). Both of these destinations receive data _from_ Segment. Use the new Salesforce (Actions) destination for additional functionality and flexibility.
 
 ### API Access
 
@@ -27,7 +25,7 @@ Also make sure that IP Security is disabled in this Salesforce user account. Thi
 
 ## Identify
 
-This destination supports the most important pain point for Salesforce users: getting your prospective customers into Salesforce as Leads from your website or mobile app. Creating/updating Leads is the default behavior of `identify` events. If you would like to customize this you can do so using [Actions](#custom-actions)
+This destination supports the most important pain point for Salesforce users: getting your prospective customers into Salesforce as Leads from your website or mobile app. Creating/updating Leads is the default behavior of `identify` events. If you would like to customize this you can do so using [Actions](#custom-actions).
 
 ### Identifying a Lead
 


### PR DESCRIPTION
### Proposed changes
StratConn is moving Salesforce (Actions) to GA on June 15. These changes (1) update Salesforce (Actions) docs to remove "beta" mention and (2) update Salesforce classic docs to include maintenance mode.

### Merge timing
- On a specific date - please deploy on June 14 release so these are ready on June 15 morning. Thanks!

### Related issues (optional)
https://segment.atlassian.net/browse/STRATCONN-1294
