### PR TITLE
updating code sample per partners request

### DIFF
--- a/src/connections/destinations/catalog/appsflyer/index.md
+++ b/src/connections/destinations/catalog/appsflyer/index.md
@@ -43,7 +43,7 @@ To use the latest AppsFlyer SDK to collect IDFAs, do the following:
    // for iOS 13 and earlier - The IDFA will be collected by the SDK. The user will NOT be prompted for permission.
    if #available(iOS 14, *) {
        // Set a timeout for the SDK to wait for the IDFA collection before handling app launch
-       AppsFlyerLib.shared().waitForAdvertisingIdentifier(withTimeoutInterval: 60)
+       AppsFlyerLib.shared().waitForATTUserAuthorization(withTimeoutInterval: 60)
        // Show the user the Apple IDFA consent dialog (AppTrackingTransparency)
        // Can be called in any place
        ATTrackingManager.requestTrackingAuthorization { (status) in


### PR DESCRIPTION
### Proposed changes
Based on partners request - updating the code sample to their new function name
"They documented an outdated version of the method waitForAdvertisingIdentifier  - https://segment.com/docs/connections/destinations/catalog/appsflyer/#additional-device-mode-set-up-for-ios-14-support
The method name has been changed in our SDK to waitForATTUserAuthorization a while ago, and their documentation needs to be updated accordingly. "

### Merge timing
ASAP once approved

