### PR TITLE
Add alias for Swift docs

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -34,7 +34,7 @@ To get started with the Analytics-Swift mobile library:
 
     ```swift
     var analytics: Analytics? = nil
-    
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
             // Override point for customization after application launch.
             let configuration = Configuration(writeKey: "WRITE_KEY")
@@ -68,6 +68,7 @@ Once you've installed the Analytics-Swift library, you can start collecting data
 - [Track](#track)
 - [Screen](#screen)
 - [Group](#group)
+- [Alias](#alias)
 
 ### Identify
 The [Identify](/docs/connections/spec/identify/) method lets you tie a user to their actions and record traits about them. This includes a unique user ID and any optional traits you know about them like their email, name, address. The traits option can include any information you want to tie to the user. When using any of the reserved traits, be sure the information reflects the name of the trait. For example, `email`  should always be a string of the user's email address.
@@ -187,7 +188,7 @@ analytics.group(groupId: "user-123", traits: MyTraits(
 {% endcodeexample %}
 
 ### Alias
-The [Alias](/docs/connections/spec/alias/) method is used to merge two user identities, effectively connecting two sets of user data as one. When this method is called, the `newId` value overwrites the old `userId`. If no `userId` is currently set, the `newId` associates with future events as the `userId`. This is an advanced method and may not be supported across the entire destination catalog. 
+The [Alias](/docs/connections/spec/alias/) method is used to merge two user identities, effectively connecting two sets of user data as one. When this method is called, the `newId` value overwrites the old `userId`. If no `userId` is currently set, the `newId` associates with future events as the `userId`. This is an advanced method and may not be supported across the entire destination catalog.
 
 {% codeexample %}
 {% codeexampletab Method signature %}
@@ -202,6 +203,7 @@ analytics.alias(newId: "user-123")
 ```
 {% endcodeexampletab %}
 {% endcodeexample %}
+
 ## Plugin Architecture
 Segment's plugin architecture enables you to modify and augment how the analytics client works. From modifying event payloads to changing analytics functionality, plugins help to speed up the process of getting things done.
 

--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -187,8 +187,7 @@ analytics.group(groupId: "user-123", traits: MyTraits(
 {% endcodeexample %}
 
 ### Alias
-The [Alias](/docs/connections/spec/alias/) method is used to merge two user identities, effectively connecting two sets of user data as one. This is an advanced method, but can be used to manage user identities successfully in some of our destinations. 
-When this method is called the `newId` value will overwrite the old userId. If no userId is currently set, the `newId` will be associated with future events as the userId. This is an advanced method and may not be supported across our destination catalog, please refer to our destination docs to understand if this method is supported or not.
+The [Alias](/docs/connections/spec/alias/) method is used to merge two user identities, effectively connecting two sets of user data as one. When this method is called the `newId` value will overwrite the old userId. If no userId is currently set, the `newId` will be associated with future events as the userId. This is an advanced method and may not be supported across the entire destination catalog, please refer to the destination docs to understand if this method is supported or not.
 
 {% codeexample %}
 {% codeexampletab Method signature %}

--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -186,6 +186,23 @@ analytics.group(groupId: "user-123", traits: MyTraits(
 {% endcodeexampletab %}
 {% endcodeexample %}
 
+### Alias
+The [Alias](/docs/connections/spec/alias/) method is used to merge two user identities, effectively connecting two sets of user data as one. This is an advanced method, but can be used to manage user identities successfully in some of our destinations. 
+When this method is called the `newId` value will overwrite the old userId. If no userId is currently set, the `newId` will be associated with future events as the userId. This is an advanced method and may not be supported across our destination catalog, please refer to our destination docs to understand if this method is supported or not.
+
+{% codeexample %}
+{% codeexampletab Method signature %}
+```swift
+func alias(newId: String)
+```
+{% endcodeexampletab %}
+
+{% codeexampletab Example use %}
+```swift
+analytics.alias(newId: "user-123")
+```
+{% endcodeexampletab %}
+{% endcodeexample %}
 ## Plugin Architecture
 Segment's plugin architecture enables you to modify and augment how the analytics client works. From modifying event payloads to changing analytics functionality, plugins help to speed up the process of getting things done.
 

--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -187,7 +187,7 @@ analytics.group(groupId: "user-123", traits: MyTraits(
 {% endcodeexample %}
 
 ### Alias
-The [Alias](/docs/connections/spec/alias/) method is used to merge two user identities, effectively connecting two sets of user data as one. When this method is called the `newId` value will overwrite the old userId. If no userId is currently set, the `newId` will be associated with future events as the userId. This is an advanced method and may not be supported across the entire destination catalog, please refer to the destination docs to understand if this method is supported or not.
+The [Alias](/docs/connections/spec/alias/) method is used to merge two user identities, effectively connecting two sets of user data as one. When this method is called, the `newId` value overwrites the old `userId`. If no `userId` is currently set, the `newId` associates with future events as the `userId`. This is an advanced method and may not be supported across the entire destination catalog. 
 
 {% codeexample %}
 {% codeexampletab Method signature %}


### PR DESCRIPTION
### Proposed changes
A customer wrote in that we do not list the Alias method in our docs. We do mention it in the migration guide, but we are lacking a definition in the main docs: https://segment.com/docs/connections/sources/catalog/libraries/mobile/swift-ios/migration/