### PR TITLE
Add info for uuid during local development

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/react-native/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/index.md
@@ -511,7 +511,7 @@ No, only the plugins listed above are supported in device-mode for Analytics Rea
 ### Will I still see device-mode integrations listed as `false` in the integrations object?
 When you successfully package a plugin in device-mode, you won't see the integration listed as `false` in the integrations object for a Segment event. This logic is packaged in the event metadata, and isn't surfaced in the Segment debugger.
 ### Why are my IDs not set in UUID format?
-Due to [issues](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/uuid.ts#L5){:target="_blank"} with the React Native bridge, Segment doesn't use UUID format for `anonymousId`s and `messageId`s in local development. These IDs will be set in UUID format for your live app.  
+Due to [limitations](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/uuid.ts#L5){:target="_blank"} with the React Native bridge, Segment doesn't use UUID format for `anonymousId`s and `messageId`s in local development. These IDs will be set in UUID format for your live app.  
 
 ## Changelog
 [View the Analytics React Native 2.0 changelog on GitHub](https://github.com/segmentio/analytics-react-native/releases){:target="_blank"}.

--- a/src/connections/sources/catalog/libraries/mobile/react-native/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/index.md
@@ -510,6 +510,8 @@ To collect the Android Advertising ID provided by Play Services, Segment provide
 No, only the plugins listed above are supported in device-mode for Analytics React Native 2.0.
 ### Will I still see device-mode integrations listed as `false` in the integrations object?
 When you successfully package a plugin in device-mode, you won't see the integration listed as `false` in the integrations object for a Segment event. This logic is packaged in the event metadata, and isn't surfaced in the Segment debugger.
+### Why are my IDs not set as UUID format?
+Due to [issues](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/uuid.ts#L5) with the React Native bridge, Segment does not use UUID format for anonymousIds and messageIds in local development. These IDs will be set to UUID format for your live app.  
 
 ## Changelog
 [View the Analytics React Native 2.0 changelog on GitHub](https://github.com/segmentio/analytics-react-native/releases){:target="_blank"}.

--- a/src/connections/sources/catalog/libraries/mobile/react-native/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/index.md
@@ -510,8 +510,8 @@ To collect the Android Advertising ID provided by Play Services, Segment provide
 No, only the plugins listed above are supported in device-mode for Analytics React Native 2.0.
 ### Will I still see device-mode integrations listed as `false` in the integrations object?
 When you successfully package a plugin in device-mode, you won't see the integration listed as `false` in the integrations object for a Segment event. This logic is packaged in the event metadata, and isn't surfaced in the Segment debugger.
-### Why are my IDs not set as UUID format?
-Due to [issues](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/uuid.ts#L5) with the React Native bridge, Segment does not use UUID format for anonymousIds and messageIds in local development. These IDs will be set to UUID format for your live app.  
+### Why are my IDs not set in UUID format?
+Due to [issues](https://github.com/segmentio/analytics-react-native/blob/master/packages/core/src/uuid.ts#L5){:target="_blank"} with the React Native bridge, Segment doesn't use UUID format for `anonymousId`s and `messageId`s in local development. These IDs will be set in UUID format for your live app.  
 
 ## Changelog
 [View the Analytics React Native 2.0 changelog on GitHub](https://github.com/segmentio/analytics-react-native/releases){:target="_blank"}.


### PR DESCRIPTION
### Proposed changes
Due to limitations with React Native, we do not set UUID during local development. UUID will be set on a live app for anonymousId and messageId, but not locally.