### PR TITLE
fixes duplicate section

### DIFF
--- a/src/connections/destinations/catalog/braze-cloud-mode-actions/index.md
+++ b/src/connections/destinations/catalog/braze-cloud-mode-actions/index.md
@@ -33,9 +33,6 @@ Braze Cloud Mode (Actions) provides the following benefit over Braze Classic:
 
 {% include components/actions-fields.html settings="true"%}
 
-{% include components/actions-fields.html%}
-
-
 ## Migration from Braze Classic
 
 {% include content/ajs-upgrade.md %}


### PR DESCRIPTION
### Proposed changes

https://segment.com/docs/connections/destinations/catalog/braze-cloud-mode-actions has duplicate sections for "Available Presets" and "Available Actions". I think it's because "components/actions-fields.html" is being loaded twice. This PR attempts to remedy this.

### Merge timing
No rush
