### PR TITLE
Disclaimer - track calls only with Marketing Hub

### DIFF
--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -82,7 +82,7 @@ analytics.track("Clicked Buy Now button", {
 ```
 
 > warning "Important"
-> Marketing Hub subscription is required to [track calls and custom marketing events](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events) in Hubspot. You must have a HubSpot Enterprise account for Segment to pass traits from an Identify call to your Track call and send them as [custom events to HubSpot](https://knowledge.hubspot.com/events-user-guide-v2/using-custom-events){:target="_blank"}.
+> Marketing Hub subscription is required to [track calls and custom marketing events](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events){:target="_blank"} in HubSpot. You must have a HubSpot Enterprise account for Segment to pass traits from an Identify call to your Track call and send them as [custom events to HubSpot](https://knowledge.hubspot.com/events-user-guide-v2/using-custom-events){:target="_blank"}.
 
 The event will appear in your HubSpot UI but may take up to 60 minutes to appear in the graph visualization.
 

--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -82,7 +82,7 @@ analytics.track("Clicked Buy Now button", {
 ```
 
 > warning "Important"
-> You must have a HubSpot Enterprise account for Segment to pass traits from an Identify call through to your Track call and send them as[custom events to HubSpot](https://knowledge.hubspot.com/events-user-guide-v2/using-custom-events).
+> Track calls and custom events in Hubspot require Hubspot Marketing Hub (https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events). You must have a HubSpot Enterprise account for Segment to pass traits from an Identify call through to your Track call and send them as[custom events to HubSpot](https://knowledge.hubspot.com/events-user-guide-v2/using-custom-events).
 
 The event will appear in your HubSpot UI but may take up to 60 minutes to appear in the graph visualization.
 

--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -82,7 +82,7 @@ analytics.track("Clicked Buy Now button", {
 ```
 
 > warning "Important"
-> Track calls and custom events in Hubspot require Hubspot Marketing Hub (https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events). You must have a HubSpot Enterprise account for Segment to pass traits from an Identify call through to your Track call and send them as[custom events to HubSpot](https://knowledge.hubspot.com/events-user-guide-v2/using-custom-events).
+> Marketing Hub subscription is required to [track calls and custom marketing events](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events) in Hubspot. You must have a HubSpot Enterprise account for Segment to pass traits from an Identify call to your Track call and send them as [custom events to HubSpot](https://knowledge.hubspot.com/events-user-guide-v2/using-custom-events){:target="_blank"}.
 
 The event will appear in your HubSpot UI but may take up to 60 minutes to appear in the graph visualization.
 


### PR DESCRIPTION
Not sure what the text after is referring to. But Hubspot required Marketing Hub subscription in order to receive Track calls / custom events.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
