### PR TITLE
Add Randomized Splits to Engage [DOC-537]

### DIFF
--- a/src/engage/journeys/build-journey.md
+++ b/src/engage/journeys/build-journey.md
@@ -99,6 +99,32 @@ Use Engage to send an SMS message as a step in a Journey.
 
 As soon as a `subscribed` user enters the Send SMS step, they'll receive the text. Visit [SMS Campaigns](/docs/engage/campaigns/sms-campaigns/) for more information.
 
+## Randomized splits
+
+> info ""
+> The randomized splits step is in beta and available to users with a Personas Advanced plan.
+
+A randomized split lets you experiment with and test the performance of a Journey's branches. When you create a randomized split, you add up to five Journey branches, each with a different step. Journeys then sends eligible users down one of the branches at random. Each branch receives a portion of the eligible users based on percentages that you assign to the branches.
+
+To test your messaging channels, for example, you might create a randomized split with three different branches, assigning 40% of users to an email campaign, 40% to an SMS campaign, and 20% to a control group. Once users flow through the split, you can determine the success of the email and SMS campaigns compared to each other and the control group.
+
+### Add a randomized split
+
+Follow these steps to add a randomized split to a Journey:
+
+1. Create a new Journey, and [add an entry condition](#adding-the-entry-condition).
+2. Select the **+** icon to add a step, then select **Create a randomized split**.
+3. Name the randomized split step, then add up to five branches.
+4. Set the distribution percentage for each branch, then select **Save**.
+5. For each branch in the split, select the child **+** icon and add a step.
+3. Save and publish your Journey.
+
+Users who meet the Journey's entry condition will then enter the Journey and flow through the randomized split.
+
+### Act on the split's results
+
+Once users complete your Journey's randomized split step, you'll have insight into how each split performed. You can take action on the results by cloning the Journey and sending a new set of users through the highest performing branch.
+
 ## Cloning a Journey
 
 To clone a Journey:

--- a/src/engage/profiles/user-subscriptions/set-user-subscriptions.md
+++ b/src/engage/profiles/user-subscriptions/set-user-subscriptions.md
@@ -27,7 +27,7 @@ These columns take the following values:
 
 - `subscribed`; for users who opted in to your marketing campaigns
 - `unsubscribed`; for users who have unsubscribed from your marketing campaigns
-- `did_not_subscribe`; for users who have neither subscribed nor unsubscribed from your marketing campaigns
+- `did-not-subscribe`; for users who have neither subscribed nor unsubscribed from your marketing campaigns
 - Blank; for profiles that have no subscription information
 
 Refer to the [User Subscription States documentation](/docs/engage/profiles/user-subscriptions/subscription-states/) for detailed explanations of each subscription state.


### PR DESCRIPTION
### Proposed changes

- Added randomized splits content to Engage Journeys instance.
- Changed `did_not_subscribe` to `did-not-subscribe` in user subscriptions page.

### Merge timing

- ASAP once approved.