### PR TITLE
Remove action source table

### DIFF
--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -66,23 +66,7 @@ Set up your Pixel to work with the Facebook Conversions API (Actions) destinatio
 
 ## Configuration options
 
-The Facebook Conversions API (Actions) destination gives you several ways to implement your conversion tracking. You can use it with [Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/), or as a stand-alone alternative. You can read more about implementation options below and in [Facebook documentation](https://developers.facebook.com/docs/marketing-api/conversions-api/guides/end-to-end-implementation#pick-your-integration-type){:target="_blank"}.
-
-### Action Source
-
-`action_source` is set to "website" as a default value.
-
-You can set `action_source` manually by passing it as a property of a Track event. You can use either snake case or camel case to include `action_source` as a property in Track events.
-
-| Action Source Values | Description                                                                                               |
-| -------------------- | --------------------------------------------------------------------------------------------------------- |
-| `chat`               | Conversion was made through a messaging app, SMS, or online messaging feature.                                |
-| `email`              | Conversion happened over email.                                                                           |
-| `other`              | Conversion happened in a way that is not listed.                                                          |
-| `phone_call`         | Conversion was made over the phone.                                                                       |
-| `physical_store`     | Conversion was made in person at your physical store.                                                     |
-| `system_generated`   | Conversion happened automatically, for example, a subscription renewal that's set on auto-pay each month. |
-| `website`            | Conversion was made on your website.                                                                      |
+The Facebook Conversions API (Actions) destination gives you several ways to implement your conversion tracking. You can use it with [Facebook Pixel](/docs/connections/destinations/catalog/facebook-pixel/), or as a stand-alone alternative. You can read more about implementation options below and in [Facebook documentation](https://developers.facebook.com/docs/marketing-api/conversions-api/guides/end-to-end-implementation#pick-your-integration-type){:target="_blank"}.                                                               |
 
 ### Send events from both the browser and the server
 


### PR DESCRIPTION
### Proposed changes
Hi team! I saw this table got added and it's incorrect. Customers can use any field or hardcode the action source in the new Facebook Conversions API (Actions) destination. In addition, we do not default to anything. This note said we default to web. I would like to remove the table and have customers rely on the FB Documentation that we link to in the description of action source so that we do not need to keep this table updated on our end. Seems repetitive to keep this in here, and in it's current state I think it's confusing. Plus the placement of it chops the configuration options section in half - the paragraph above should go along with sections beneath action source. Thanks!

This got me thinking, is there a process to have PMs review docs updates requested by support before publishing them?

### Merge timing
- ASAP once approved

