### PR TITLE
Vale Substitution List Updates

### DIFF
--- a/vale-styles/segment/subs.yml
+++ b/vale-styles/segment/subs.yml
@@ -13,3 +13,4 @@ swap:
   leveraging: using
   via: through, or using
   drop in: enter
+  Sendgrid: SendGrid

--- a/vale-styles/segment/subs.yml
+++ b/vale-styles/segment/subs.yml
@@ -14,3 +14,4 @@ swap:
   via: through, or using
   drop in: enter
   Sendgrid: SendGrid
+  APi: API


### PR DESCRIPTION
### Proposed changes

- Added flags for `Sendgrid` and `APi` to the Vale substitution rules list.

### Merge timing

- ASAP once approved.