### PR TITLE
Removed the email section from GCS public beta flag

### DIFF
--- a/src/connections/storage/catalog/google-cloud-storage/index.md
+++ b/src/connections/storage/catalog/google-cloud-storage/index.md
@@ -12,9 +12,7 @@ The Google Cloud Storage (GCS) destination puts the raw logs of the data Segment
 > warning ""
 > The Google Cloud Storage destination works differently than other destinations in Segment. Segment sends **all** data from a Personas source to GCS during the sync process, not only the connected audiences and traits. Using a destinations selector like the [integrations object](/docs/connections/spec/common/#integrations) doesn't affect the events events sent to GCS.
 
-**Note**: The GCS destination is currently in beta, and does not support product features such as deletions, replays, or surfacing errors in the UI.
-
-If you are interested in joining the beta program, contact us at [beta@segment.com](mailto:beta@segment.com) to request access.
+**Note**: The GCS destination is currently in public beta, and does not support product features such as deletions, replays, or surfacing errors in the UI.
 
 
 ## Getting Started


### PR DESCRIPTION
### Proposed changes
Removed the "email for access" section from the GCS public beta flag (based on info from a beta@segment.com email thread)

### Merge timing
ASAP

### Related issues (optional)

