### PR TITLE
fix kotlin outdated info

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
@@ -203,25 +203,6 @@ analytics.group("user-123", buildJsonObject {
 {% endcodeexampletab %}
 {% endcodeexample %}
 
-## Utility Methods
-
-### Reset
-The `reset` method clears the SDK’s internal stores for the current user and group. This is useful for apps where users log in and out with different identities on the same device over time. 
-
-{% codeexample %}
-{% codeexampletab Method signature %}
-```java
-fun reset()
-```
-{% endcodeexampletab %}
-
-{% codeexampletab Example use %}
-```java
-analytics.reset()
-```
-{% endcodeexampletab %}
-{% endcodeexample %}
-
 ## Plugin Architecture
 Segment's plugin architecture enables you to modify and augment how the analytics client works. From modifying event payloads to changing analytics functionality, plugins help to speed up the process of getting things done.
 
@@ -365,6 +346,7 @@ The Analytics-Kotlin utility methods help you work with plugins from the analyti
 - [Add](#add)
 - [Find](#find)
 - [Remove](#remove)
+- [Reset](#reset)
 
 There's also the [Flush](#flush) method to help you manage the current queue of events.
 
@@ -437,6 +419,23 @@ public fun flush()
 {% codeexampletab Example use %}
 ```java
 analytics.flush("SomePlugin")
+```
+{% endcodeexampletab %}
+{% endcodeexample %}
+
+### Reset
+The `reset` method clears the SDK’s internal stores for the current user and group. This is useful for apps where users log in and out with different identities on the same device over time.
+
+{% codeexample %}
+{% codeexampletab Method signature %}
+```java
+fun reset()
+```
+{% endcodeexampletab %}
+
+{% codeexampletab Example use %}
+```java
+analytics.reset()
 ```
 {% endcodeexampletab %}
 {% endcodeexample %}

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
@@ -203,6 +203,25 @@ analytics.group("user-123", buildJsonObject {
 {% endcodeexampletab %}
 {% endcodeexample %}
 
+## Utility Methods
+
+### Reset
+The `reset` method clears the SDK’s internal stores for the current user and group. This is useful for apps where users log in and out with different identities on the same device over time. 
+
+{% codeexample %}
+{% codeexampletab Method signature %}
+```java
+fun reset()
+```
+{% endcodeexampletab %}
+
+{% codeexampletab Example use %}
+```java
+analytics.reset()
+```
+{% endcodeexampletab %}
+{% endcodeexample %}
+
 ## Plugin Architecture
 Segment's plugin architecture enables you to modify and augment how the analytics client works. From modifying event payloads to changing analytics functionality, plugins help to speed up the process of getting things done.
 

--- a/src/connections/sources/catalog/libraries/server/kotlin/index.md
+++ b/src/connections/sources/catalog/libraries/server/kotlin/index.md
@@ -176,25 +176,6 @@ analytics.group("user-123", buildJsonObject {
 {% endcodeexampletab %}
 {% endcodeexample %}
 
-## Utility Methods
-
-### Reset
-The `reset` method clears the SDK’s internal stores for the current user and group. This is useful for apps where users log in and out with different identities on the same device over time. 
-
-{% codeexample %}
-{% codeexampletab Method signature %}
-```java
-fun reset()
-```
-{% endcodeexampletab %}
-
-{% codeexampletab Example use %}
-```java
-analytics.reset()
-```
-{% endcodeexampletab %}
-{% endcodeexample %}
-
 ## Plugin Architecture
 Segment's plugin architecture enables you to modify and augment how the analytics client works. From modifying event payloads to changing analytics functionality, plugins help to speed up the process of getting things done.
 
@@ -338,6 +319,7 @@ The Analytics-Kotlin utility methods help you work with plugins from the analyti
 - [Add](#add)
 - [Find](#find)
 - [Remove](#remove)
+- [Reset](#reset)
 
 There's also the [Flush](#flush) method to help you manage the current queue of events.
 
@@ -410,6 +392,23 @@ public fun flush()
 {% codeexampletab Example use %}
 ```java
 analytics.flush("SomePlugin")
+```
+{% endcodeexampletab %}
+{% endcodeexample %}
+
+### Reset
+The `reset` method clears the SDK’s internal stores for the current user and group. This is useful for apps where users log in and out with different identities on the same device over time.
+
+{% codeexample %}
+{% codeexampletab Method signature %}
+```java
+fun reset()
+```
+{% endcodeexampletab %}
+
+{% codeexampletab Example use %}
+```java
+analytics.reset()
 ```
 {% endcodeexampletab %}
 {% endcodeexample %}

--- a/src/connections/sources/catalog/libraries/server/kotlin/index.md
+++ b/src/connections/sources/catalog/libraries/server/kotlin/index.md
@@ -198,7 +198,7 @@ analytics.reset()
 ## Plugin Architecture
 Segment's plugin architecture enables you to modify and augment how the analytics client works. From modifying event payloads to changing analytics functionality, plugins help to speed up the process of getting things done.
 
-Plugins are run through a timeline, which executes in order of insertion based on their entry types. Segment has these 5 entry types:
+Plugins are run through a timeline, which executes in order of insertion based on their entry types. Segment has these five entry types:
 
 | Type          | Details                                                                                        |
 | ------------- | ---------------------------------------------------------------------------------------------- |

--- a/src/connections/sources/catalog/libraries/server/kotlin/index.md
+++ b/src/connections/sources/catalog/libraries/server/kotlin/index.md
@@ -22,7 +22,7 @@ To get started with the Analytics-Kotlin server library:
 
 2.  Add the Analytics dependency to your `build.gradle`.
 
-      Segment recommends you to install the library with a build system like Gradle, as it simplifies the process of upgrading versions and adding integrations. The library is distributed through [Jitpack](https://jitpack.io/){:target="_blank"}. Add the analytics module to your build.gradle as a dependency as shown in the code sample below.
+      Segment recommends you to install the library with a build system like Gradle, as it simplifies the process of upgrading versions and adding integrations. The library is distributed through [Maven Central](https://repo1.maven.org/maven2/com/segment/analytics/kotlin/android/){:target="_blank"}. Add the analytics module to your build.gradle as a dependency as shown in the code sample below, and replace `<latest_version>` with the latest version listed on Segment's [releases page](https://github.com/segmentio/analytics-kotlin/releases){:target="_blank"}
 
       ```java
       repositories {

--- a/src/connections/sources/catalog/libraries/server/kotlin/index.md
+++ b/src/connections/sources/catalog/libraries/server/kotlin/index.md
@@ -25,12 +25,12 @@ To get started with the Analytics-Kotlin server library:
       Segment recommends you to install the library with a build system like Gradle, as it simplifies the process of upgrading versions and adding integrations. The library is distributed through [Maven Central](https://repo1.maven.org/maven2/com/segment/analytics/kotlin/android/){:target="_blank"}. Add the analytics module to your build.gradle as a dependency as shown in the code sample below, and replace `<latest_version>` with the latest version listed on Segment's [releases page](https://github.com/segmentio/analytics-kotlin/releases){:target="_blank"}
 
       ```java
-      repositories {
-        maven { url 'https://jitpack.io' }
-      }
-      dependencies {
-          implementation 'com.github.segmentio.analytics-kotlin:core:+'
-      }
+        repositories {
+            mavenCentral()
+        }
+        dependencies {
+            implementation 'com.segment.analytics.kotlin:core:<latest_version>'
+        }
       ```
 3. Initialize and configure the client.
 
@@ -172,6 +172,25 @@ analytics.group("user-123", buildJsonObject {
     put("email", "hello@test.com")
     put("plan", "premium")
 });
+```
+{% endcodeexampletab %}
+{% endcodeexample %}
+
+## Utility Methods
+
+### Reset
+The `reset` method clears the SDK’s internal stores for the current user and group. This is useful for apps where users log in and out with different identities on the same device over time. 
+
+{% codeexample %}
+{% codeexampletab Method signature %}
+```java
+fun reset()
+```
+{% endcodeexampletab %}
+
+{% codeexampletab Example use %}
+```java
+analytics.reset()
 ```
 {% endcodeexampletab %}
 {% endcodeexample %}

--- a/src/connections/sources/catalog/libraries/server/kotlin/index.md
+++ b/src/connections/sources/catalog/libraries/server/kotlin/index.md
@@ -22,7 +22,7 @@ To get started with the Analytics-Kotlin server library:
 
 2.  Add the Analytics dependency to your `build.gradle`.
 
-      Segment recommends you to install the library with a build system like Gradle, as it simplifies the process of upgrading versions and adding integrations. The library is distributed through [Maven Central](https://repo1.maven.org/maven2/com/segment/analytics/kotlin/android/){:target="_blank"}. Add the analytics module to your build.gradle as a dependency as shown in the code sample below, and replace `<latest_version>` with the latest version listed on Segment's [releases page](https://github.com/segmentio/analytics-kotlin/releases){:target="_blank"}
+      Segment recommends you to install the library with a build system like Gradle, as it simplifies the process of upgrading versions and adding integrations. The library is distributed through [Maven Central](https://repo1.maven.org/maven2/com/segment/analytics/kotlin/android/){:target="_blank"}. Add the analytics module to your build.gradle as a dependency as shown in the code sample below, and replace `<latest_version>` with the latest version listed on Segment's [releases page](https://github.com/segmentio/analytics-kotlin/releases){:target="_blank"}.
 
       ```java
         repositories {


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->
the kotlin-server page has outdated setup info that misleads people to use the outdated version of sdk. this pr updates that info also added a section of a new api `reset`

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->
ASAP once approved 

### Related issues (optional)
segmentio/analytics-kotlin#85
<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
