### PR TITLE
Update FB Conversions API Actions with API upgrade

### DIFF
--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -8,7 +8,7 @@ id: 61806e472cd47ea1104885fc
 Facebook Conversions API (Actions) enables advertisers to send events from their servers directly to Facebook. Server-side events link to Facebook Pixel events, and process like browser pixel events. This means that server-side events are used in measurement, reporting, and optimization, just like browser pixel events.
 
 > info "Customer Information Parameters Requirements"
-> As of Marketing API V13.0, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
+> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
 
 ## Benefits of Facebook Conversions API (Actions) vs Facebook Conversions API Classic
 

--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -8,7 +8,7 @@ id: 61806e472cd47ea1104885fc
 Facebook Conversions API (Actions) enables advertisers to send events from their servers directly to Facebook. Server-side events link to Facebook Pixel events, and process like browser pixel events. This means that server-side events are used in measurement, reporting, and optimization, just like browser pixel events.
 
 > info "Customer Information Parameters Requirements"
-> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
+> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events don't throw an error, Segment recommends that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
 
 ## Benefits of Facebook Conversions API (Actions) vs Facebook Conversions API Classic
 

--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -7,6 +7,9 @@ id: 61806e472cd47ea1104885fc
 ---
 Facebook Conversions API (Actions) enables advertisers to send events from their servers directly to Facebook. Server-side events link to Facebook Pixel events, and process like browser pixel events. This means that server-side events are used in measurement, reporting, and optimization, just like browser pixel events.
 
+> info "Customer Information Parameters Requirements"
+> As of Marketing API V13.0, Facebook began enforcing new requirements for customer information parameters (user data). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
+
 ## Benefits of Facebook Conversions API (Actions) vs Facebook Conversions API Classic
 
 The Facebook Conversions API (Actions) destination provides the following benefits over the classic Facebook Conversions API destination:


### PR DESCRIPTION
### Proposed changes
StratConn is updating our FB integrations to use the latest API (V14.0). We are currently on V12.0. V13.0 introduced new requirements so this adds a note to our docs so customers are aware of this.

### Merge timing
- On a specific date? We are starting to the roll-out the upgrades from July 27-Aug 2. Since the first customers to get this upgrade will be on July 27 let's publish this note in our **Thurs, July 28** docs deploy please.

### Reference
- https://paper.dropbox.com/doc/STRATCONN-1433-Updating-from-V12.0-to-V14.0-of-the-FB-Marketing-API.--BmB1qelDYJ9tYEu14z50LuXtAQ-22DVMwQQ4Odqy78dfi3zy
- https://segment.atlassian.net/browse/STRATCONN-1433
