### PR TITLE
Update Edge proxy language

### DIFF
--- a/src/guides/regional-segment.md
+++ b/src/guides/regional-segment.md
@@ -69,6 +69,11 @@ Regional Segment in the EU changes the way you [configure the Data Lakes AWS env
 ### Warehouse Public IP Range
 Use Segment's custom CIDR `3.251.148.96/29` while authorizing Segment to write in to your Redshift or Postgres port. [BigQuery](/docs/connections/storage/catalog/bigquery/#getting-started) doesn't require you to allow a custom IP address.
 
+## Known Limitations
+-   Regional Segment is currently limited to the EU. Future expansion of Regional Segment beyond the EU is under evaluation by Segment Product and R&D.
+    
+-   Edge proxies have been deprecated. Customers still using edge proxies may have US-based IP addresses show up in event payloads. For EU customers, it is recommended that a Regionalized EU workspace is used instead For non-EU customers, it is recommended that the US-based endpoint (`api.segment.io`) is used to preserve client IP addresses.
+
 ## Destination support and Regional endpoint availability
 
 > info "Don't see a regional endpoint for a tool you're using?"

--- a/src/guides/regional-segment.md
+++ b/src/guides/regional-segment.md
@@ -72,7 +72,7 @@ Use Segment's custom CIDR `3.251.148.96/29` while authorizing Segment to write i
 ## Known Limitations
 -   Regional Segment is currently limited to the EU. Future expansion of Regional Segment beyond the EU is under evaluation by Segment Product and R&D.
     
--   Edge proxies have been deprecated. Customers still using edge proxies may have US-based IP addresses show up in event payloads. For EU customers, it is recommended that a Regionalized EU workspace is used instead For non-EU customers, it is recommended that the US-based endpoint (`api.segment.io`) is used to preserve client IP addresses.
+-   Edge proxies are deprecated. Customers using edge proxies may see US-based IP addresses in event payloads. For EU customers, Segment recommends using a Regionalized EU workspace. For non-EU customers, Segment recommends using the US-based endpoint (`api.segment.io`) to preserve client IP addresses.
 
 ## Destination support and Regional endpoint availability
 


### PR DESCRIPTION
Updated known limitations for edge proxies, based on https://segment.atlassian.net/browse/DRES-983

- Encouraged EU customers to switch to regionalized workspaces
- Asked customers using edge proxies to switch to US api endpoint if preserving client IP addresses in payload is needed
