### PR TITLE
Add required variable to Swift documentation

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -33,6 +33,8 @@ To get started with the Analytics-Swift mobile library:
     For example, in a lifecycle method such as `didFinishLaunchingWithOptions` in iOS:
 
     ```swift
+    var analytics: Analytics? = nil
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
             // Override point for customization after application launch.
             let configuration = Configuration(writeKey: "WRITE_KEY")


### PR DESCRIPTION
### Proposed changes
A customer was running into a build issue as they did not define the analytics var. Adding this to our docs to be more explicit.

