### PR TITLE
Make cordial actions searchable in catalog

### DIFF
--- a/src/connections/destinations/catalog/actions-cordial/index.md
+++ b/src/connections/destinations/catalog/actions-cordial/index.md
@@ -1,6 +1,5 @@
 ---
 title: Cordial (Actions) Destination
-hidden: true
 hide-boilerplate: true
 hide-dossier: true
 ---

--- a/src/connections/destinations/catalog/actions-cordial/index.md
+++ b/src/connections/destinations/catalog/actions-cordial/index.md
@@ -2,6 +2,8 @@
 title: Cordial (Actions) Destination
 hide-boilerplate: true
 hide-dossier: true
+redirect_from:
+  - '/connections/destinations/catalog/cordial-actions'
 ---
 
 {% include content/plan-grid.md name="actions" %}


### PR DESCRIPTION
### Proposed changes

Make cordial actions searchable in catalog, and redirect from broken link: 

<img width="395" alt="Screen Shot 2022-08-23 at 3 16 42 PM" src="https://user-images.githubusercontent.com/64277654/186248372-24bcec00-46f4-4755-983c-252d33a35fa2.png">

<img width="646" alt="Screen Shot 2022-08-23 at 3 26 08 PM" src="https://user-images.githubusercontent.com/64277654/186248834-1330b758-fa50-4b48-8729-2ea4cf2864b4.png">
<img width="734" alt="Screen Shot 2022-08-23 at 3 26 23 PM" src="https://user-images.githubusercontent.com/64277654/186248843-c759b4d1-2c92-4d69-9789-c45db75c8809.png">


### Merge timing
asap
