### PR TITLE
Remove Tracking Plan Google Sheet References [DOC-545]

### DIFF
--- a/src/getting-started/03-planning-full-install.md
+++ b/src/getting-started/03-planning-full-install.md
@@ -2,7 +2,7 @@
 title: Planning a Full Installation
 ---
 
-Now that we've shown you Segment in action, let's step back and think through what a full implementation of Segment for your organization would look like. We know that figuring out what events to track in Segment can feel overwhelming. You should expect this planning process to have the following steps:
+Now that you've seen Segment in action, step back and think through what a full implementation of Segment for your organization would look like. Figuring out what events to track in Segment can feel overwhelming. You should expect this planning process to have the following steps:
 
 <!-- TOC depthFrom:1 depthTo:2 withLinks:1 updateOnSave:1 orderedList:0 -->
 
@@ -100,7 +100,7 @@ Regardless of approach, here are some important best practices to keep in mind:
 
 - **Don't create property keys dynamically:** Avoid creating property names like `"feature_1":"true"`,`"feature_2":"false"` as these are ambiguous and very difficult to analyze
 
-![](/docs/protocols/images/asset_nVdJ3ZyA.png)
+![An image comparing good and bad naming and collection standards](/docs/protocols/images/asset_nVdJ3ZyA.png)
 
 
 Got all that? Great! You're now ready to develop a Tracking Plan.
