### PR TITLE
Remove region unsupported box

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/customer-io/index.md
+++ b/src/connections/sources/catalog/cloud-apps/customer-io/index.md
@@ -3,7 +3,6 @@ title: Customer.io Source
 redirect_from: "/connections/sources/catalog/cloud-apps/customer.io/"
 id: sTypQz3Fd2
 ---
-{% include content/source-region-unsupported.md %}
 
 [Customer.io](https://customer.io/) is an automated email tool. It lets you set up rules to automatically send emails to your users after they perform actions, making drip email campaigns really easy.
 


### PR DESCRIPTION
### Proposed changes
Removed {% include content/source-region-unsupported.md %}, as Customer.io's UI now enables customers to select which of Segment's data ingestion endpoints they want to use. I updated code to enable customers in EU workspaces to use this source

### Merge timing
- ASAP once approved