### PR TITLE
add Pardot (Actions) to salesforce nav

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -84,6 +84,8 @@ sections:
     title: Salesforce (Actions) destination
   - path: /connections/destinations/catalog/salesforce-marketing-cloud
     title: Salesforce Marketing Cloud destination
+  - path: /connections/destinations/catalog/actions-pardot
+    title: Salesforce Pardot (Actions) destination
   - path: /connections/destinations/catalog/pardot
     title: Salesforce Pardot destination
   - path: /connections/sources/catalog/cloud-apps/salesforce


### PR DESCRIPTION
### Proposed changes
We are moving Pardot (Actions) to public beta to get more visibility. This change adds Pardot (Actions) to the side nav for Salesforce.

### Merge timing
- ASAP once approved - ideally Oct 27 deploy alongside this PR: https://github.com/segmentio/segment-docs/pull/3724

