### PR TITLE
Add info about defining Screen events

### DIFF
--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -26,7 +26,7 @@ You can enable [violation event forwarding](/docs/protocols/validate/forward-vio
 
 ### How do I add Page and Screen events to my tracking plan?
 
-To consolidate the views in the Schema tab, Segment automatically converts `page` and `screen` calls into `Page Viewed` and `Screen Viewed` events that appear in the Schema Events view. Segment recommends adding a `Page Viewed` or `Screen Viewed` event to your Tracking Plan with any properties you want to validate against. At this time, to validate that a specific named page/screen (`analytics.page('Homepage') | analytics.screen('Home')`) has a specific set of required properties, you will need to use the [JSON Schema](https://segment.com/docs/protocols/tracking-plan/create/#edit-underlying-json-schema).
+To consolidate the views in the Schema tab, Segment automatically converts `page` and `screen` calls into `Page Viewed` and `Screen Viewed` events that appear in the Schema Events view. Segment recommends adding a `Page Viewed` or `Screen Viewed` event to your Tracking Plan with any properties you want to validate against. At this time, to validate that a specific named page/screen (`analytics.page('Homepage') | analytics.screen('Home')`) has a specific set of required properties, you will need to use the [JSON Schema](/docs/protocols/tracking-plan/create/#edit-underlying-json-schema).
 
 ### How can I see who made changes to my Tracking Plan?
 

--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -24,9 +24,9 @@ You can enable [violation event forwarding](/docs/protocols/validate/forward-vio
 
 ## Protocols Tracking Plan
 
-### Do I need to add a Page Viewed event to my tracking plan?
+### Ho do I add Page and Screen events to my tracking plan?
 
-Yes. To consolidate the views in the Schema tab, Segment automatically converts `page` calls into `Page Viewed` events that appear in the Schema Events view. Segment recommends adding a `Page Viewed` event to your Tracking Plan with any properties you want to validate against. At this time, you cannot validate that a specific named page (`analytics.page('Homepage')`) has a specific set of required properties.
+To consolidate the views in the Schema tab, Segment automatically converts `page` and `screen` calls into `Page Viewed` and `Screen Viewed` events that appear in the Schema Events view. Segment recommends adding a `Page Viewed` or `Screen Viewed` event to your Tracking Plan with any properties you want to validate against. At this time, to validate that a specific named page/screen (`analytics.page('Homepage') | analytics.screen('Home')`) has a specific set of required properties, you will need to use the [JSON Schema](https://segment.com/docs/protocols/tracking-plan/create/#edit-underlying-json-schema).
 
 ### How can I see who made changes to my Tracking Plan?
 

--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -24,7 +24,7 @@ You can enable [violation event forwarding](/docs/protocols/validate/forward-vio
 
 ## Protocols Tracking Plan
 
-### Ho do I add Page and Screen events to my tracking plan?
+### How do I add Page and Screen events to my tracking plan?
 
 To consolidate the views in the Schema tab, Segment automatically converts `page` and `screen` calls into `Page Viewed` and `Screen Viewed` events that appear in the Schema Events view. Segment recommends adding a `Page Viewed` or `Screen Viewed` event to your Tracking Plan with any properties you want to validate against. At this time, to validate that a specific named page/screen (`analytics.page('Homepage') | analytics.screen('Home')`) has a specific set of required properties, you will need to use the [JSON Schema](https://segment.com/docs/protocols/tracking-plan/create/#edit-underlying-json-schema).
 


### PR DESCRIPTION
### Proposed changes

Add info about defining Screen events in a tracking plan. Similar to page events, so piggybacking on those docs. 