### PR TITLE
Adding docs for Segment RETL destination

### DIFF
--- a/src/connections/destinations/catalog/actions-segment/index.md
+++ b/src/connections/destinations/catalog/actions-segment/index.md
@@ -3,6 +3,7 @@ title: Segment Destination
 hide-boilerplate: true
 hide-dossier: false
 id: 6371eee1ae5e324869aa8b1b
+private: true
 ---
 
 The Segment destination enables you to mold data extracted from your warehouse into [Segment Spec](/docs/connections/spec/) API calls that can be processed by Segment's Tracking API.


### PR DESCRIPTION
### Proposed changes

Segment (Actions) are in private beta. We are moving to public beta on December 13.

Since this destination is in Private Beta, can we make sure that the dossier and other tables (other versions of destination, settings, actions, fields) get pre-populated upon deploy just in case the partner portal status hasn't updated in time? Thank you!

### Merge timing
- On a specific date - This should go out on the Dec 13 deploy as that is when we move the Segment destination to Public Beta.

### Related issues (optional)
new-integration
