### PR TITLE
Remove beta status for mixpanel actions

### DIFF
--- a/src/connections/destinations/catalog/actions-mixpanel/index.md
+++ b/src/connections/destinations/catalog/actions-mixpanel/index.md
@@ -3,7 +3,6 @@ title: Mixpanel (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
 id: 615c7438d93d9b61b1e9e192
-beta: true
 redirect_from:
   - '/connections/destinations/catalog/mixpanel-actions'
 ---


### PR DESCRIPTION
### Proposed changes

remove beta status

### Merge timing
asap

### note

I changed the status in the partner portal to Public, not sure if this would have been automatically updated on the docs page as a result, but being that beta was hard-coded in the file header I went ahead and removed it.

