### PR TITLE
Update index.md file for the HTTP API section

### DIFF
--- a/src/connections/sources/catalog/libraries/server/http-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/http-api/index.md
@@ -14,7 +14,9 @@ Segment has native [sources](/docs/connections/sources/) for most use cases (lik
 Authenticate to the Tracking API by sending your project's **Write Key** along with a request.
 Authentication uses HTTP Basic Auth, which involves a `username:password` that is base64 encoded and prepended with the string `Basic`.
 
-In practice that means taking a Segment source **Write Key**,`'abc123'`, as the username, adding a colon, and then the password field is left empty. After base64 encoding `'abc123'` becomes `'YWJjMTIz'`; and this is passed in the authorization header like so: `'Authorization: Basic YWJjMTIz'`.
+In practice that means taking a Segment source **Write Key**,`'abc123'`, as the username, adding a colon, and then the password field is left empty. After base64 encoding `'abc123:'` becomes `'YWJjMTIzOg=='`; and this is passed in the authorization header like so: `'Authorization: Basic YWJjMTIzOg=='`.
+
+**Note:** Encoding the write key without a colon may work due to backward compatibility, but this may not always be the case so it is important to include the colon prior to encoding.
 
 ### Content-Type
 

--- a/src/connections/sources/catalog/libraries/server/http-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/http-api/index.md
@@ -16,7 +16,7 @@ Authentication uses HTTP Basic Auth, which involves a `username:password` that i
 
 In practice that means taking a Segment source **Write Key**,`'abc123'`, as the username, adding a colon, and then the password field is left empty. After base64 encoding `'abc123:'` becomes `'YWJjMTIzOg=='`; and this is passed in the authorization header like so: `'Authorization: Basic YWJjMTIzOg=='`.
 
-**Note:** Encoding the write key without a colon may work due to backward compatibility, but this may not always be the case so it is important to include the colon prior to encoding.
+**Note:** Encoding the write key without a colon may work due to backward compatibility, but this may not always be the case, so it's important to include the colon before encoding.
 
 ### Content-Type
 


### PR DESCRIPTION
Updating the auth header example to add the colon back in and also adding a note about not relying on the absence of the colon because of past behavior.

We had originally removed the colon example due to customer feedback, however this is the proper way to perform the encoding. Also adding a note to recommend not relying on backward compatibility support (lack of a colon) moving forward.

### Merge timing
Would love to merge this asap once approved.
