### PR TITLE
Add Analytics.js Cookie Subdomain Info [DOC-582]

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -97,7 +97,7 @@ sections:
   section_title: Analytics.js Documentation
   section:
   - path: /connections/sources/catalog/libraries/website/javascript
-    title: Analytics.js (Javascript) Source
+    title: Analytics.js (JavaScript) Source
   - path: /connections/sources/catalog/libraries/website/javascript/ajs-classic
     title: Analytics.js Classic
   - path: /connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2

--- a/src/connections/sources/catalog/libraries/website/javascript/persistence.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/persistence.md
@@ -5,15 +5,15 @@ strat: ajs
 
 This page explains what data Analytics.js stores on the client and how to override and change what and how this data is stored.
 
-## Segment ID Persistence
+## Segment ID persistence
 
 <!-- Note: 1st 2 paragraphs copied from identity.md -->
 
-To ensure high fidelity, first-party customer data, Segment writes the user's IDs to the user's local storage, and uses that as the Segment ID on the cookie whenever possible. Local storage is for storing this type of first-party customer information.
+To ensure high fidelity, first-party customer data, Segment writes the user's IDs to the user's local storage and uses that as the Segment ID on the cookie whenever possible. Local storage is for storing this type of first-party customer information.
 
 If a user returns to your site after the cookie expires, Analytics.js looks for an old ID in the user's `localStorage`, and if one is found, it sets as the user's ID again in the new cookie. If a user clears their cookies _and_ `localStorage`, all of the IDs are removed, and the user gets a completely new [`anonymousID`](/docs/connections/sources/catalog/libraries/website/javascript/identity/#anonymous-ids) when they next visit the page.
 
-### Cookie Settings
+### Cookie settings
 
 Analytics.js sets some default properties when creating cookies for user or group identities. You can override the default cookie properties in code when loading Analytics.js by passing in a `cookie` object to the load method.
 
@@ -21,7 +21,7 @@ Here is the full list of available parameters with their default values:
 
 | Parameter | Description | Default value |
 | --- | --- | --- |
-| `domain` | The domain to set the cookie to. This must match the domain of the JavaScript origin. Cookies set on top-level domain are available to sub-domains. | Top-level domain |
+| `domain` | The domain to set the cookie to. This must match the domain of the JavaScript origin. If an Analytics.js cookie already exists at the top-level domain, Segment carries the same cookie value to any subdomains, despite `domain` configuration. | Top-level domain |
 | `maxage` | The maximum amount of time in seconds before the cookie expires. Browsers may clear cookies before this elapses. | 1 year |
 | `path` | The path the cookie is valid for. | `"/"` |
 | `sameSite` | This prevents the browser from sending the cookie along with cross-site requests. | `Lax` |
@@ -40,7 +40,7 @@ analytics.load('writeKey', {
 })
 ```
 
-### User Settings
+### User settings
 
 Analytics.js automatically persists the user's ID and traits locally. You can override how and where the user ID and traits are stored when loading Analytics.js by passing in a `user` object to the load method.
 
@@ -68,7 +68,7 @@ analytics.load('writeKey', {
 })
 ```
 
-### Group Settings
+### Group settings
 
 Analytics.js automatically persists the user's group ID and group properties locally. You can override how and where the group ID and properties are stored when loading Analytics.js by passing in a `group` object to the load method.
 
@@ -95,11 +95,11 @@ analytics.load('writeKey', {
 })
 ```
 
-## Persistent Retries
+## Persistent retries
 
 When enabled, Analytics.js automatically retries network and server errors. When the client is offline or your application can't connect to Segment's API, Analytics.js stores events in `localStorage` and falls back to in-memory storage when `localStorage` is unavailable.
 
-## Disable All Client-Side Persistence
+## Disable all client-side persistence
 
 <!-- TODO: Mention GDPR and/or regulations as a reason to do this? -->
 Analytics.js supports disabling persisting any data locally. This will force analytics.js to store data in-memory only and disables automatic identity tracking across pages.
@@ -114,9 +114,9 @@ analytics.load('writeKey', { disableClientPersistence: true })
 
 When `disableClientPersistence` is set to `true`, Analytics.js won't be able to automatically keep track of a user's identity when navigating to different pages. This can cause increased MTU usage if the anonymous usage can't be associated with a `userId`.
 
-You can still manually track identity by calling `analytics.identify()` with the known identity on each page load, or you can pass in identity information to each page using the [querystring API](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/querystring/).
+You can still manually track identity by calling `analytics.identify()` with the known identity on each page load, or you can pass in identity information to each page using the [querystring API](/docs/connections/sources/catalog/libraries/website/javascript/querystring/).
 
-### Event Retries
+### Event retries
 
 Analytics.js tries to detect when a page is about to be closed and saves pending events to `localStorage`. When the user navigates to another page within the same domain, Analytics.js attempts to send any events it finds in localStorage.
 


### PR DESCRIPTION
### Proposed changes

- Added clarification about Analytics.js cookie behavior on subdomains.
- Minor cleanup (relative URL, header casing, `Javascript` to `JavaScript`).

### Merge timing

- ASAP once approved.