### PR TITLE
Fixed link to correct page (led to a 404 page before)

### DIFF
--- a/src/api/config-api/index.md
+++ b/src/api/config-api/index.md
@@ -99,6 +99,6 @@ $ curl \
 
 ## Reference
 
-For an overview of the API's common design patterns and important information about versioning and compatibility, see the [API Design](/docs/config-api/api-design) document.
+For an overview of the API's common design patterns and important information about versioning and compatibility, see the [API Design](/docs/api/config-api/api-design) document.
 
 To see all the API methods and models see the [Segment Config API Reference](https://reference.segmentapis.com/).

--- a/src/api/config-api/index.md
+++ b/src/api/config-api/index.md
@@ -101,4 +101,4 @@ $ curl \
 
 For an overview of the API's common design patterns and important information about versioning and compatibility, see the [API Design](/docs/api/config-api/api-design) document.
 
-To see all the API methods and models see the [Segment Config API Reference](https://reference.segmentapis.com/).
+To see all the API methods and models see the [Segment Config API Reference](https://reference.segmentapis.com/){:target="_blank"}.


### PR DESCRIPTION
link led to a 404 before, now the link to `API Design` should work.

### Proposed changes

changed path from /docs/config-api/fql/ to /docs/api/config-api/fql/

https://segment.com/docs/config-api/fql/ surfaces a 404 error
https://segment.com/docs/api/config-api/fql/ works

### Merge timing

- ASAP once approved
