### PR TITLE
added a redirect from a deprecated page (shows a 404) to the current one

### DIFF
--- a/src/api/config-api/fql.md
+++ b/src/api/config-api/fql.md
@@ -1,5 +1,7 @@
 ---
 title: Destination Filter Query Language
+redirect_from:
+  - '/docs/config-api/fql'
 ---
 
 {% include content/papi-ga.html %}


### PR DESCRIPTION
redirected old url `/docs/config-api/fql` to new one `/docs/app/config-api/fql`

### Proposed changes

going to https://segment.com/docs/config-api/fql/ lands on a 404 page, so redirecting it to the correct page

### Merge timing

- ASAP once approved

### Related issues (optional)

fixing a hyperlink with same issue: #3622