### PR TITLE
Update FB Offline Conversions with API upgrade note

### DIFF
--- a/src/connections/destinations/catalog/facebook-offline-conversions/index.md
+++ b/src/connections/destinations/catalog/facebook-offline-conversions/index.md
@@ -7,7 +7,7 @@ id: 58ae54dc70a3e552b95415f6
 [Facebook Offline Conversions](https://www.facebook.com/business/help/1782327938668950?utm_source=segmentio&utm_medium=docs&utm_campaign=partners) enables offline event tracking, so marketers can run campaigns, upload transaction data, and compare in-store transactions.
 
 > info "Customer Information Parameters Requirements"
-> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (match keys). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
+> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (match keys). To ensure your events don't throw an error, Segment recommends that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
 
 ## Other Facebook Destinations Supported by Segment
 This page is about the **Facebook Offline Conversions**. For documentation on other Facebook destinations, see the pages linked below.

--- a/src/connections/destinations/catalog/facebook-offline-conversions/index.md
+++ b/src/connections/destinations/catalog/facebook-offline-conversions/index.md
@@ -7,7 +7,7 @@ id: 58ae54dc70a3e552b95415f6
 [Facebook Offline Conversions](https://www.facebook.com/business/help/1782327938668950?utm_source=segmentio&utm_medium=docs&utm_campaign=partners) enables offline event tracking, so marketers can run campaigns, upload transaction data, and compare in-store transactions.
 
 > info "Customer Information Parameters Requirements"
-> As of Marketing API V13.0, Facebook began enforcing new requirements for customer information parameters (match keys). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
+> As of Facebook Marketing API v13.0+, Facebook began enforcing new requirements for customer information parameters (match keys). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
 
 ## Other Facebook Destinations Supported by Segment
 This page is about the **Facebook Offline Conversions**. For documentation on other Facebook destinations, see the pages linked below.

--- a/src/connections/destinations/catalog/facebook-offline-conversions/index.md
+++ b/src/connections/destinations/catalog/facebook-offline-conversions/index.md
@@ -6,6 +6,8 @@ id: 58ae54dc70a3e552b95415f6
 ---
 [Facebook Offline Conversions](https://www.facebook.com/business/help/1782327938668950?utm_source=segmentio&utm_medium=docs&utm_campaign=partners) enables offline event tracking, so marketers can run campaigns, upload transaction data, and compare in-store transactions.
 
+> info "Customer Information Parameters Requirements"
+> As of Marketing API V13.0, Facebook began enforcing new requirements for customer information parameters (match keys). To ensure your events do not throw an error, we recommend that you review [Facebook’s new requirements](https://developers.facebook.com/docs/graph-api/changelog/version13.0#conversions-api){:target="_blank"}.
 
 ## Other Facebook Destinations Supported by Segment
 This page is about the **Facebook Offline Conversions**. For documentation on other Facebook destinations, see the pages linked below.


### PR DESCRIPTION
### Proposed changes
StratConn is updating our FB integrations to use the latest API (V14.0). We are currently on V12.0. V13.0 introduced new requirements so this adds a note to our docs so customers are aware of this.

### Merge timing
- On a specific date? We are starting to the roll-out the upgrades from July 27-Aug 2. Since the first customers to get this upgrade will be on July 27 let's publish this note in our **Thurs, July 28** docs deploy please.

### Reference
- https://paper.dropbox.com/doc/STRATCONN-1433-Updating-from-V12.0-to-V14.0-of-the-FB-Marketing-API.--BmB1qelDYJ9tYEu14z50LuXtAQ-22DVMwQQ4Odqy78dfi3zy
- https://segment.atlassian.net/browse/STRATCONN-1433
