### PR TITLE
Additional changes for the upcoming destination GA and Public Betas

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -58,7 +58,7 @@ sections:
   - path: /connections/destinations/catalog/google-tag-manager
     title: Google Tag Manager destination
   - path: /connections/destinations/catalog/actions-google-enhanced-conversions
-    title: Google Enhanced Conversions destination
+    title: Google Ads Conversions destination
   - path: /connections/destinations/catalog/doubleclick-floodlight
     title: DoubleClick Floodlight destination
   - path: /connections/destinations/catalog/google-ads-classic
@@ -78,10 +78,12 @@ sections:
 - slug: salesforce
   section_title: Salesforce Integrations
   section:
-  - path: /connections/destinations/catalog/salesforce
-    title: Salesforce destination
   - path: /connections/destinations/catalog/actions-salesforce
     title: Salesforce (Actions) destination
+  - path: /connections/destinations/catalog/salesforce
+    title: Salesforce destination
+  - path: /connections/destinations/catalog/actions-salesforce-marketing-cloud
+    title: Salesforce Marketing Cloud (Actions) destination
   - path: /connections/destinations/catalog/salesforce-marketing-cloud
     title: Salesforce Marketing Cloud destination
   - path: /connections/destinations/catalog/actions-pardot

--- a/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
@@ -2,8 +2,6 @@
 title: Salesforce Marketing Cloud (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-private: true
 strat: salesforce
 id: 62e30bad99f1bfb98ee8ce08
 versions:

--- a/src/connections/destinations/catalog/actions-webhook/index.md
+++ b/src/connections/destinations/catalog/actions-webhook/index.md
@@ -2,8 +2,6 @@
 title: Webhooks (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
-hidden: true
-private: true
 id: 614a3c7d791c91c41bae7599
 versions:
   - name: 'Webhooks (Classic)'

--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -4,6 +4,7 @@ title: HubSpot Destination
 hide-personas-partial: true
 cmode-override: true
 id: 54521fd725e721e32a72eec1
+maintenance: true
 ---
 [HubSpot](https://www.hubspot.com/){:target="_blank"} is an inbound marketing and sales platform that helps companies attract visitors, convert leads, and close customers. The `analytics.js` HubSpot Destination is open-source. You can browse the code [on GitHub](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/hubspot){:target="_blank"}.
 

--- a/src/connections/destinations/catalog/intercom/index.md
+++ b/src/connections/destinations/catalog/intercom/index.md
@@ -4,6 +4,7 @@ hide-cmodes: true
 hide-personas-partial: true
 cmode-override: true
 id: 54521fd725e721e32a72eec6
+maintenance: true
 ---
 [Intercom](https://www.intercom.com/) makes customer messaging apps for sales, marketing, and support, connected on one platform. The Intercom Destination is open-source. You can browse the code for [analytics.js](https://github.com/segment-integrations/analytics.js-integration-intercom), [iOS](https://github.com/segment-integrations/analytics-ios-integration-intercom) and [Android](https://github.com/segment-integrations/analytics-android-integration-intercom) on GitHub.
 

--- a/src/connections/destinations/catalog/pardot/index.md
+++ b/src/connections/destinations/catalog/pardot/index.md
@@ -2,7 +2,9 @@
 title: Salesforce Pardot Destination
 strat: salesforce
 id: 54521fd925e721e32a72eee1
+maintenance: true
 ---
+
 ## Getting Started
 
 When you enable Pardot in the Segment web app, your changes appear in the Segment CDN in about 45 minutes, and then Analytics.js starts asynchronously loading Pardot's javascript onto your page. This means you should remove Pardot's snippet from your page. Pardot automatically collects anonymous visitor data data on your site. Pardot is supported on the client-side and server-side.


### PR DESCRIPTION
### Proposed changes
Additional changes for the upcoming destinations. Adds maintenance notes to classic destinations, unhide Salesforce Marketing Cloud (Actions) and Webhook (Actions) - both moving to Public Beta on 12/13, and update strat sidebar nav.

### Merge timing
- On a specific date -  These should all go out on the Dec 13 deploy as that is when we GA/Public Beta the destinations.

### Related PR
https://github.com/segmentio/segment-docs/pull/3930
