### PR TITLE
Update index.md

### DIFF
--- a/src/connections/sources/catalog/libraries/server/go/index.md
+++ b/src/connections/sources/catalog/libraries/server/go/index.md
@@ -40,7 +40,11 @@ That will create a `client` that you can use to send data to Segment for your so
 The default initialization settings are production-ready and queue 20 messages before sending a batch request, and a 5 second interval.
 
 ### Regional configuration
-{% include content/regional-config.md %}
+For Business plans with access to Regional Segment, you can use the host configuration parameter to send data to the desired region:
+
+Oregon (Default) — api.segment.io/
+Dublin — events.eu1.segmentapis.com
+
 ## Identify
 
 > note ""


### PR DESCRIPTION
Bug with Regional Configuration

In the go library the configuration fails with Endpoint: "https://events.eu1.segmentapis.com/" - and works with Endpoint: "https://events.eu1.segmentapis.com"

	client, _ := analytics.NewWithConfig(writeKey, analytics.Config{
		Endpoint: "https://events.eu1.segmentapis.com",
		Verbose:  true,
	})

This is inconsistent across libraries...

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
