### PR TITLE
Unhide HubSpot Web Actions on 11/8 Public Beta

### DIFF
--- a/src/connections/destinations/catalog/actions-hubspot-web/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-web/index.md
@@ -2,8 +2,6 @@
 title: HubSpot Web (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-private: true
 id: 631a1c2bfdce36a23f0a14ec
 versions:
   - name: 'HubSpot Cloud Mode (Actions)'


### PR DESCRIPTION
### Proposed changes
We are moving HubSpot Web (Actions) to Public Beta on Nov 8. This unhides the public docs ahead of that.

### Merge timing
- ASAP once approved - Can we get this merged and deployed in the Tues, Nov 8 deploy please? Thanks!

