### PR TITLE
Clean up gtag docs and remove adwords mention

### DIFF
--- a/src/connections/destinations/catalog/google-ads-gtag/index.md
+++ b/src/connections/destinations/catalog/google-ads-gtag/index.md
@@ -6,22 +6,19 @@ strat: google
 name-override: true
 id: 5a03bfe73156760001ab34ec
 ---
-## Before you begin
 
-If you're using the [new Google Ads (Gtag) experience](https://support.google.com/adwords/answer/6095821?hl=en&ref_topic=3165803), you can enable the **Google Ads (Gtag)** Destination (previously called "Google Adwords New") in the Segment catalog. The new Google Ads uses a Global Site Tag (Gtag) and event snippets.
+The [Google global site tag (gtag.js)](https://support.google.com/google-ads/answer/7548399?hl=en){:target="_blank"} is a JavaScript tagging framework and API that allows you to send web conversions to Google Ads. With the Segment Google Ads (Gtag) destination, Segment loads gtag.js for you so you can make efficient use of your existing tracking implementation.
 
-> info "Info message."
-> **IMPORTANT**: Only use this destination if your Google Ads account is using the _New_ (Gtag) Experience. If you're using Google Tag Manager (a separate product) as well, don't add the global site tag again in your GTM containers. You should also disable any [Google Ads (Classic)](/docs/connections/destinations/catalog/adwords/) destinations within the same source, since **Google Ads (Classic)** can't load at the same times as **Google Ads (Gtag)**.
+> info ""
+> Only use this destination if your Google Ads account is using Gtag. If you're using Google Tag Manager, don't add the global site tag (gtag.js) in your GTM containers. You should also disable any [Google Ads (Classic)](/docs/connections/destinations/catalog/adwords/) destinations within the same source, since **Google Ads (Classic)** can't load at the same time as **Google Ads (Gtag)**.
 
 ## Getting Started
 
-You can use this destination to map your `.page()` calls to **Page Load Conversions** or `.track()` calls to **Click Conversions**.
-
-Currently this is only supported on the browser.
+You can use this destination to map your `.page()` calls to **Page Load Conversions** or `.track()` calls to **Click Conversions**. Currently this is only supported on the browser.
 
 ## Page
 
-If you want to map all your unnamed `.page()` calls to a default Page Load Conversion, you can enter the AdWords Conversion ID in **Settings > Default Page Conversion**. However, if you created specific Page Load Conversions in Google Ads that you'd like to map your named `.page()` calls in Segment, you can map the events in **Settings > Page Load Conversions**.
+If you want to map all your unnamed `.page()` calls to a default Page Load Conversion, you can enter the Conversion ID in **Settings > Default Page Conversion**. However, if you created specific Page Load Conversions in Google Ads that you'd like to map your named `.page()` calls in Segment, you can map the events in **Settings > Page Load Conversions**.
 
 Segment forwards all the `properties` of the page call, such as `path`, `title`, `url`, because by default, Google Ads (Gtag) makes these available in your remarketing campaigns.
 
@@ -48,9 +45,9 @@ If you pass `properties.value`, `properties.currency`, or `properties.order_id`,
 
 The only exception is that for `Order Completed` events, Segment will map Google's semantic `value` field to your `properties.revenue`.
 
-## Troubleshooting AdWords Conversions
-To figure out if an event is flagged for Conversion by the AdWords SDK, follow these steps:
-1. Confirm that the events mapped to Google Ads Conversion are being sent in device-mode while using the Segment Analytics.js library. To do this:
+## Troubleshooting Google Ads Conversions
+To figure out if an event is flagged for conversion, follow these steps:
+1. Confirm that the events mapped to a Google Ads conversion are being sent in device-mode while using the Segment Analytics.js library. To do this:
     1. Go to **Connections > Sources** in your workspace and choose your Source.
     2. Go to the **Debugger** tab.
     3. Click on an event and look at the **Raw** view to make sure the events have a library name of `analytics.js`. There should be a snippet of code that looks like this:
@@ -66,16 +63,16 @@ To figure out if an event is flagged for Conversion by the AdWords SDK, follow t
 
       ![Network tab](../../images/network-tab.png)
 
-5. Go to the **Settings** tab for your Gtag destination in Segment on a new webpage and choose **Click Conversions** to look at the mapped `track()` events and make sure the events are mapped to the correct **Adwords Conversion Label**.
+5. Go to the **Settings** tab for your Gtag destination in Segment on a new webpage and choose **Click Conversions** to look at the mapped `track()` events and make sure the events are mapped to the correct **Conversion Label**.
 
       ![Edit Settings](../../images/conversion-settings.png)
 
 6. Go back to your website and trigger the event mapped to the conversion. For example, as shown in the image above, it would be `Order Completed`.
-7. Go to the Network tab in your browser and enter the **Adwords Conversion Label** linked to the event you triggered in the **Filter** field.
+7. Go to the Network tab in your browser and enter the **Conversion Label** linked to the event you triggered in the **Filter** field.
 
       ![Network tab](../../images/network-tab-search.png)
 
-8. See if the value for the `ct_cookie_present` changed to `true`. If `true`, it means that Adwords counts the event as a conversion.  
+8. See if the value for the `ct_cookie_present` changed to `true`. If `true`, it means that Google Ads counts the event as a conversion.  
 
 ## Multiple Google Ads Accounts
 


### PR DESCRIPTION
### Proposed changes
Updating gtag docs and removing mentions of "Google Adwords" as it is all called "Google Ads" now. I also updated the settings description in Partner Portal if we run `make catalog` they should update in our docs.

### Merge timing
- ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/DOC-546
