### PR TITLE
Unhide Google Sheets documentation

### DIFF
--- a/src/connections/destinations/catalog/actions-google-sheets/index.md
+++ b/src/connections/destinations/catalog/actions-google-sheets/index.md
@@ -2,17 +2,13 @@
 title: Google Sheets Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-private: true
+hidden: false
 id: 627ea052118e3cd530d28963
 ---
 
 The Google Sheets destination allows you to sync your warehouse data to a Google spreadsheet, and automate updates to that spreadsheet as your data changes. This destination allows you to automate the workflow of exporting CSVs from your warehouse.
 
-The Google Sheets destination is intended for use with **Reverse ETL sources only**. 
-
-> info ""
-> The Google Sheets destination is in beta and is in active development. Some functionality may change before it becomes generally available.
+The Google Sheets destination can be connected to **Reverse ETL warehouse sources only**. 
 
 ## Getting started
 
@@ -26,13 +22,13 @@ The Google Sheets destination is intended for use with **Reverse ETL sources onl
 3. Navigate to the **Reverse ETL > Destinations** tab and click **Add Destination**. 
 4. Select Google Sheets and click **Next**. Select the source you configured and name the destination.
 5. On the **Settings** tab, authenticate the Google Sheets API using OAuth. Select the email account that owns the spreadsheet you created above. Make sure you enable the `See, edit, create, and delete all your Google Sheets spreadsheets` permission. 
-6. On the **Mappings** tab, click **Add Mapping** and create a Post Sheet mapping. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
+6. On the **Mappings** tab, click **Add Mapping** and create a Post Sheet mapping. Within the mapping, configure how warehouse records should map to your Google Sheets spreadsheet.
 7. Enable the destination and configured mappings.
 
 > info ""
 > The Google Sheets destination only supports sending new or updated rows to your spreadsheet. Deleting rows is not supported.
 
-{% include components/actions-fields.html %}
+{% include components/actions-fields.html settings="false"%}
 
 ## FAQ
 
@@ -42,4 +38,4 @@ The Record Identifier mapping is used to make a distinction between adding a new
 
 ### How do I define the columns in my spreadsheet?
 
-The Fields mapping controls which fields in your model will be written as columns. Input the desired column name(s) on the left, and select the data variable that will populate the value for that column on the right. Please note,at least one Field must be configured to send data to Google Sheets otherwise no columns will be created or synced.
+The Fields mapping controls which fields in your model will be written as columns. Input the desired column name(s) on the left, and select the data variable that will populate the value for that column on the right. Please note, at least one field must be configured to send data to Google Sheets otherwise no columns will be created or synced.

--- a/src/connections/destinations/catalog/actions-google-sheets/index.md
+++ b/src/connections/destinations/catalog/actions-google-sheets/index.md
@@ -2,7 +2,6 @@
 title: Google Sheets Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: false
 id: 627ea052118e3cd530d28963
 ---
 

--- a/src/connections/destinations/catalog/actions-google-sheets/index.md
+++ b/src/connections/destinations/catalog/actions-google-sheets/index.md
@@ -5,7 +5,7 @@ hide-dossier: false
 id: 627ea052118e3cd530d28963
 ---
 
-The Google Sheets destination allows you to sync your warehouse data to a Google spreadsheet, and automate updates to that spreadsheet as your data changes. This destination allows you to automate the workflow of exporting CSVs from your warehouse.
+The Google Sheets destination allows you to sync your warehouse data to a Google spreadsheet, and update the spreadsheet automatically as your data changes. This destination automates the workflow of exporting CSVs from your warehouse.
 
 The Google Sheets destination can be connected to **Reverse ETL warehouse sources only**. 
 


### PR DESCRIPTION
### Proposed changes
We are moving the Google Sheets destination to GA next Monday 12/5 (like ~afternoon). We'd like this doc unhidden by 12/6 so that when Reverse ETL goes to public beta on 12/6, customers who want to use Google Sheets will be able to find these instructions. Thanks!

### Merge timing
- ASAP once approved

### Related issues (optional)
<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
