### PR TITLE
Add example that shows how to set the host to the EU endpoint

### DIFF
--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -36,6 +36,14 @@ This will create an instance of `Analytics` that you can use to send data to Seg
 For Business plans with access to [Regional Segment](/docs/guides/regional-segment), you can use the `host` configuration parameter to send data to the desired region:
 1. Oregon (Default) — `api.segment.io/v1`
 2. Dublin — `events.eu1.segmentapis.com/v1/`
+
+An example of setting the host to the EU endpoint using the Node library would be:
+```javascript
+var analytics = new Analytics('YOUR_WRITE_KEY', {
+    host: "https://events.eu1.segmentapis.com"
+  });
+```
+
 ## Identify
 
 > note ""

--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -35,7 +35,7 @@ This will create an instance of `Analytics` that you can use to send data to Seg
 ### Regional configuration
 For Business plans with access to [Regional Segment](/docs/guides/regional-segment), you can use the `host` configuration parameter to send data to the desired region:
 1. Oregon (Default) — `api.segment.io/v1`
-2. Dublin — `events.eu1.segmentapis.com/v1/`
+2. Dublin — `events.eu1.segmentapis.com`
 
 An example of setting the host to the EU endpoint using the Node library would be:
 ```javascript


### PR DESCRIPTION
We're facing a lot of confusion from customers on how to change the host to point towards to EU. Usually when we show them a code example they understand.

### Proposed changes

I've added an example of how to set the host to the EU endpoint in the Regional Section to make it quicker and easier for customers to implement. Changing the host changes from library to library with no way for the customer know other than to check our integration code or testing multiple versions of the URL.

### Merge timing
ASAP once approved

