### PR TITLE
Unhide Intercom Actions docs ahead of Public Beta

### DIFF
--- a/src/connections/destinations/catalog/actions-intercom-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-intercom-cloud/index.md
@@ -2,8 +2,6 @@
 title: Intercom Cloud Mode (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-private: true
 id: 62ded0cf5753c743883ca0f3
 versions:
   - name: 'Intercom Web (Actions)'

--- a/src/connections/destinations/catalog/actions-intercom-web/index.md
+++ b/src/connections/destinations/catalog/actions-intercom-web/index.md
@@ -2,8 +2,6 @@
 title: Intercom Web (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-private: true
 id: 62d9daff84a6bf190da9f592
 hide_action:
   - id: 5W984Qq59XEQnFYKXKHGeZ


### PR DESCRIPTION
### Proposed changes
We are going to put Intercom Web (Actions) and Intercom Cloud Mode (Actions) in Public Beta next Monday 10/10. This will be a fairly silent Public Beta, but we do want to make sure the docs are available for customers who do stumble upon the destinations. This PR unhides the two docs.

### Merge timing
- On a specific date - Can we please include this in the Tues 10/11 docs deploy? Thanks!

### Related issues (optional)
https://segment.atlassian.net/browse/HGI-32
https://segment.atlassian.net/browse/HGI-31
