### PR TITLE
add note about order id

### DIFF
--- a/src/connections/destinations/catalog/google-ads-gtag/index.md
+++ b/src/connections/destinations/catalog/google-ads-gtag/index.md
@@ -13,7 +13,7 @@ The [Google global site tag (gtag.js)](https://support.google.com/google-ads/ans
 > Only use this destination if your Google Ads account is using Gtag. If you're using Google Tag Manager, don't add the global site tag (gtag.js) in your GTM containers. You should also disable any [Google Ads (Classic)](/docs/connections/destinations/catalog/adwords/) destinations within the same source, since **Google Ads (Classic)** can't load at the same time as **Google Ads (Gtag)**.
 
 > success "" 
-> If you are sending [enhancement data to Google Ads](/docs/connections/destinations/catalog/actions-google-enhanced-conversions/) in parallel with Gtag, you must include the same Order ID (Transaction ID) on both sets of data. This is required to properly deduplicate conversions between Gtag conversions and enhanced conversions. To send Order ID (Transaction ID) to Gtag, include `order_id` as a property on your web events. 
+> If you're sending [enhancement data to Google Ads](/docs/connections/destinations/catalog/actions-google-enhanced-conversions/) in parallel with Gtag, you must include the same Order ID (Transaction ID) on both sets of data. This is required to properly deduplicate conversions between Gtag conversions and enhanced conversions. To send Order ID (Transaction ID) to Gtag, include `order_id` as a property on your web events. 
 
 ## Getting Started
 

--- a/src/connections/destinations/catalog/google-ads-gtag/index.md
+++ b/src/connections/destinations/catalog/google-ads-gtag/index.md
@@ -12,6 +12,9 @@ The [Google global site tag (gtag.js)](https://support.google.com/google-ads/ans
 > info ""
 > Only use this destination if your Google Ads account is using Gtag. If you're using Google Tag Manager, don't add the global site tag (gtag.js) in your GTM containers. You should also disable any [Google Ads (Classic)](/docs/connections/destinations/catalog/adwords/) destinations within the same source, since **Google Ads (Classic)** can't load at the same time as **Google Ads (Gtag)**.
 
+> info "" 
+> If you are sending [enhancement data to Google Ads](/docs/connections/destinations/catalog/actions-google-enhanced-conversions/) in parallel with Gtag, you must include the same Order ID (Transaction ID) on both sets of data. This is required to properly deduplicate conversions between Gtag conversions and enhanced conversions. To send Order ID (Transaction ID) to Gtag, include `order_id` as a property on your web events. 
+
 ## Getting Started
 
 You can use this destination to map your `.page()` calls to **Page Load Conversions** or `.track()` calls to **Click Conversions**. Currently this is only supported on the browser.

--- a/src/connections/destinations/catalog/google-ads-gtag/index.md
+++ b/src/connections/destinations/catalog/google-ads-gtag/index.md
@@ -12,7 +12,7 @@ The [Google global site tag (gtag.js)](https://support.google.com/google-ads/ans
 > info ""
 > Only use this destination if your Google Ads account is using Gtag. If you're using Google Tag Manager, don't add the global site tag (gtag.js) in your GTM containers. You should also disable any [Google Ads (Classic)](/docs/connections/destinations/catalog/adwords/) destinations within the same source, since **Google Ads (Classic)** can't load at the same time as **Google Ads (Gtag)**.
 
-> info "" 
+> success "" 
 > If you are sending [enhancement data to Google Ads](/docs/connections/destinations/catalog/actions-google-enhanced-conversions/) in parallel with Gtag, you must include the same Order ID (Transaction ID) on both sets of data. This is required to properly deduplicate conversions between Gtag conversions and enhanced conversions. To send Order ID (Transaction ID) to Gtag, include `order_id` as a property on your web events. 
 
 ## Getting Started


### PR DESCRIPTION
### Proposed changes
We're finding that most of the errors with Enhanced Conversions setup are around customers not sending Order IDs over via both Gtag and Enhanced Conversions (it is required for both to work nicely together). Google has requested we add this paragraphs/note to ensure customers implement correctly.

### Merge timing
- ASAP once approved

### Related issues (optional)
Similar note added for Google Enhanced Conversions the other week: https://github.com/segmentio/segment-docs/pull/3440
