### PR TITLE
fix fql references in docs

### DIFF
--- a/src/_data/sidenav/main.yml
+++ b/src/_data/sidenav/main.yml
@@ -475,8 +475,13 @@ sections:
     title: Verifying Your Email Address
 - section_title: API
   section:
-  - path: /api/public-api
-    title: Public API
+  - section_title: Public API
+    slug: api/public-api
+    section:
+    - path: /api/public-api
+      title: Public API
+    - path: /api/public-api/fql
+      title: Destination Filter Query Language
   - section_title: Config API
     slug: api/config-api
     section:
@@ -486,8 +491,6 @@ sections:
       title: API design
     - path: /api/config-api/authentication
       title: Authentication
-    - path: /api/config-api/fql
-      title: Destination Filter Query Language
     # - path: "https://reference.segmentapis.com/"
     #   title: Reference
     #   menu_icon: new-tab

--- a/src/api/public-api/fql.md
+++ b/src/api/public-api/fql.md
@@ -1,7 +1,7 @@
 ---
 title: Destination Filter Query Language
 redirect_from:
-  - '/docs/config-api/fql'
+  - '/docs/public-api/fql'
 ---
 
 {% include content/papi-ga.html %}

--- a/src/api/public-api/fql.md
+++ b/src/api/public-api/fql.md
@@ -1,7 +1,7 @@
 ---
 title: Destination Filter Query Language
 redirect_from:
-  - '/docs/public-api/fql'
+  - '/docs/config-api/fql'
 ---
 
 {% include content/papi-ga.html %}

--- a/src/api/public-api/fql.md
+++ b/src/api/public-api/fql.md
@@ -130,7 +130,7 @@ You can use parentheses to group subexpressions for more complex "and / or" logi
 | `length( list or string )`          | `number`    | Returns the number of elements in a list or number of bytes (not necessarily characters) in a string. For example, `a`  is 1 byte and`ア` is 3 bytes long. |
 | `lowercase( s string )`             | `string`    | Returns `s` with all uppercase characters replaced with their lowercase equivalent.                                                                        |
 | `typeof( value )`                   | `string`    | Returns the type of the given value: `"string"`, `"number"`, `"list"`, `"bool"`, or `"null"`.                                                              |
-| `match( s string, pattern string )` | `bool`      | Returns `true` if the glob pattern `pattern` matches `s`. See below for more details about glob matching.                                                  |
+| `match( s string, pattern string )` | `bool`      | Returns `true` if the glob pattern `pattern` matches `s`. See below for more details about glob matching.  |
 
 Functions handle `null` with sensible defaults to make writing FQL more concise.
 For example, you can write `length( userId ) > 0` instead of `typeof( userId ) =

--- a/src/api/public-api/index.md
+++ b/src/api/public-api/index.md
@@ -1,5 +1,7 @@
 ---
 title: Public API
+redirect_from:
+  - '/public-api'
 ---
 The Segment Public API helps you manage your Segment workspaces and its resources. You can use the API to perform CRUD (create, read, update, delete) operations at no extra charge. This includes working with resources such as Sources, Destinations, Warehouses, Tracking Plans, and the Segment Destinations and Sources Catalogs.
 

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -46,7 +46,7 @@ To create a destination filter:
 
 ## Destination filters API
 
-The destination filters API provides more power than Segment's dashboard destination filters settings. With the API, you can create complex filters that are conditionally applied using Segment's [Filter Query Language (FQL)](/docs/api/config-api/fql/).
+The destination filters API provides more power than Segment's dashboard destination filters settings. With the API, you can create complex filters that are conditionally applied using Segment's [Filter Query Language (FQL)](/docs/api/public-api/fql/).
 
 The destination filters API offers four different filter types:
 


### PR DESCRIPTION
### Proposed changes
- We recently got the following comment from a different PM
```
- When looking at the information around FQL, I found the information architecture to be a bit off, I don’t know if this would be in y’all’s court or maybe Public API team?
  - Destination Filters [docs](https://segment.com/docs/connections/destinations/destination-filters/) reference FQL, which links to>
  - An FQL page contained within the [Segment docs section for Config API docs](https://segment.com/docs/api/config-api/fql/), which points to the fact that Public API is available, and also links to the config api docs>
  - However it says full filter reference docs can be found in the [main config api reference](https://reference.segmentapis.com/#6c12fbe8-9f84-4a6c-848e-76a2325cb3c5) material (which we can assume will be deprecated at some point in favor of Public API?), which also has a link to ‘more detailed documentation including a list of all operators and functions’, which links to>
  - [an empty page](https://segment.com/docs/config-api/fql)
additionally, the [Public API docs](https://docs.segmentapis.com/) have no reference to FQL that I can find, and does not replicate the important FQL language structure that is seen in the config api docs
```
- In order to fix the above:
  - FQL references should be moved under PAPI from Config API 
  - Fixing couple of broken links (also making changes to the public-api repo)

### Merge timing
- ASAP once approved?

