### PR TITLE
Unhide Snapchat CAPI docs before Public Beta

### DIFF
--- a/src/connections/destinations/catalog/actions-snap-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-snap-conversions/index.md
@@ -2,7 +2,6 @@
 title: Snapchat Conversions API (Actions)
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
 private: true
 id: 6261a8b6cb4caa70e19116e8
 ---


### PR DESCRIPTION
### Proposed changes
unhiding these docs ahead of Public Beta on Wed 6/29.

### Merge timing
- ASAP once approved - I would like this included in the Tues 6/28 deploy so that it's visible come Wed 6/29 morning. Thanks!

### Related issues (optional)
https://segment.atlassian.net/browse/STRATCONN-1464
