### PR TITLE
Remove Beta Notes and Other Changes for Destination GAs

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -58,7 +58,7 @@ sections:
   - path: /connections/destinations/catalog/google-tag-manager
     title: Google Tag Manager destination
   - path: /connections/destinations/catalog/actions-google-enhanced-conversions
-    title: Google Enhanced Conversions destination
+    title: Google Ads Conversions destination
   - path: /connections/destinations/catalog/doubleclick-floodlight
     title: DoubleClick Floodlight destination
   - path: /connections/destinations/catalog/google-ads-classic

--- a/src/connections/destinations/catalog/actions-adobe-target-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-adobe-target-cloud/index.md
@@ -11,9 +11,6 @@ Segment offers two destinations for Adobe Target:
 - [Adobe Target Web](/docs/connections/destinations/catalog/actions-adobe-target-web/)
 - [Adobe Target Cloud Mode](/docs/connections/destinations/catalog/actions-adobe-target-cloud/)
 
-> info ""
-> The Adobe Target Cloud Mode destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 > success "Good to know"
 > This page is about Segment's Adobe Target Cloud Mode destination. There's also a page about Segment's [Adobe Target Web destination](/docs/connections/destinations/catalog/actions-adobe-target-web/). **In order to use Adobe Target Cloud Mode, you must have a parallel web integration with Adobe Target as profiles can only be created by the Adobe Target `at.js` web script.**
 

--- a/src/connections/destinations/catalog/actions-adobe-target-web/index.md
+++ b/src/connections/destinations/catalog/actions-adobe-target-web/index.md
@@ -11,9 +11,6 @@ Segment offers two destinations for Adobe Target:
 - [Adobe Target Web](/docs/connections/destinations/catalog/actions-adobe-target-web/)
 - [Adobe Target Cloud Mode](/docs/connections/destinations/catalog/actions-adobe-target-cloud/)
 
-> info ""
-> The Adobe Target Web destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 > success "Good to know"
 > This page is about Segment's Adobe Target Web destination. There's also a page about Segment's [Adobe Target Cloud Mode destination](/docs/connections/destinations/catalog/actions-adobe-target-cloud/).
 

--- a/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
@@ -1,60 +1,50 @@
 ---
-title: Google Enhanced Conversions Destination
+title: Google Ads Conversions Destination
 strat: google
 hide-boilerplate: true
 hide-dossier: false
 id: 60ae8b97dcb6cc52d5d0d5ab
-hide_action:
-  - id: 2n3RKy5oyzS1kLdEEYV99N
-    name: "Upload Conversion Adjustment"
-  - id: uEYL2A2fTEoxCzYmsRwRmT
-    name: "Upload Call Conversion"
-  - id: fv1r2SiUg6i12jzdy8hitm
-    name: "Upload Click Conversion"
 ---
 
