### PR TITLE
Replace appspot.com references in Pendo setup

### DIFF
--- a/src/connections/destinations/catalog/pendo/index.md
+++ b/src/connections/destinations/catalog/pendo/index.md
@@ -28,7 +28,9 @@ To add the Pendo destination using Cloud-mode, use the [Webhooks](/docs/connecti
 
 1. From the Segment web app, click **Catalog**.
 2. Search for **Webhooks** in the Catalog, select it, and choose which of your JavaScript sources to connect the destination to.
-3. Add the following as your Webhook URL: `https://pendo-io.appspot.com/data/segmentio/YOUR_PENDO_API_KEY` and replace `YOUR_PENDO_API_KEY` with your actual Pendo API Key which you can find in the Pendo UI under [Site Settings](https://app.pendo.io/admin) > Basic Information > API Key.
+3. Webhook URL configuration will vary based on which Pendo environment you use and your API key:
+  * For US customers, add the following as your Webhook URL: `https://segment.us.pendo.io/data/segmentio/YOUR_PENDO_API_KEY` and replace `YOUR_PENDO_API_KEY` with your actual Pendo API Key, which you can find in the Pendo UI under [Site Settings](https://app.pendo.io/admin) > Basic Information > API Key.
+  * For EU customers, add the following as your Webhook URL: `https://segment.eu.pendo.io/data/segmentio/YOUR_PENDO_API_KEY` and teplace `YOUR_PENDO_API_KEY` with your actual Pendo API Key, which you can find in the Pendo UI under [Site Settings](https://app.eu.pendo.io/admin) > Basic Information > API Key.
 4. Headers are not required in Webhook configuration. Once you're done adding in your URL, save changes.
 5. Using Track method also requires a setting enabled on your Pendo subscription. contact Pendo to enable this feature flag for your account.
 


### PR DESCRIPTION
Also add differentiated instruction for EU customers.

### Proposed changes

* Replace appspot.com hostnames, which are deprecated.
* Add separate webhook URL instruction for EU customer setup

### Merge timing

ASAP once approved

### Related issues (optional)
