### PR TITLE
Update FB Conversions API with API upgrade note

### DIFF
--- a/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
@@ -13,7 +13,7 @@ hide-dossier: true
 [Facebook Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api){:target="_blank"} allows advertisers to send events from their servers directly to Facebook. Server-side events are linked to a pixel and are processed like browser pixel events. This means that server-side events are used in measurement, reporting, and optimization in the same way as browser pixel events.
 
 > info "Customer Information Parameters Requirements"
-> As of Marketing API V13.0, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
+> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
 
 > info "Server Event Parameter Requirements"
 > On February 15th, 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that do not meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements).

--- a/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
@@ -10,10 +10,13 @@ hide-dossier: true
 
 <!-- LR: 2/16/2021: Redirect pulls in from `facebook-conversions-api` because while this destination's display name has changed, the slug is still the old name and the docs build needs to match on slug to find it in `destinations.yml` -->
 
-[Facebook Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api) allows advertisers to send events from their servers directly to Facebook. Server-Side events are linked to a pixel and are processed like browser pixel events. This means that Server-Side events are used in measurement, reporting, and optimization in the same way as browser pixel events.
+[Facebook Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api){:target="_blank"} allows advertisers to send events from their servers directly to Facebook. Server-side events are linked to a pixel and are processed like browser pixel events. This means that server-side events are used in measurement, reporting, and optimization in the same way as browser pixel events.
+
+> info "Customer Information Parameters Requirements"
+> As of Marketing API V13.0, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
 
 > info "Server Event Parameter Requirements"
-> On February 15th, 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that do not meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements)
+> On February 15th, 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that do not meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements).
 
 > info "Destination name change"
 > Facebook Conversions API was renamed from Facebook Pixel Server-Side.

--- a/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
@@ -13,10 +13,10 @@ hide-dossier: true
 [Facebook Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api){:target="_blank"} allows advertisers to send events from their servers directly to Facebook. Server-side events are linked to a pixel and are processed like browser pixel events. This means that server-side events are used in measurement, reporting, and optimization in the same way as browser pixel events.
 
 > info "Customer Information Parameters Requirements"
-> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, Segment recommends that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
+> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events don't throw an error, Segment recommends that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
 
 > info "Server Event Parameter Requirements"
-> On February 15th, 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that do not meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements).
+> On February 15th, 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that don't meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements).
 
 > info "Destination name change"
 > Facebook Conversions API was renamed from Facebook Pixel Server-Side.

--- a/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
@@ -13,7 +13,7 @@ hide-dossier: true
 [Facebook Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api){:target="_blank"} allows advertisers to send events from their servers directly to Facebook. Server-side events are linked to a pixel and are processed like browser pixel events. This means that server-side events are used in measurement, reporting, and optimization in the same way as browser pixel events.
 
 > info "Customer Information Parameters Requirements"
-> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
+> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, Segment recommends that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
 
 > info "Server Event Parameter Requirements"
 > On February 15th, 2021, Facebook began enforcing new requirements for server event parameters. After that date, events sent to the Conversions API that do not meet the new requirements might not be available for optimization, targeting, or measurement. For details on how to implement these requirements see [Server Event Parameter Requirements](/docs/connections/destinations/catalog/facebook-pixel-server-side/#server-event-parameter-requirements).


### PR DESCRIPTION
### Proposed changes
StratConn is updating our FB integrations to use the latest API (V14.0). We are currently on V12.0. V13.0 introduced new requirements so this adds a note to our docs so customers are aware of this.

### Merge timing
- On a specific date? We are starting to the roll-out the upgrades from July 27-Aug 2. Since the first customers to get this upgrade will be on July 27 let's publish this note in our **Thurs, July 28** docs deploy please.

### Reference
- https://paper.dropbox.com/doc/STRATCONN-1433-Updating-from-V12.0-to-V14.0-of-the-FB-Marketing-API.--BmB1qelDYJ9tYEu14z50LuXtAQ-22DVMwQQ4Odqy78dfi3zy
- https://segment.atlassian.net/browse/STRATCONN-1433