-The Google Enhanced Conversions destination enables you to improve the accuracy of your conversion measurement. You can supplement existing conversion tags by sending first-party customer conversion data from your website, such as email address, to Google Ads. Segment hashes this data and sends it in a privacy-safe way. Google matches hashed data with signed-in Google accounts to attribute the conversion to ad events, such as clicks or views. To learn more about Google Enhanced Conversions, see Google's documentation [About enhanced conversions](https://support.google.com/google-ads/answer/9888656?hl=en-GB){:target="_blank"}.
-
-> warning "Before you begin"
-> Enable Enhanced Conversions in your Google Ads account. For each Conversion, specify in the settings that you will use the Enhanced Conversions API:
-> 1.  When you log in to Google Ads, make sure you are in [Expert Mode](https://support.google.com/google-ads/answer/9520605?hl=en){:target="_blank"}.
-> 2. Click **Tools & Settings** in the top bar, and select **Conversions** from the dropdown. Select the website **Conversion Action** you want Segment to log to.
-> 3. Expand the tab for **Enhanced conversions**. Enable **Turn on enhanced conversions**. Under "To start, select how you want to set up enhanced conversions", select **API**.
-> 
-> When you authenticate your Segment workspace with your Google Account, use a Google Account that is a member of your Google Ads account.
-
-
-> info ""
-> To deduplicate conversions that are recorded from the Google Ads Conversion tag (Gtag) from the data that is sent to Google Enhanced Conversions, Order ID (Transaction ID) must be implemented in the Google Ads Conversion tag (Gtag) **and** the same Order IDs must be sent with the corresponding Enhanced Conversions data. This is required for Google to successfully process your enhancement data.
+The Google Ads Conversions destination enables you to upload offline conversions and conversion adjustments to Google Ads in a privacy safe way. With this server-side destination, you can upload conversions to the [Google Ads API](https://developers.google.com/google-ads/api/docs/conversions/overview){:target="_blank"} and tie them to a user's online click or phone call. In addition, you can improve the accuracy of your conversion measurement by sending conversion enhancements, restatements, and retractions.
 
 ## Getting started
 1. From the Segment web app, click **Catalog**, then click **Destinations**.
-2. Search for “Google Enhanced Conversions” in the Destinations Catalog, and select the destination.
-3. Click **Configure Google Enhanced Conversions** in the top-right corner of the screen.
-4. Select the source that will send data to Google Enhanced Conversions and follow the steps to name your destination.
-5. On the **Settings** tab, enter the Conversion ID and click **Save**. Find the Conversion ID in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en){:target="_blank"}. You'll follow these same instructions to get the Conversion Label, which you'll need when you set up your first Mapping.
-6. On the **Settings** tab, authenticate with Google using OAuth. Click **Connect to Google Enhanced Conversions**. Follow the prompts to authenticate using OAuth, with a Google login that is a member of the Google Ads account with Enhanced Conversions enabled.
+2. Search for “Google Ads Conversions” in the Destinations Catalog, and select the destination.
+3. Click **Configure Google Ads Conversions** in the top-right corner of the screen.
+4. Select the source that will send data to Google Ads Conversions and follow the steps to name your destination.
+5. On the **Settings** tab, enter your account-level Conversion ID and/or Customer ID and click **Save**.
+6. On the **Settings** tab, authenticate with Google using OAuth. Click **Connect to Google Ads Conversions**. Follow the prompts to authenticate using OAuth, with a Google account that is a member of your Google Ads account.
 7. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
 > info ""
-> The Conversion ID is a global setting because it's an account-level ID that's the same for all conversion actions in your Google Ads account. The Conversion Label is unique to each conversion action and is therefore configured per Mapping.
+> When you use the "Upload Enhanced Conversion (Legacy)" action, Segment sends data to the legacy Enhanced Conversions API. To authenticate into the legacy API and send enhancement data, Segment needs your Conversion ID and Conversion Label. The Conversion ID is a global setting because it's an account-level ID that's the same for all conversion actions in your Google Ads account. The Conversion Label is unique to each conversion action and is therefore configured per mapping. Find the Conversion ID and Conversion Label in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en){:target="_blank"}.
+> When you use the "Upload Click Conversion", "Upload Call Conversion", and "Upload Conversion Adjustment" actions, Segment sends data to the new Google Ads API. To authenticate into the Google Ads API, Segment needs your Customer ID and Conversion Action ID. The Customer ID is a global setting because it's an account-level ID that's the same for all conversion actions in your Google Ads account. The Conversion Action ID is unique to each conversion action and is therefore configured per mapping. The Conversion Action ID can only be found in the browser URL of your given conversion action under the `ctId` parameter. For example, if the URL is `https://ads.google.com/aw/conversions/detail?ocid=00000000&ctId=576882000`, your Conversion Action ID is `576882000`.
+> Please note that the Conversion ID, Conversion Label, Customer ID, and Conversion Action ID should always be different values.
 
-{% include components/actions-fields.html content1=conv_label section1="postConversion" content2=test_mapping section2="postConversion" %}
+{% include components/actions-fields.html settings="true"%}
 
 ## FAQ & Troubleshooting
 
