### PR TITLE
Functions: Updates jsforce in dependencies list

### DIFF
--- a/src/_includes/content/functions/runtime.md
+++ b/src/_includes/content/functions/runtime.md
@@ -15,6 +15,7 @@ The following dependencies are installed in the function environment by default.
 - [`@google-cloud/functions v1.1.0`](https://www.npmjs.com/package/@google-cloud/functions) exposed as `google.cloud.functions`
 - [`@google-cloud/pubsub v2.6.0`](https://www.npmjs.com/package/@google-cloud/pubsub) exposed as `google.cloud.pubsub`
 - [`@google-cloud/storage v5.3.0`](https://www.npmjs.com/package/@google-cloud/storage) exposed as `google.cloud.storage`
+- [`jsforce v1.11.0`](https://www.npmjs.com/package/jsforce) exposed as `jsforce`
 - [`jsonwebtoken v8.5.1`](https://www.npmjs.com/package/jsonwebtoken) exposed as `jsonwebtoken`
 - [`lodash v4.17.15`](https://www.npmjs.com/package/lodash) exposed as `_`
 - [`moment v2.26.0`](https://www.npmjs.com/package/moment/v/2.26.0) exposed as `moment`


### PR DESCRIPTION
Proposed changes
This PR updates the list of libraries used in functions. We have added jsforce dependency.

Merge timing
This can be merge once FUNC-246 PR  is merged in funk repo

Related issues (optional)
N/A