### PR TITLE
update http api index file

### DIFF
--- a/src/connections/sources/catalog/libraries/server/http-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/http-api/index.md
@@ -14,7 +14,7 @@ Segment has native [sources](/docs/connections/sources/) for most use cases (lik
 Authenticate to the Tracking API by sending your project's **Write Key** along with a request.
 Authentication uses HTTP Basic Auth, which involves a `username:password` that is base64 encoded and prepended with the string `Basic`.
 
-In practice that means taking a Segment source **Write Key**,`'abc123'`, as the username, adding a colon, and then the password field is left empty. After base64 encoding `'abc123:'` becomes `'YWJjMTIzOg=='`; and this is passed in the authorization header like so: `'Authorization: Basic YWJjMTIzOg=='`.
+In practice that means taking a Segment source **Write Key**,`'abc123'`, as the username, adding a colon, and then the password field is left empty. After base64 encoding `'abc123'` becomes `'YWJjMTIz'`; and this is passed in the authorization header like so: `'Authorization: Basic YWJjMTIz'`.
 
 ### Content-Type
 


### PR DESCRIPTION
Updating the base64 encoding example

Removed the colon from the write key example and updated the base64 encoding of that updated value, this was highlighted by one of our customers. 

Ideally this will merge at the earliest convenience of the docs team.