-### Conversion Tracking with Gtag
+### Enhanced Conversions
 
-To use Google Enhanced Conversions, you must record conversions using the standard Google Ads Conversion tag (Gtag). After a conversion is recorded, you can send hashed first-party data through Segment's Google Enhanced Conversions destination for up to 24 hours after the conversion. Segment offers a [Google Ads (Gtag) destination](/docs/connections/destinations/catalog/google-ads-gtag/) so you can use your existing Segment implementation to activate Gtag.
+[Enhanced conversions](https://support.google.com/google-ads/answer/11062876){:target="_blank"} is a feature that can improve the accuracy of your conversion measurement and unlock more powerful bidding. It supplements your existing conversion tags by sending hashed, first-party conversion data from your website to Google in a privacy safe way. You can use the "Upload Conversion Adjustment" action to send enhancements to the Google Ads API. In order to send enhanced conversions, you must record first conversions using the standard Google Ads Conversion tag (Gtag). Segment offers a [Google Ads (Gtag) destination](/docs/connections/destinations/catalog/google-ads-gtag/) so you can use your existing Segment implementation to activate Gtag. Enhancements can be sent to web conversion actions that have **Turn on enhanced conversions** by API enabled.
 
-Conversions tracked by other means, such as importing goals from Google Analytics, are not eligible for Google Enhanced Conversions.
+Conversions tracked by other means, such as importing goals from Google Analytics, are not eligible for enhancement.
+
+> info ""
+> To send enhancements for conversions that are initially tracked with Gtag, an Order ID (Transaction ID) must be implemented in the Gtag **and** the same Order IDs must be sent with the corresponding enhnacement data. This is required for Google to successfully process your enhancement data.
+
+### Enhanced Conversions for Leads
+
+[Enhanced conversions for leads](https://developers.google.com/google-ads/api/docs/conversions/upload-identifiers){:target="_blank"} allows you to use hashed, first-party user-provided data from your website lead forms for offline lead measurement. When you upload your leads, the provided hashed information is used to attribute back to the Google Ad campaign. In order to send enhanced conversions for leads, you can use the "Upload Click Conversion" action. Instead of sending GCLID, send an email address or phone number of the user for Segment to hash and send to Google Ads. 
 
 ### Refreshing Access Tokens
 
-When you use OAuth to authenticate into the Google Enhanced Conversions destination, Segment stores an access token and refresh token. Access tokens for Google Enhanced Conversions expire after one hour. Once expired, Segment receives an error and then uses the refresh token to fetch a new access token. This results in two API requests to Google Enhanced Conversions, one failure and one success.
+When you use OAuth to authenticate into the Google Ads Conversions destination, Segment stores an access token and refresh token. Access tokens for Google Ads Conversions expire after one hour. Once expired, Segment receives an error and then uses the refresh token to fetch a new access token. This results in two API requests to Google Ads Conversions, one failure and one success.
 
-Because of the duplicate API requests, you may see a warning in Google for unprocessed conversions due to incorrect or missing OAuth credentials. This warning is expected and does not indicate data loss. Google has confirmed that conversions are being processed, and OAuth retry behavior will not cause any issues for your web conversions. Whenever possible, Segment caches access tokens to reduce the total number of requests we make to Google Enhanced Conversions.
+Because of the duplicate API requests, you may see a warning in Google for unprocessed conversions due to incorrect or missing OAuth credentials. This warning is expected and does not indicate data loss. Google has confirmed that conversions are being processed, and OAuth retry behavior will not cause any issues for your web conversions. Whenever possible, Segment caches access tokens to reduce the total number of requests we make to Google Ads Conversions.
 
-### Sending App Conversions for Incrementality Studies
+### Sending App Conversions for Incrementality Studies (Legacy Enhanced Conversions API only)
 
-The Google Enhanced Conversions API does not offer standard reporting for app conversions at this point. As such, Google requires that you set up a new web conversion action specifically for the purposes of app incrementality studies. To send app conversions in your incrementality study, be sure to input the Conversion Label associated with your incrementality study **and** set the App Conversion for Incrementality Study field to `true`. You should create separate web conversion actions in Google Ads for each app event you want to send data for.
+The legacy Enhanced Conversions API does not offer standard reporting for app conversions. As such, Google requires that you set up a new web conversion action specifically for the purposes of app incrementality studies. To send app conversions in your incrementality study, use the "Upload Enhanced Conversion (Legacy)" action. Be sure to input the Conversion Label associated with your incrementality study **and** set the App Conversion for Incrementality Study field to `true`. You should create separate web conversion actions in Google Ads for each app event you want to send data for.

--- a/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
@@ -33,7 +33,7 @@ The Google Ads Conversions destination enables you to upload offline conversions
 Conversions tracked by other means, such as importing goals from Google Analytics, are not eligible for enhancement.
 
 > info ""
-> To send enhancements for conversions that are initially tracked with Gtag, an Order ID (Transaction ID) must be implemented in the Gtag **and** the same Order IDs must be sent with the corresponding enhnacement data. This is required for Google to successfully process your enhancement data.
+> To send enhancements for conversions that are initially tracked with Gtag, an Order ID (Transaction ID) must be implemented in the Gtag **and** the same Order IDs must be sent with the corresponding enhancement data. This is required for Google to successfully process your enhancement data.
 
 ### Enhanced Conversions for Leads
 
@@ -43,7 +43,7 @@ Conversions tracked by other means, such as importing goals from Google Analytic
 
 When you use OAuth to authenticate into the Google Ads Conversions destination, Segment stores an access token and refresh token. Access tokens for Google Ads Conversions expire after one hour. Once expired, Segment receives an error and then uses the refresh token to fetch a new access token. This results in two API requests to Google Ads Conversions, one failure and one success.
 
-Because of the duplicate API requests, you may see a warning in Google for unprocessed conversions due to incorrect or missing OAuth credentials. This warning is expected and does not indicate data loss. Google has confirmed that conversions are being processed, and OAuth retry behavior will not cause any issues for your web conversions. Whenever possible, Segment caches access tokens to reduce the total number of requests we make to Google Ads Conversions.
+Because of the duplicate API requests, you may see a warning in Google for unprocessed conversions due to incorrect or missing OAuth credentials. This warning is expected and does not indicate data loss. Google has confirmed that conversions are being processed, and OAuth retry behavior will not cause any issues for your web conversions. Whenever possible, Segment caches access tokens to reduce the total number of requests made to Google Ads Conversions.
 
 ### Sending App Conversions for Incrementality Studies (Legacy Enhanced Conversions API only)
 

--- a/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
@@ -18,9 +18,20 @@ The Google Ads Conversions destination enables you to upload offline conversions
 7. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
 > info ""
-> When you use the "Upload Enhanced Conversion (Legacy)" action, Segment sends data to the legacy Enhanced Conversions API. To authenticate into the legacy API and send enhancement data, Segment needs your Conversion ID and Conversion Label. The Conversion ID is a global setting because it's an account-level ID that's the same for all conversion actions in your Google Ads account. The Conversion Label is unique to each conversion action and is therefore configured per mapping. Find the Conversion ID and Conversion Label in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en){:target="_blank"}.
-> When you use the "Upload Click Conversion", "Upload Call Conversion", and "Upload Conversion Adjustment" actions, Segment sends data to the new Google Ads API. To authenticate into the Google Ads API, Segment needs your Customer ID and Conversion Action ID. The Customer ID is a global setting because it's an account-level ID that's the same for all conversion actions in your Google Ads account. The Conversion Action ID is unique to each conversion action and is therefore configured per mapping. The Conversion Action ID can only be found in the browser URL of your given conversion action under the `ctId` parameter. For example, if the URL is `https://ads.google.com/aw/conversions/detail?ocid=00000000&ctId=576882000`, your Conversion Action ID is `576882000`.
-> Please note that the Conversion ID, Conversion Label, Customer ID, and Conversion Action ID should always be different values.
+> When you use the "Upload Enhanced Conversion (Legacy)" action, Segment sends data to the legacy Enhanced Conversions API. To authenticate into the legacy API and send enhancement data, Segment needs your Conversion ID and Conversion Label. 
+> 
+> The Conversion ID is a global setting because it's an account-level ID that's the same for all conversion actions in your Google Ads account. 
+> 
+> The Conversion Label is unique to each conversion action and is therefore configured per mapping. Find the Conversion ID and Conversion Label in your Google Ads account using the instructions in the article [Google Ads conversions](https://support.google.com/tagmanager/answer/6105160?hl=en){:target="_blank"}.
+
+> info ""
+> When you use the "Upload Click Conversion", "Upload Call Conversion", and "Upload Conversion Adjustment" actions, Segment sends data to the new Google Ads API. 
+> 
+> To authenticate into the Google Ads API, Segment needs your Customer ID and Conversion Action ID. The Customer ID is a global setting because it's an account-level ID that's the same for all conversion actions in your Google Ads account. The Conversion Action ID is unique to each conversion action and is  configured per mapping. The Conversion Action ID can only be found in the browser URL of your given conversion action under the `ctId` parameter. For example, if the URL is `https://ads.google.com/aw/conversions/detail?ocid=00000000&ctId=576882000`, your Conversion Action ID is `576882000`.
+
+
+> info ""
+> Conversion ID, Conversion Label, Customer ID, and Conversion Action ID should always be different values.
 
 {% include components/actions-fields.html settings="true"%}
 

--- a/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
@@ -16,9 +16,6 @@ HubSpot is an all-in-one marketing tool that helps attract new leads and convert
 
 When you use the HubSpot Cloud Mode (Actions) destination, Segment sends your data to [HubSpot's REST API](https://developers.hubspot.com/docs/api/overview){:target="_blank"}.
 
-> info ""
-> The HubSpot Cloud Mode (Actions) destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 > warning ""
 > The **Upsert Company** action is not compatible with the Segment Event Tester. As a result, Segment recommends using other tools to test and troubleshoot the creation and updates of companies in HubSpot.
 
@@ -54,6 +51,9 @@ Segment provides prebuilt mappings for contacts and companies. If there are othe
 
 ### Why aren't my custom behavioral events appearing in HubSpot?
 HubSpot has several limits for custom behavioral events, including a limit on the number of event properties per event. Each event can contain data for up to 50 properties. If this limit is exceeded, the request will fail. See [HubSpot documentation](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events#define-the-api-call){:target="_blank"} for other limits.
+
+> note ""
+> A HubSpot Enterprise Marketing Hub account is required to send Custom Behavioral Events.
 
 ### Does the HubSpot Cloud Mode (Actions) destination support EU data residency?
 Yes. HubSpot will automatically redirect API requests directly to an EU data center if your HubSpot instance is on an EU data center. See more in HubSpot's [Routing API Traffic](https://product.hubspot.com/blog/routing-api-traffic){:target="_blank"} article.

--- a/src/connections/destinations/catalog/actions-hubspot-web/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-web/index.md
@@ -16,10 +16,6 @@ HubSpot is an all-in-one marketing tool that helps attract new leads and convert
 
 When you use the HubSpot Web (Actions) destination, Segment loads the [HubSpot tracking code](https://developers.hubspot.com/docs/api/events/tracking-code){:target="_blank"} for you. In addition to tracking page views, the HubSpot tracking code allows you to identify visitors, track events, and manually track page views without reloading the page. The tracking code API allows you to dynamically create events and track event data in HubSpot.
 
-> info ""
-> The HubSpot Web (Actions) destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
-
 ## Benefits of HubSpot Web (Actions) vs HubSpot Classic
 HubSpot Web (Actions) provides the following benefits over the classic HubSpot destination:
 
@@ -40,3 +36,11 @@ HubSpot Web (Actions) provides the following benefits over the classic HubSpot d
 7. Enable the destination and configured mappings.
 
 {% include components/actions-fields.html settings="true"%}
+
+## FAQ & Troubleshooting
+
+### Why aren't my custom behavioral events appearing in HubSpot?
+HubSpot has several limits for custom behavioral events, including a limit on the number of event properties per event. Each event can contain data for up to 50 properties. If this limit is exceeded, HubSpot will truncate to only update 50 properties per event completion. See [HubSpot documentation](https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events#define-the-api-call){:target="_blank"} for other limits.
+
+> note ""
+> A HubSpot Enterprise Marketing Hub account is required to send Custom Behavioral Events.

--- a/src/connections/destinations/catalog/actions-intercom-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-intercom-cloud/index.md
@@ -16,9 +16,6 @@ Intercom is a customer communications platform that shows you who is using your 
 
 When you use the Intercom Cloud Mode (Actions) destination, Segment will send your data to [Intercom's REST API](https://developers.intercom.com/building-apps/docs/rest-apis){:target="_blank"}.
 
-> info ""
-> The Intercom Cloud Mode (Actions) destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 ## Benefits of Intercom Cloud Mode (Actions) vs Intercom Classic
 Intercom Cloud Mode (Actions) provides the following benefits over the classic Intercom destination:
 

--- a/src/connections/destinations/catalog/actions-intercom-web/index.md
+++ b/src/connections/destinations/catalog/actions-intercom-web/index.md
@@ -21,9 +21,6 @@ Intercom is a customer communications platform that shows you who is using your 
 
 When you use the Intercom Web (Actions) destination, Segment loads the [Intercom JavaScript library](https://developers.intercom.com/installing-intercom/docs/intercom-for-web){:target="_blank"} for you. The Intercom library enables you to track your user’s events on your website and interact with the Intercom messenger window.
 
-> info ""
-> The Intercom Web (Actions) destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 ## Benefits of Intercom Web Mode (Actions) vs Intercom Classic
 Intercom Web (Actions) provides the following benefits over the classic Intercom destination:
 

--- a/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
@@ -11,9 +11,6 @@ LinkedIn Audiences enables advertisers to send Segment Engage Audiences to Linke
 
 By using Segment's Engage Audiences with LinkedIn, you can increase traffic and drive conversions with hyper-relevant ads that promote product discovery.
 
-> info ""
-> The LinkedIn Audiences destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 ## Getting Started
 
 Before connecting to the LinkedIn Audiences destination, you must have a [LinkedIn Campaign Manager](https://www.linkedin.com/campaignmanager){:target="_blank"} account and an Ad Account ID. In addition, the user authenticating with LinkedIn must have one of the following LinkedIn ad account roles: `ACCOUNT_BILLING_ADMIN`, `ACCOUNT_MANAGER`, `CAMPAIGN_MANAGER`, or `CREATIVE_MANAGER`.
@@ -43,7 +40,7 @@ To add the LinkedIn Audiences destination:
 
 11. Navigate back to **Engage > Audiences** and click on the Audience from Step 1. 
 
-12. Click **Add Destinations** and select the LinkedIn Audiences destination you just created. In the settings that appear in the side panel, toggle the **Send Track** option on and disable **Send Identify**. Click **Save Settings**.
+12. Click **Add Destinations** and select the LinkedIn Audiences destination you just created. In the settings that appear in the side panel, toggle the **Send Track** option on and do **not** change the Audience Entered/Audience Exited event names. Click **Save Settings**.
 
 The setup is complete and the Audience will start syncing to LinkedIn. Segment automatically creates a new DMP Segment in LinkedIn and will add or remove users accordingly. The Audience appears in your [LinkedIn Campaign Manager](https://www.linkedin.com/campaignmanager){:target="_blank"}, account under **Plan > Audiences > Matched**.
 

--- a/src/connections/destinations/catalog/actions-pardot/index.md
+++ b/src/connections/destinations/catalog/actions-pardot/index.md
@@ -4,16 +4,16 @@ hide-boilerplate: true
 hide-dossier: false
 strat: salesforce
 id: 62df16e45ba0058c864a75d1
+versions:
+  - name: "Pardot (Classic)"
+    link: '/docs/connections/destinations/catalog/pardot/'
 ---
+
+{% include content/plan-grid.md name="actions" %}
+
 Pardot is a Salesforce marketing automation and analytics solution that lets you send automated emails to prospects and track conversions in emails and across social networks.
 
 Segment’s Pardot (Actions) destination enables you to create and update prospects with custom traits that can be leveraged in your marketing efforts. Segment sends data to [version 5 of the Pardot API](https://developer.salesforce.com/docs/marketing/pardot/guide/version5overview.html){:target="_blank"}.
-
-> info ""
-> The Pardot (Actions) destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
-> success "Good to know"
-> This page is about the [Actions-framework](/docs/connections/destinations/actions/) Pardot destination. There's also a page about the [non-Actions Pardot destination](/docs/connections/destinations/catalog/pardot/). Both of these destinations receive data from Segment.
 
 ## Benefits of Pardot (Actions) Destination vs Pardot Destination Classic
 

--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -22,6 +22,7 @@ The Salesforce (Actions) destination provides the following benefits over the cl
 - **Clearer mapping of data**. Actions-based destinations enable you to define the mapping between the data Segment receives from your source, and the data Segment sends to Salesforce.
 - **OAuth 2.0 support**. Authentication with Salesforce leverages OAuth 2.0 instead of a username/password.
 - **Flexible match keys**. Upsert and update records based on any match key, including external IDs, record IDs, email and other object fields.
+- **Batch support**. Reduce Salesforce overages and rate-limit errors by batching your Segment data to Salesforce's Bulk API 2.0.
 
 ## Getting started
 
@@ -102,6 +103,3 @@ To check how many API calls you have left in Salesforce, go to **Setup > Company
 When using the `create` operation, it's possible for duplicate records to be created in Salesforce. This is because Segment retries records once they hit the internal timeout. It's possible Salesforce's REST API eventually processes the original record in addition to the retried record, resulting in duplicates. You may encounter this behavior if Salesforce's REST API throttles your records (for example, due to hitting API limits or complex workflow automation). To prevent duplicates, you can use [Duplicate Rules](https://help.salesforce.com/s/articleView?id=duplicate_rules_map_of_reference.htm&language=en_US){:target="_blank"} in Salesforce. See set up information in [Resolve and Prevent Duplicate Data in Salesforce](https://trailhead.salesforce.com/content/learn/modules/sales_admin_duplicate_management/sales_admin_duplicate_management_unit_2){:target="_blank"}.
 
 Please note this is only a concern when using the `create` operation. You can use the `upsert` operation instead to avoid duplicates if `upsert` meets your needs.
-
-### Can I send data to the Salesforce Bulk API 2.0?
-Segment is in the process of adding support for the Bulk API to help reduce API calls made to Salesforce. This is not yet available.


### PR DESCRIPTION
### Proposed changes
We are moving several destinations to GA on Dec 13. Specifically:

- HubSpot Web (Actions)
- HubSpot Cloud Mode (Actions)
- Intercom Web (Actions)
- Intercom Cloud Mode (Actions)
- LinkedIn Audiences
- Pardot (Actions)
- Adobe Target Web (Actions)
- Adobe Target Cloud Mode (Actions)

In addition, we are releasing support for:
- Batching/bulk API in Salesforce (Actions)
- New functionality in Google Enhanced Conversions, including renaming to Google Ads Conversions. 

These changes make updates to all those docs to remove beta notes, clean up outdated info, etc.

### Merge timing
- On a specific date - **These should all go out on the Dec 13 deploy as that is when we GA all of them!**

### Related issues (optional)
