### PR TITLE
Fix Server Debugger Typo #3558

### DIFF
--- a/src/_includes/content/troubleshooting-server-debugger.md
+++ b/src/_includes/content/troubleshooting-server-debugger.md
@@ -2,6 +2,6 @@
 
 1. Double check that you've followed all the steps in the [Quickstart](quickstart/).
 
-2. Make sure that you're calling one of our API methods once the library is successfully installed—[`identify`](#identify), [`track`](#track), etc.
+2. Make sure that you're calling a Segment API method once the library is successfully installed—[`identify`](#identify), [`track`](#track), etc.
 
-3. Make sure your application isn't shutting down before the `Analytics.Client` local queue events are pushed to Segemet. You can manually call `Analytics.Client.Flush()` to ensure the queue is fully processed before shutdown.
+3. Make sure your application isn't shutting down before the `Analytics.Client` local queue events are pushed to Segment. You can manually call `Analytics.Client.Flush()` to ensure the queue is fully processed before shutdown.


### PR DESCRIPTION
### Proposed changes

- Fixed `Segement` typo in server debugger includes.
- Fixed a first-person plural usage in the same includes. 

### Merge timing

- ASAP once approved.

### Related issues (optional)

- Closes #3558.