### PR TITLE
Unhide Pardot Actions docs

### DIFF
--- a/src/connections/destinations/catalog/actions-pardot/index.md
+++ b/src/connections/destinations/catalog/actions-pardot/index.md
@@ -2,8 +2,6 @@
 title: Pardot (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-private: true
 strat: salesforce
 id: 62df16e45ba0058c864a75d1
 ---

--- a/src/connections/destinations/catalog/actions-pardot/index.md
+++ b/src/connections/destinations/catalog/actions-pardot/index.md
@@ -1,5 +1,5 @@
 ---
-title: Pardot (Actions) Destination
+title: Salesforce Pardot (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
 strat: salesforce


### PR DESCRIPTION
### Proposed changes
We are moving Pardot (Actions) to public beta to get more visibility. This change unhides the docs so customers can find/see them in our public docs.

### Merge timing
- ASAP once approved - ideally in the Oct 27 deploy! 

PR for adding to salesforce side nav: https://github.com/segmentio/segment-docs/pull/3725

