### PR TITLE
correct role definition

### DIFF
--- a/src/segment-app/iam/roles.md
+++ b/src/segment-app/iam/roles.md
@@ -43,7 +43,7 @@ The following roles are only available to Segment Business Tier accounts.
 
 
 #### Profiles and Engage Read-only
-* Read-only access to Profiles settings and if purchased, edit access to Engage audiences, traits, journeys, and content. Cannot download PII or edit settings in Profiles or Engage.
+* Read-only access to Profiles settings and if purchased, Engage audiences, traits, journeys, and content. Cannot download PII or edit settings in Profiles or Engage.
 * **Scope:** Grants access to either: all current and future Spaces, or a specific list of Spaces, or Spaces with a specific Label (BT only).
 
 #### Profiles Read-only, Engage User


### PR DESCRIPTION
### Proposed changes

Profiles and Engage Read-only only has read-only access to profiles and engage settings, while the docs were suggesting that this role is giving edit access to engage features/settings.

Aligning the docs to what the UI shows when assigning permissions to a user.

### Merge timing
- ASAP once approved

### Related issues 

Slack discussion: https://twilio.slack.com/archives/C7F3N3RV4/p1666807822161969
ZD Ticket: https://segment.zendesk.com/agent/tickets/490456