### PR TITLE
fix(typo): minor misspelling

### DIFF
--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -152,7 +152,7 @@ Segment creates a SHA-256 hash of the following fields before sending to Faceboo
 - Email
 - Phone
 - Gender
-- Data of Birth
+- Date of Birth
 - Last Name
 - First Name
 - City


### PR DESCRIPTION
- `data of birth` → `date of birth`

### Proposed changes
Noticed a minor misspelling of the `date of birth` property while looking at that property for a customer (WB Games)

### Merge timing
- ASAP once approved
