### PR TITLE
adds FAQ to Source Function docs about GET requests

### DIFF
--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -399,6 +399,6 @@ The execution time limit is five seconds, however Segment strongly recommends th
 
 Segment alphabetizes payload fields that come in to **deployed** Source Functions. Segment doesn't alphabetize payloads in the Functions tester. If you need to verify the exact payload that hits a Source Function, alphabetize it first. You can then make sure it matches what the Source Function ingests.
 
-#### Does the source function allow GET requests?
+#### Does the source function allow `GET` requests?
 
-GET requests are not supported with a source function, and the only way for the source function to receive data is through a POST request.
+`GET` requests are not supported with a source function, and the only way for the source function to receive data is through a POST request.

--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -398,3 +398,7 @@ The execution time limit is five seconds, however Segment strongly recommends th
 #### Does Segment alter incoming payloads?
 
 Segment alphabetizes payload fields that come in to **deployed** Source Functions. Segment doesn't alphabetize payloads in the Functions tester. If you need to verify the exact payload that hits a Source Function, alphabetize it first. You can then make sure it matches what the Source Function ingests.
+
+#### Does the source function allow GET requests?
+
+GET requests are not supported with a source function, and the only way for the source function to receive data is through a POST request.

--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -401,4 +401,4 @@ Segment alphabetizes payload fields that come in to **deployed** Source Function
 
 #### Does the source function allow `GET` requests?
 
-`GET` requests are not supported with a source function, and the only way for the source function to receive data is through a POST request.
+`GET` requests are not supported with a source function. Source functions can only receive data through `POST` requests.


### PR DESCRIPTION
### Proposed changes

Added a FAQ to the Source Functions docs to mention that source functions only support POST requests currently, and GET requests are not supported. We have had a few ZD tickets about this

### Merge timing
- ASAP once approved

### Related issues 

https://segment.zendesk.com/agent/tickets/484695
https://segment.zendesk.com/agent/tickets/438133
https://segment.zendesk.com/agent/tickets/470517