### PR TITLE
Add section for supported Alias call to CleverTap

### DIFF
--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -27,6 +27,13 @@ When you identify a user, Segment passes that user's information to CleverTap wi
 
 All other traits will be sent to CleverTap as custom attributes. The default logic will lower case and snake_case any user traits - custom or special - passed to CleverTap.
 
+## Alias
+
+> warning ""
+> Alias is supported by Device-mode Web connections
+
+When you send an Alias call to CleverTap, CleverTap updates the user's profile with the contents of the Alias call.
+
 ## Track
 
 When you `track` an event, Segment sends that event to CleverTap as a custom event.  Note that CleverTap does not support arrays or nested objects for custom track event properties.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Mention that CleverTap (Classic) supports Alias, in Device-mode web connections.
<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