@@ -112,27 +112,6 @@ Got all that? Great! You're now ready to develop a Tracking Plan.
 A [tracking plan](https://segment.com/blog/what-is-a-tracking-plan/) clarifies what events to track, where those events live in the code base, and why you're tracking those events (from a business perspective). **A good tracking plan represents the single source of truth about what data you collect, and why.**
 
 Your tracking plan is probably maintained in a spreadsheet (unless you use our tracking-plan tool, [Protocols](/docs/protocols/)), and serves as a project management tool to get your organization in agreement about what data to use to make decisions. A tracking plan helps build a shared understanding of the data among marketers, product managers, engineers, analysts, and any other data users.
-
-In the next section, we share how to build a tracking plan from the ground up using a Google Sheet template. Note that you can use any tool to create the tracking plan!
-
-### Using the Tracking Plan Google Sheets template
-
-To help you get started, we developed a Tracking Plan template in [Google Sheets](https://docs.google.com/spreadsheets/d/1TA6qTcDHoZzsG7-C6p5yHGximDxqoNtizguKs7Z0av4/view).
-
-The template includes all of our Business-case ("semantic") Specs (which we mentioned [above](#shortcut-check-if-a-business-spec-meets-your-needs)) as tabs, including [eCommerce](/docs/connections/spec/ecommerce/v2/), [B2B SaaS](/docs/connections/spec/mobile/), [Mobile](/docs/connections/spec/mobile/) and [Video](/docs/connections/spec/video/), and a collection of common properties.
-
-![](images/trackingplans.png)
-
-With your business goals defined, start by defining how you want to track Page/Screen, Identify and Group events. Most customers use [default page tracking](/docs/connections/sources/catalog/libraries/website/javascript/#page) and skip over that tab.
-
-The Identify tab is where you specify which user traits you intend to collect like `first_name`, `last_name`, `email`, etc. Read more about the [identify call below](/docs/protocols/tracking-plan/best-practices/#identify-your-users).
-
-From there, we recommend you specify Track events in the **Track (Custom)** tab. The template includes preexisting events with different numbers of grouped properties (1 Prop Event, 2 Prop Event, etc). While this might be more challenging to work with at first, this structure allows you to use the **Minimize Rows** button at the top to organize and view all events.
-
-Once you complete the tracking plan, you can share the Google Sheet with stakeholders to review, comment, and edit, or simply to share as a reference for implementation.
-
-> success ""
-> **Tip**! If you decide to purchase [Protocols](/docs/protocols/) in the future, you'll be able to upload the tracking plan into Segment [using the Config API](/docs/protocols/apis-and-extensions/#google-sheets-tracking-plan-uploader).
 
 ### Plan your Identify and Group calls
 

--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -26,23 +26,23 @@ You can enable [violation event forwarding](/docs/protocols/validate/forward-vio
 
 ### Do I need to add a Page Viewed event to my tracking plan?
 
-Yes. To consolidate the views in the Schema tab, Segment automatically converts `page` calls into `Page Viewed` events that appear in the Schema Events view. We recommend adding a `Page Viewed` event to your Tracking Plan with any properties you want to validate against. At this time, you cannot validate that a specific named page (`analytics.page('Homepage')`) has a specific set of required properties.
+Yes. To consolidate the views in the Schema tab, Segment automatically converts `page` calls into `Page Viewed` events that appear in the Schema Events view. Segment recommends adding a `Page Viewed` event to your Tracking Plan with any properties you want to validate against. At this time, you cannot validate that a specific named page (`analytics.page('Homepage')`) has a specific set of required properties.
 
 ### How can I see who made changes to my Tracking Plan?
 
-Each Tracking Plan includes a Changelog which shows which changes were made by which users. To view it, open a Tracking Plan, click the **...** button (also known as the dot-dot-dot, or ellipses menu) next to the Edit Tracking Plan button, and click **View Changelog**.
+Each Tracking Plan includes a Changelog, which shows which changes were made by which users. To view it, open a Tracking Plan, click the **...** button (also known as the dot-dot-dot, or ellipses menu) next to the Edit Tracking Plan button, and click **View Changelog**.
 
 ### How many Sources can I connect to a Tracking Plan?
 
-The Tracking Plan to Source relationship is a one-to-many relationship. This means you can connect as many Sources to a Tracking Plan as you need. However we recommend connecting 1-3 Sources per Tracking Plan, because it's rare to have more than 3 Sources that share an identical set of events, especially when tracking events across platforms. For example, many of our mobile SDKs (iOS and Android) automatically collect events that would not make sense to collect in a web app. We recommend against including events in a Tracking Plan that would never be tracked in a Source.
+The Tracking Plan to Source relationship is a one-to-many relationship. This means you can connect as many Sources to a Tracking Plan as you need. However Segment recommends connecting 1-3 Sources per Tracking Plan, because it's rare to have more than three Sources that share an identical set of events, especially when tracking events across platforms. For example, many Segment mobile SDKs (iOS and Android) automatically collect events that would not make sense to collect in a web app. Segment doesn't recommend including events in a Tracking Plan that would never be tracked in a Source.
 
 ### Can I duplicate a Tracking Plan in the Segment UI?
 
-You cannot currently duplicate Tracking Plans in the Segment web app. Instead, we recommend using the [Tracking Plan API](/docs/protocols/apis-and-extensions/) to copy the underlying JSON schema from one Tracking Plan to another. You can also use our [Google Sheets uploader](https://docs.google.com/spreadsheets/u/1/d/1TA6qTcDHoZzsG7-C6p5yHGximDxqoNtizguKs7Z0av4/copy) to duplicate events from one Tracking Plan into another.
+You cannot currently duplicate Tracking Plans in the Segment web app. Instead, Segment recommends using the [Tracking Plan API](/docs/protocols/apis-and-extensions/) to copy the underlying JSON schema from one Tracking Plan to another.
 
 ### How do I handle versioning with mobile apps?
 
-We currently support the ability to [create multiple versions of an event](/docs/protocols/tracking-plan/create/#tracking-plan-event-versioning) in a Tracking Plan. This is ideal for mobile apps, where a breaking change like adding a new required property to an event could cause all previous app versions out in the wild on user devices to generate violations. You must manually add a `context.protocols.event_version` property to the specific track call so that we can correctly validate the event against the defined version. You can learn more about [setting up Tracking Plan event versioning here](/docs/protocols/tracking-plan/create/#tracking-plan-event-versioning).
+Segment currently supports the ability to [create multiple versions of an event](/docs/protocols/tracking-plan/create/#tracking-plan-event-versioning) in a Tracking Plan. This is ideal for mobile apps, where a breaking change like adding a new required property to an event could cause all previous app versions on user devices to generate violations. You must manually add a `context.protocols.event_version` property to the specific track call so that Segment can correctly validate the event against the defined version. Learn more in the [Tracking Plan event versioning documentation](/docs/protocols/tracking-plan/create/#tracking-plan-event-versioning).
 
 ### How do I handle null property values?
 
@@ -58,14 +58,14 @@ You can search in a Tracking Plan to find a specific event, and then copy the UR
 
 ### Can I create a master Tracking Plan that supersedes all other Tracking Plans?
 
-Yes! [Tracking Plan Libraries](/docs/protocols/tracking-plan/libraries/) makes it easy to create groups of events or properties that can be easily imported into multiple Tracking plans.
+Yes. [Tracking Plan Libraries](/docs/protocols/tracking-plan/libraries/) makes it easy to create groups of events or properties that can be easily imported into multiple Tracking plans.
 
 ## Protocols Validation
 
 ### What is the difference between Violations Emails and the Violations page in the Segment UI?
 
 **Violations Daily Digest**
-The Violations Daily Digest is a great way to keep informed of new violations which might be easy to overlook on the Protocols Violations page. The digest sends one email digest per source, every day at approximately 12AM EST. You cannot currently opt in or out of specific sources.
+The Violations Daily Digest is a great way to keep informed of new violations that might be easy to overlook on the Protocols Violations page. The digest sends one email digest per source, every day at approximately 12AM EST. You cannot currently opt in or out of specific sources.
 
 The digest contains all violations for that source that are _unique_ in the previous 48 hours. For example, if an event `testEvent` had violations on the first day of the month, then those violations won't appear in the digest until the third of the month.
 
@@ -74,19 +74,19 @@ The email includes information about the violation to help you track down its so
 **Protocols Violations Page**
 The Protocols Violations page shows a live count for violations. You can adjust the timeframe to show violations in the last hour, the last 24 hours, or the last seven days.
 
-You might see a difference between the count on the Violations page and the count in the Violations email digests. This is can happen because of differences between the time periods available (24 hours in in the live page, 48 hours in the daily digest email), and the fact that the digest only shows _unique_ violations. The fields displayed on the Violations page are more detailed than those included in the email digest.
+You might see a difference between the count on the Violations page and the count in the Violations email digests. This can happen due to differences between the time periods available (24 hours in in the live page, 48 hours in the daily digest email), and the fact that the digest only shows _unique_ violations. The fields displayed on the Violations page are more detailed than those included in the email digest.
 
 ## Protocols Enforcement
 
 ### Why can't I use the Schema to filter my events?
 
-The schema functionality is a _reactive_ way to clean up your data, where the Tracking Plan functionality is a _proactive_, intentional way to clean and unify all future data. We've found that the best data driven companies invest the time required to build strong processes and controls around their data. The investment pays off exponentially.
+The schema functionality is a _reactive_ way to clean up your data, where the Tracking Plan functionality is a _proactive_, intentional way to clean and unify all future data. Segment has found that the best data driven companies invest the time required to build strong processes and controls around their data. The investment pays off exponentially.
 
 That being said, there are plenty of scenarios where the reactive Schema functionality solves immediate needs for customers. Often times, customers will use both Schema Controls and Tracking Plan functionality across their Segment Sources. For smaller volume Sources with less important data, the Schema functionality often works perfectly.
 
 ### If I enable blocking, what happens to the blocked events? Are events just blocked from specific Destinations or the entire Segment pipeline?
 
-Blocked events are blocked from sending to all Segment Destinations, including warehouses and streaming Destinations. When an Event is blocked using a Tracking Plan, it does not count towards your MTU limit. They will however count toward your MTU limit if you enable [blocked event forwarding](/docs/protocols/enforce/forward-blocked-events/) in your Source settings.
+Blocked events are blocked from sending to all Segment Destinations, including warehouses and streaming Destinations. When an Event is blocked using a Tracking Plan, it does not count towards your MTU limit. They will, however, count toward your MTU limit if you enable [blocked event forwarding](/docs/protocols/enforce/forward-blocked-events/) in your Source settings.
 
 ### Do blocked and discarded events count towards my MTU counts?
 
@@ -96,28 +96,28 @@ Blocked events will not count towards your MTU counts as long as blocked event f
 
 ### Do transformations work with Segment replays?
 
-If you create a destination scoped transformation and request a replay for that destination, the transformation will transform events into the destination. It's not recommended to request a replay to resend events to a destination as that will likely result in duplicate events in the destination.
+If you create a destination scoped transformation and request a replay for that destination, the transformation will transform events into the destination. Segment doesn't recommended requesting a replay to resend events to a destination as that will likely result in duplicate events in the destination.
 
 ### Why can't I create multiple transformations of the same type for the same event?
 
-To reduce the risk of creating circular and conflicting transformations, we only allow a single transformation to be created for each distinct source, event, destination and type pairing. That means you cannot create two **Rename track event** transformations for a `order_completed` event. This eliminates the possibility of different stakeholders creating conflicting transformations to satisfy their own needs. It also simplifies the Transformations list view, making it much easier to sort and filter by source, event, destination, etc.
+To reduce the risk of creating circular and conflicting transformations, Segment only allows a single transformation to be created for each distinct source, event, destination and type pairing. That means you cannot create two **Rename track event** transformations for a `order_completed` event. This eliminates the possibility of different stakeholders creating conflicting transformations to satisfy their own needs. It also simplifies the Transformations list view, making it much easier to sort and filter by source, event, destination, etc.
 
 ### Why can't I select multiple events or destinations in a single transformation?
 
-In early transformations prototypes we allowed users to select multiple events and destinations for a single transformation rule. We realized however that this created a structure that was impossible to scale, and likely to generate unintended consequences. For example, if we allow multiple track events to be selected for a property name change, it'd be possible to create conflicting changes. Instead, by enforcing a single event, we can check to see if a transformation rule exists and smartly link you to that rule using a warning.
+In early transformations prototypes, Segment allowed users to select multiple events and destinations for a single transformation rule. Segment realized, however, that this created a structure that was impossible to scale, and likely to generate unintended consequences. For example, if Segment allows multiple track events to be selected for a property name change, it'd be possible to create conflicting changes. Instead, by enforcing a single event, Segment can check to see if a transformation rule exists and smartly link you to that rule using a warning.
 
 ### What permissions are required to create and edit transformations?
 
-With great power, comes great responsibility. Currently only workspace admins are allowed to create transformations.
+Only workspace admins are allowed to create transformations.
 
 ### What permissions are required to view transformations?
 
-All users with Protocols admin or readonly permissions can view transformations.
+All users with Protocols admin or read-only permissions can view transformations.
 
 ### Why can't we support transformations for device-mode destinations?
 
-Transformations introduce advanced logic that at scale may impact performance of client-side libraries. We are exploring ways to maintain high performance while selectively supporting transformations in the clients. If you are interested in testing new functionality which supports device-mode destination transformations in analytics.js, contact your account rep.
+Transformations introduce advanced logic that at scale may impact performance of client-side libraries. If you are interested in testing new functionality which supports device-mode destination transformations in analytics.js, contact your account rep.
 
 ### Why do I need Protocols to use transformations?
 
-Transformations are but one tool among many to help you improve data quality. We highly recommend that all customers interested in improving data quality start with a well defined Tracking Plan. The Tracking Plan serves as a roadmap for how you want to collect data. Without a clear roadmap, it's nearly impossible to build alignment around how transformations should be used to improve data quality, leading to more data quality issues than it solves.
+Transformations are but one tool among many to help you improve data quality. Segment highly recommends that all customers interested in improving data quality start with a well defined Tracking Plan. The Tracking Plan serves as a roadmap for how you want to collect data. Without a clear roadmap, it's nearly impossible to build alignment around how transformations should be used to improve data quality, leading to more data quality issues than it solves.

--- a/src/protocols/tracking-plan/best-practices.md
+++ b/src/protocols/tracking-plan/best-practices.md
@@ -5,23 +5,23 @@ redirect_from:
   - '/protocols/tracking-plan/'
 ---
 
-Figuring out what events to track in Segment can feel overwhelming. Fortunately, Segment has helped 1000s of customers through this process and have amassed a ton of resources to help you get started. Whether you're a small team just getting your app off the ground, or a highly complex enterprise with 100s of stakeholders, these resources can help!
+Figuring out what events to track in Segment can feel overwhelming. Fortunately, Segment has helped thousands of customers through this process and has amassed a ton of resources to help you get started. Whether you're a small team just getting your app off the ground or a highly complex enterprise with 100s of stakeholders, these resources can help.
 
 That being said, be prepared to invest time defining how you want to track data. Any investment in improving data quality will reap massive rewards, and compound over time by allowing your analytics teams to produce better insights, your marketing teams to run better campaigns and so much more.
 
-## Data Tracking Philosophy
+## Data tracking philosophy
 
 Tracking is about learning and taking action. Think about what you want to know about your product or customers. Think about what assumptions need to be tested or invalidated. Think about the unknowns. Here are some helpful questions to get started:
 
-* What kind of events or data will shed light on the how your customers use your product?
-* How do people discover, start using, and paying for your product?
-* What are the most important steps in a customers journey?
+* What kind of events or data will shed light on how your customers use your product?
+* How do people discover, pay for, and start using your product?
+* What are the most important steps in a customer's journey?
 
-## Define Business Objectives
+## Define business objectives
 
-While it may seem obvious, we highly recommend documenting your high level business objectives (see [Goals tab in Google Sheet Tracking Plan](https://docs.google.com/spreadsheets/d/1TA6qTcDHoZzsG7-C6p5yHGximDxqoNtizguKs7Z0av4/view){:target="_blank"} template). More specifically, what are the measurable business outcomes you want to achieve this year. Are you looking to acquire new customers, activate new signups, drive incremental revenues among your current customer base, etc? Answering this question is best done by interviewing stakeholders who would consume the data in your organization.
+Segment recommends documenting your high-level business objectives. What measurable business outcomes do you want to achieve? Do you want to acquire new customers, activate new signups, drive incremental revenues among your current customer base? You can best answer this question by interviewing stakeholders who would consume the data in your organization.
 
-With your business goals documented, you now need to map user actions to those business goals. For example, if one of your goals is to activate new signups, you want to think about which activities are related to a signup. Ask yourself, what actions do people take before signing up? Are there specific actions that can predict a user signing up?
+With your business goals documented, you now need to map user actions to those business goals. For example, if one of your goals is to activate new signups, you want to think about which activities are related to a signup. Ask yourself what actions people take before signing up. Do specific actions predict user signups?
 
 As an example, you may end up with a list like the following:
 
@@ -33,51 +33,38 @@ As an example, you may end up with a list like the following:
 * Form Submitted
 * User Signed Up
 
-While the above represents a small portion of the total user actions you will track, focusing on business objectives helps break up the overwhelmingness of data collection into smaller chunks.
+ While these may only represent a portion of the total user actions you will track, focusing on business objectives helps make data collection more manageable.
 
-## Formalize Your Naming and Collection Standards
 
-With your business objectives documented, it's time to build a set of standards that you and your team will use when determining what to track. Our most successful customers limit their tracking plan to a minimal number of core events with rich properties to provide context. While we've generally seen more success with the "less is more" philosophy of tracking data, we've had plenty of customers take a more liberal "track more and analyze later" approach. Like everything, each alternative has pros and cons that are important to consider especially as it relates to your company's needs.
+## Formalize your naming and collection standards
 
-Regardless of approach, here are some important notes to keep in mind:
+With your business objectives documented, it's time to build a set of standards that you and your team will use when determining what to track. Segment's most successful customers limit their tracking plan to a minimal number of core events with rich properties that provide context. While some customers find success with the "less is more" philosophy of tracking data, others take a more liberal "track more and analyze later" approach. Both options have pros and cons you should take into account when you consider your company's needs.
 
-* **Pick a casing convention:** We recommend _Title Case_ for event names and _snake_case_ for property names. Make sure you pick a casing standard and enforce it across your events and properties.
+Regardless of your approach, keep the following tips in mind:
 
-* **Pick an event name structure:** As you may have noticed from our [specs](/docs/connections/spec/semantic/), we're big fans of the Object (`Blog Post`) + Action (`Read`) framework for event names. Pick a convention and stick to it!
+* **Pick a casing convention.** Segment recommends _Title Case_ for event names and _snake_case_ for property names. Make sure you pick a casing standard and enforce it across your events and properties.
 
-* **Don't create event names dynamically:** Avoid creating events that pull a dynamic value into the event name (ex. `User Signed Up (11-01-2019)`)
+* **Pick an event name structure.** As you may have noticed from the [Segment specs](/docs/connections/spec/semantic/), Segment uses the Object (`Blog Post`) + Action (`Read`) framework for event names. Pick a convention and stick to it.
 
-* **Don't create events to track properties:** Avoid adding values to event names that could be a property. Instead, add values a property (ex. `"blog_post_title":"Best Tracking Plans Ever"`)
+* **Don't create event names dynamically.** Avoid creating events that pull a dynamic value into the event name (like `User Signed Up (11-01-2019)`).
 
-* **Don't create property keys dynamically:** Avoid creating property names like `"feature_1":"true"`,`"feature_2":"false"` as these are ambiguous and very difficult to analyze
+* **Don't create events to track properties.** Avoid adding values to event names that could be a property. Instead, add values a property (like `"blog_post_title":"Best Tracking Plans Ever"`).
 
-![](../images/asset_nVdJ3ZyA.png)
+* **Don't create property keys dynamically.** Avoid creating property names like `"feature_1":"true"`,`"feature_2":"false"`, as these are ambiguous and difficult to analyze.
 
-## Create a Tracking Plan
+![An image comparing good and bad naming and collection standards](../images/asset_nVdJ3ZyA.png)
 
-A [tracking plan](https://segment.com/blog/what-is-a-tracking-plan/) clarifies what events to track, where those events live in the code base, and why those events are necessary from a business perspective. Prior to Protocols, tracking plans typically lived in a spreadsheet. The tracking plan served as a project management tool to align an entire organization around data as the basis on which to make decisions. The tracking plan helps marketers, product managers, engineers, analysts, etc. get on the same page. It represents the single source of truth for what data to collect and why.
+## Create a tracking plan
 
-The tracking plan has been so instrumental in helping organizations reclaim their own data efforts that we invested years of product development to create [Protocols](/docs/protocols/).
+A [tracking plan](https://segment.com/blog/what-is-a-tracking-plan/) clarifies what events to track, where those events live in the code base, and why those events are necessary from a business perspective. Prior to Protocols, tracking plans typically lived in a spreadsheet. The tracking plan served as a project management tool to align an entire organization around data as the basis on which to make decisions. The tracking plan helps marketers, product managers, engineers, and analysts get on the same page.
 
-In the following, we share how to build a tracking plan from the ground up using a Google Sheet template. Note that you can use any tool to create the tracking plan!
-
-## Tracking Plan Google Sheets Template
-
-To help you get started, we developed a Tracking Plan template in [Google Sheets](https://docs.google.com/spreadsheets/d/1TA6qTcDHoZzsG7-C6p5yHGximDxqoNtizguKs7Z0av4/view). The template includes all of our semantic specs including [eCommerce](/docs/connections/spec/ecommerce/v2/), [B2B SaaS](/docs/connections/spec/mobile/), [Mobile](/docs/connections/spec/mobile/) and [Video](/docs/connections/spec/video/), and a collection of common properties.
-
-We highly recommend you start by [defining your business objectives](/docs/protocols/tracking-plan/best-practices/#define-business-objectives), and have included a template in the **Goals** tab to guide that process.
-
-With your business goals defined, start by defining how you want to track Page/Screen, Identify and Group events. Most customers use [default page tracking](/docs/connections/sources/catalog/libraries/website/javascript/#page) and skip over that tab. The identify tab is where you specify which user traits you intend to collect like `first_name`, `last_name`, `email`, etc. Read more about the [identify call below](/docs/protocols/tracking-plan/best-practices/#identify-your-users).
-
-From there, we recommend you specify Track events in the **Track (Custom)** tab. Note that we pre-created events with varying numbers of grouped properties (1 Prop Event, 2 Prop Event, etc). While more challenging to manage at first, this structure allows you to use the **Minimize Rows** button at the top to organize and view all events.
-
-Once completed, the Google Sheet tracking plan can be shared with your stakeholders to either review, comment, edit or simply reference for implementation. And if you decide to purchase Protocols in the future, you'll be able to upload the tracking plan into Segment [via the Config API](/docs/protocols/apis-and-extensions/#google-sheets-tracking-plan-uploader).
+The tracking plan has been so instrumental in helping organizations reclaim their own data efforts that Segment invested years of product development to create [Protocols](/docs/protocols/). Whatever tool you choose to build your tracking plan, make sure that it represents a single source of truth for your data collection efforts.
 
 ## Identify your users
 
-The `.identify()` call is important, because it updates all records of the user with a set of traits. But how do you choose which traits to include?
+The Identify call is important because it updates all records of the user with a set of traits. But how do you choose which traits to include?
 
-Here is a sample `.identify()` call (with [analytics.js](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/)) for Segment:
+Here is a sample Identify call (with [analytics.js](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/)) for Segment:
 
 ```js
 analytics.identify({
@@ -89,25 +76,25 @@ analytics.identify({
 });
 ```
 
-The traits represent dimensions in your data that you can group or pivot on. For example, in the above, you can easily create cohorts of all types that are `users` or accounts created within a time window of your choosing.
+The traits represent dimensions in your data that you can group or pivot on. For example, in the previous sample call, you can easily create cohorts of all types that are `users` or accounts created within a time window of your choosing.
 
 ## Define your Track events
 
-After you've documented your [event naming and collection standards](/docs/protocols/tracking-plan/best-practices/#formalize-your-naming-and-collection-standards) it's time to add events to your tracking plan. We recommend starting with fewer events that are directly tied to one of your [business objectives](/docs/protocols/tracking-plan/best-practices/#define-business-objectives). This focused effort helps avoid a situation where you become overwhelmed by endless number of possible actions to track. As you get more comfortable, you can add more events to your tracking plan that can answer peripheral questions.
+After you've documented your [event naming and collection standards](/docs/protocols/tracking-plan/best-practices/#formalize-your-naming-and-collection-standards), it's time to add events to your tracking plan. Segment recommends starting with fewer events that are directly tied to one of your [business objectives](/docs/protocols/tracking-plan/best-practices/#define-business-objectives). This focused effort helps avoid a situation where you become overwhelmed by endless possible actions to track. As you get more comfortable, you can add more events to your tracking plan that can answer peripheral questions.
 
-At Segment, we started out tracking these events:
+Segment began by tracking these events:
 - **User Signed Up**
 - **Source Data Sent**
 - **Subscription Started**
 
 
-Then we added some peripheral events to to better understand how we're performing, for the following reasons:
-- **User Invited**
-   When users invite more people to their organization, it's a good indicator that they're engaged and serious about using the product. This helps us measure growth in organizations.
-- **Destination Enabled**
-   Turning on an destination is a key value driver for our customers.
-- **Debugger Call Expanded**
-   When we see that a certain customer has used the live event stream feature a number of times, we can contact them to see if we can help them debug.
+Next, Segment added some of the following peripheral events that helped monitor performance:
+- **User Invited**;
+   When users invite more people to their organization, it's a good indicator that they're engaged and serious about using the product. This helps measure organizational growth.
+- **Destination Enabled**;
+   Turning on a destination is a key value driver for Segment's customers.
+- **Debugger Call Expanded**;
+   When Segment sees that a certain customer has used the live event stream feature a number of times, Segment can contact them to see if they need help debugging.
 
 
 For an ecommerce company, however, the main events might be something like:
@@ -117,22 +104,22 @@ For an ecommerce company, however, the main events might be something like:
 - **Order Completed**
 
 
-Note that Segment has a set of "reserved" event names specifically for ecommerce, called our [ecommerce spec](https://segment.com/docs/connections/spec/ecommerce/v2). Check it out to see which events we cover and how they are used in our downstream destinations.
+Note that Segment has a set of "reserved" event names specifically for ecommerce, called the Segment [ecommerce spec](https://segment.com/docs/connections/spec/ecommerce/v2). Check it out to see which events Segments covers and how they are used in our downstream destinations.
 
-For a community, on the other hand, there is an entirely different set of actions that indicate engagement, listed in the below pyramid. For example, a community like [GrowthHackers](https://growthhackers.com/) may want to track actions like:
+For a community, on the other hand, an entirely different set of actions indicate engagement, listed in the following pyramid. For example, a community like [GrowthHackers](https://growthhackers.com/){:target="_blank"} may want to track actions like:
 - **Content Viewed**
 - **Content Shared**
 - **Comment Submitted**
 - **Content Produced**
 - **Content Curated**
 
-With this, they're able to measure key metrics around engagement and understand how users are moving towards their ultimate conversion event: curation content for others. For more information, check out [this article](https://segment.com/blog/growthhackers-community-metrics/) from GrowthHackers about the events they track and why.
+With this, they're able to measure key metrics around engagement and understand how users are moving towards their ultimate conversion event: curation content for others. For more information, check out [this article](https://segment.com/blog/growthhackers-community-metrics/){:target="_blank"} from GrowthHackers about the events they track and why.
 
 ## Define your Track event properties
 
-Each `.track()` call can accept an optional dictionary of `properties`, which can contain any key-value pair you want. These `properties` act as dimensions that allow your end tool to group, filter, and analyze the events. They give you additional detail on broader events.
+Each Track call can accept an optional dictionary of `properties`, which can contain any key-value pair you want. These `properties` act as dimensions that allow your end tool to group, filter, and analyze the events. They give you additional detail on broader events.
 
-As mentioned earlier, events should be generic and high level, whereas properties are specific and detailed. For example, at Segment, `Business Tier Workspace Created` is a horrible event name. Instead, we used `Workspace Created` with a `property` of `account_tier` and value of `business` :
+As mentioned earlier, events should be generic and high level, whereas properties are specific and detailed. For example, at Segment, `Business Tier Workspace Created` works poorly as an event name. Instead, Segment used `Workspace Created` with a `property` of `account_tier` and value of `business`:
 
 ```js
 analytics.track('Workspace Created', {
@@ -140,11 +127,11 @@ analytics.track('Workspace Created', {
 })
 ```
 
-Similar to the traits in the `.identify()` call, the properties provide you a column that you can pivot against or filter on in your analytics tools or allow you to create a cohort of users in email tools.
+Similar to the traits in the Identify call, the properties provide you a column that you can pivot against or filter on in your analytics tools or allow you to create a cohort of users in email tools.
 
-There also shouldn't be any dynamically generated `key`'s in the `properties` dictionary, as each `key` will create a new column in your downstream tools. Dynamically generated `key`'s will clutter your tools with tons of data that will make it difficult and confusing to use later.
+Avoid dynamically generated `key`'s in the `properties` dictionary, as each `key` will create a new column in your downstream tools. Dynamically generated `key`'s will clutter your tools with data that will make it difficult and confusing to use later.
 
-Here is Segment's `Lead Captured` `.track()` call:
+Here is Segment's `Lead Captured` Track call:
 
 ```js
 analytics.track(userId, 'Lead Captured', {
@@ -154,8 +141,8 @@ analytics.track(userId, 'Lead Captured', {
 });
 ```
 
-The high level event is **Lead Captured** and all of the details are tucked into the `properties` dictionary. In our downstream tools, we'll be able to easily look at how many leads were captured in different locations on our site.
+The high level event is **Lead Captured** and all of the details are tucked into the `properties` dictionary. In its downstream tools, Segment can easily look at how many leads were captured in different locations on the Segment website.
 
-If you want to learn more about how properties are used by downstream tools, check out [The Anatomy of a Track Call](https://segment.com/academy/collecting-data/the-anatomy-of-a-track-call/).
+If you want to learn more about how properties are used by downstream tools, check out [The Anatomy of a Track Call](https://segment.com/academy/collecting-data/the-anatomy-of-a-track-call/){:target="_blank"}.
 
-Want a free consultation from our Customer Success Managers on how they simplify our customer's analytics? [Request a demo of Segment](https://segment.com/contact/demo).
+Want a free consultation from our Customer Success Managers on how they simplify customer's analytics? [Request a demo of Segment](https://segment.com/contact/demo){:target="_blank"}.


### PR DESCRIPTION
### Proposed changes

- Removed references to the Tracking Plan Google Sheet from several pages.
- General cleanup (first-person plural, Latin, exclamation points).

### Merge timing

- ASAP once approved.

### Related issues (optional)