### PR TITLE
Customer.io destination actions don't support alias or group calls

### DIFF
--- a/src/_data/catalog/destinations.yml
+++ b/src/_data/catalog/destinations.yml
@@ -12673,8 +12673,8 @@ items:
   methods:
     track: true
     identify: true
-    group: true
-    alias: true
+    group: false
+    alias: false
     page: true
   platforms:
     browser: true


### PR DESCRIPTION
### Proposed changes

Remove `alias` and `group` methods from Customer.io Destination Actions page. 

I had some local environment issues and struggled to build locally, but I'm pretty sure I made this change in the right place.

### Merge timing
- ASAP once approved
