### PR TITLE
Clarify HTTP API Rate Limits [DOC-534] 

### DIFF
--- a/src/_includes/content/troubleshooting-intro.md
+++ b/src/_includes/content/troubleshooting-intro.md
@@ -1,2 +1,1 @@
-If you're having trouble we have a few tips that help common problems.
-
+The following tips often help resolve common issues.

--- a/src/_includes/menu/menu.html
+++ b/src/_includes/menu/menu.html
@@ -26,7 +26,7 @@
           </a>
         </li>
 
-        <!-- <li class="menu-item {% if currentPage == "release-notes" %}menu-item--active{% endif %}">
+        <li class="menu-item">
           <a class="menu-item__link menu-item__link--highlight menu-item__link--icon flex flex--middle" href="https://segment.com/release-notes/" target="_blank">
             <div class="menu-item__icon flex__column">
               {% include icons/megaphone.svg %}
@@ -34,7 +34,7 @@
 
             <div class="flex__column">Release Notes</div>
           </a>
-        </li> -->
+        </li>
 
         <li class="menu-item menu-item--separated">
           <a class="menu-item__link menu-item__link--small menu-item__link--highlight" href="https://segment.com/">Back to Segment.com</a>

--- a/src/connections/sources/catalog/libraries/server/http-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/http-api/index.md
@@ -28,7 +28,7 @@ Segment welcomes feedback on API responses and error messages. [Reach out to sup
 
 ## Rate Limits
 
-There is no hard rate limit at which point Segment will drop your data. [Contact support](https://segment.com/help/contact/) if you need to import at a rate exceeding 500 requests per second. Requests include batches sent with the [batch method](#batch), which means you can send a large batch of events inside of a single request.
+The HTTP API has no hard rate limit. However, Segment recommends not exceeding 500 requests per second, including large groups of events sent with a single [`batch` request](#batch).
 
 ## Max Request Size
 
@@ -182,7 +182,7 @@ Find details on the **`screen` payload** in our [Spec](/docs/connections/spec/sc
 
 ## Group
 
-`group` lets you associate an [identified user](/docs/connections/sources/catalog/libraries/server/node/#identify) with a group. A group could be a company, organization, account, project or team! It also lets you record custom traits about the group, like industry or number of employees.
+`group` lets you associate an [identified user](/docs/connections/sources/catalog/libraries/server/node/#identify) with a group. A group could be a company, organization, account, project, or team. It also lets you record custom traits about the group, like industry or number of employees.
 
 This is useful for tools like [Intercom](/docs/connections/destinations/catalog/intercom/), [Preact](/docs/connections/destinations/catalog/preact/) and [Totango](/docs/connections/destinations/catalog/totango/), as it ties the user to a **group** of other users.
 
@@ -255,7 +255,7 @@ You can import historical data by adding the `timestamp` argument to any of your
 
 Historical imports can only be done into destinations that can accept historical timestamped data. Most analytics tools like Mixpanel, Amplitude, and Kissmetrics can handle that type of data just fine. One common destination that does not accept historical data is Google Analytics since their API cannot accept historical data.
 
-**Note:** If you're tracking things that are happening right now, leave out the `timestamp` and our servers will timestamp the requests for you.
+**Note:** If you're tracking things that are happening right now, leave out the `timestamp` and Segment servers will timestamp the requests for you.
 
 ## Batch
 
@@ -400,6 +400,6 @@ When sending a HTTP call from a user's device, you can collect the IP address by
 
 1. Double check that you've set up the library correctly.
 
-2. Make sure that you're calling one of our API methods once the library is successfully installed—[`identify`](#identify), [`track`](#track), and so on.
+2. Make sure that you're calling a Segment API method once the library is successfully installed—[`identify`](#identify), [`track`](#track), and so on.
 
 {% include content/troubleshooting-server-integration.md %}


### PR DESCRIPTION
### Proposed changes

- Clarified that the HTTP API has no hard limits.
- Removed advice to contact support if requests exceed 500 per second.
- Removed first-person plural from troubleshooting content.

### Merge timing

- ASAP once approved.