### PR TITLE
Add section for api token security [SECFEAT-1021]

### DIFF
--- a/src/api/public-api/index.md
+++ b/src/api/public-api/index.md
@@ -25,3 +25,24 @@ The Public API includes the following benefits over the Config API:
 | Cleaner mapping         | The Public API uses unique IDs for reference, in place of slugs in the Config API. Unique IDs are, by design, unique.                                               |
 | Available in Europe     | The Public API is accessible to both US and EU-based workspaces.                                                                                                                                                                   |
 | Increased reliability   | The Public API features more stable endpoints, and a 99.8% success rate                                                                                             |
+
+## API Token Security
+
+To enhance API token security, Segment partners with GitHub to prevent fraudulent use of exposed API tokens found in public git repositories. Malicious actors can use exposed tokens to perform unauthorized actions in your Segment workspace. 
+
+GitHub scans each commit in public repositories for Public API tokens and detected tokens are sent to Segment. Valid tokens are automatically revoked and workspace owners are notified. This process, Github identifying a token and Segment revoking it, typically takes seconds.
+
+Learn more about [GitHub's secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program).
+
+### Frequently Asked Questions
+#### What should I do if I see a notification that my token was exposed?
+In most cases, identifying and revoking an exposed token takes seconds. Still, we recommend you check the [audit trail](/docs/segment-app/iam/audit-trail/) to ensure no unauthorized actions were taken with the token.
+
+#### How did my token get exposed?
+Typically, tokens are exposed when developers commit them to a public git repository. This can happen when developers use a token in a local development environment and forget to remove it before committing their code.
+
+#### Why are exposed tokens automatically revoked?
+By automatically revoking the exposed token, we help keep your workspace secure and prevent potential abuse of the token.
+
+#### How do I enable this feature?
+This feature is automatically enabled for all workspaces on Team or Business tier plans.

--- a/src/api/public-api/index.md
+++ b/src/api/public-api/index.md
@@ -30,7 +30,7 @@ The Public API includes the following benefits over the Config API:
 
 To enhance API token security, Segment partners with GitHub to prevent fraudulent use of exposed API tokens found in public git repositories. Malicious actors can use exposed tokens to perform unauthorized actions in your Segment workspace. 
 
-GitHub scans each commit in public repositories for Public API tokens and detected tokens are sent to Segment. Valid tokens are automatically revoked and workspace owners are notified. This process, Github identifying a token and Segment revoking it, typically takes seconds.
+GitHub scans each commit in public repositories for Public API tokens and detected tokens are sent to Segment. Valid tokens are automatically revoked and workspace owners are notified. This process, GitHub identifying a token and Segment revoking it, typically takes seconds.
 
 Learn more about [GitHub's secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program).
 
@@ -42,7 +42,7 @@ In most cases, identifying and revoking an exposed token takes seconds. Still, w
 Typically, tokens are exposed when developers commit them to a public git repository. This can happen when developers use a token in a local development environment and forget to remove it before committing their code.
 
 #### Why are exposed tokens automatically revoked?
-By automatically revoking the exposed token, we help keep your workspace secure and prevent potential abuse of the token.
+By automatically revoking the exposed token, Segment helps keep your workspace secure and prevents potential abuse of the token.
 
 #### How do I enable this feature?
 This feature is automatically enabled for all workspaces on Team or Business tier plans.

--- a/src/api/public-api/index.md
+++ b/src/api/public-api/index.md
@@ -30,7 +30,7 @@ The Public API includes the following benefits over the Config API:
 
 To enhance API token security, Segment partners with GitHub to prevent fraudulent use of exposed API tokens found in public git repositories. This helps to prevent malicious actors from using exposed tokens to perform unauthorized actions in your Segment workspace. 
 
-GitHub scans each commit in public repositories for Public API tokens and detected tokens are sent to Segment. Valid tokens are automatically revoked and workspace owners are notified. This process, GitHub identifying a token and Segment revoking it, typically takes seconds.
+Within seconds, GitHub scans each commit in public repositories for Public API tokens, and sends detected tokens to Segment. Valid tokens are automatically revoked and workspace owners are notified. 
 
 Learn more about [GitHub's secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program){:target="_blank"}.
 

--- a/src/api/public-api/index.md
+++ b/src/api/public-api/index.md
@@ -32,14 +32,14 @@ To enhance API token security, Segment partners with GitHub to prevent fraudulen
 
 GitHub scans each commit in public repositories for Public API tokens and detected tokens are sent to Segment. Valid tokens are automatically revoked and workspace owners are notified. This process, GitHub identifying a token and Segment revoking it, typically takes seconds.
 
-Learn more about [GitHub's secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program).
+Learn more about [GitHub's secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program){:target="_blank"}.
 
 ### Frequently Asked Questions
 #### What should I do if I see a notification that my token was exposed?
-In most cases, identifying and revoking an exposed token takes seconds. Still, we recommend you check the [audit trail](/docs/segment-app/iam/audit-trail/) to ensure no unauthorized actions were taken with the token.
+In most cases, identifying and revoking an exposed token takes seconds. Segment recommends you check the [audit trail](/docs/segment-app/iam/audit-trail/) to ensure no unauthorized actions were taken with the token.
 
 #### How did my token get exposed?
-Typically, tokens are exposed when developers commit them to a public git repository. This can happen when developers use a token in a local development environment and forget to remove it before committing their code.
+Developers can accidentally commit tokens to public repositories, exposing them to the public. This can happen when developers use a token in a local development environment and forget to remove it before committing their code.
 
 #### Why are exposed tokens automatically revoked?
 By automatically revoking the exposed token, Segment helps keep your workspace secure and prevents potential abuse of the token.

--- a/src/api/public-api/index.md
+++ b/src/api/public-api/index.md
@@ -28,7 +28,7 @@ The Public API includes the following benefits over the Config API:
 
 ## API Token Security
 
-To enhance API token security, Segment partners with GitHub to prevent fraudulent use of exposed API tokens found in public git repositories. Malicious actors can use exposed tokens to perform unauthorized actions in your Segment workspace. 
+To enhance API token security, Segment partners with GitHub to prevent fraudulent use of exposed API tokens found in public git repositories. This helps to prevent malicious actors from using exposed tokens to perform unauthorized actions in your Segment workspace. 
 
 GitHub scans each commit in public repositories for Public API tokens and detected tokens are sent to Segment. Valid tokens are automatically revoked and workspace owners are notified. This process, GitHub identifying a token and Segment revoking it, typically takes seconds.
 


### PR DESCRIPTION
### Proposed changes
This PR adds a section under the public api page in order to describe a new feature that is being rolled out (exposed papi token service, see sdd [here](https://paper.dropbox.com/doc/SDD-GitHubLab-token-scanning--BuUoS~Py32zurYUtRDgWxRPWAg-9H5ol1zdKPdm5MbCc4wyv)). 

![Screen Shot 2022-12-07 at 6 39 24 PM](https://user-images.githubusercontent.com/1812749/206342823-a3afce93-05de-40b8-a9ca-348a26016583.png)



### Merge timing
This depends on https://github.com/segmentio/exposed-papi-token-service being shipped to production. We're aiming for an early January release.

