### PR TITLE
Add override for actions slug

### DIFF
--- a/src/_includes/content/destination-maintenance.md
+++ b/src/_includes/content/destination-maintenance.md
@@ -1,5 +1,9 @@
 {% capture name %}{{page.title | replace: 'Destination', ''}}{% endcapture %}
-{% capture link %}/docs/connections/destinations/catalog/actions-{{name | slugify}}{% endcapture %}
+{% if page.actions-slug %}
+{% capture link %}/docs/connections/destinations/catalog/{{page.actions-slug}}{% endcapture %}
+{% else %}
+{% capture link %}/docs/connections/destinations/catalog/actions-{{name}}{% endcapture %}
+{% endif %}
 {% if page.maintenance-content %}
 {% capture blurb %}{{page.maintenance-content}} {% endcapture %}
 {% else %}

--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -5,6 +5,7 @@ hide-personas-partial: true
 cmode-override: true
 id: 54521fd725e721e32a72eec1
 maintenance: true
+maintenance-content: New versions of the destination are available. See [HubSpot Web (Actions)](/docs/connections/destinations/catalog/actions-hubspot-web/) and [HubSpot Cloud (Actions)](/docs/connections/destinations/catalog/actions-hubspot-cloud/) for more information.
 ---
 [HubSpot](https://www.hubspot.com/){:target="_blank"} is an inbound marketing and sales platform that helps companies attract visitors, convert leads, and close customers. The `analytics.js` HubSpot Destination is open-source. You can browse the code [on GitHub](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/hubspot){:target="_blank"}.
 

--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -5,7 +5,7 @@ hide-personas-partial: true
 cmode-override: true
 id: 54521fd725e721e32a72eec1
 maintenance: true
-maintenance-content: New versions of the destination are available. See [HubSpot Web (Actions)](/docs/connections/destinations/catalog/actions-hubspot-web/) and [HubSpot Cloud (Actions)](/docs/connections/destinations/catalog/actions-hubspot-cloud/) for more information.
+maintenance-content: New versions of the destination are available. See [HubSpot Cloud Mode (Actions)](/docs/connections/destinations/catalog/actions-hubspot-cloud/) and [HubSpot Web (Actions)](/docs/connections/destinations/catalog/actions-hubspot-web/) for more information.
 ---
 [HubSpot](https://www.hubspot.com/){:target="_blank"} is an inbound marketing and sales platform that helps companies attract visitors, convert leads, and close customers. The `analytics.js` HubSpot Destination is open-source. You can browse the code [on GitHub](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/hubspot){:target="_blank"}.
 

--- a/src/connections/destinations/catalog/intercom/index.md
+++ b/src/connections/destinations/catalog/intercom/index.md
@@ -5,7 +5,7 @@ hide-personas-partial: true
 cmode-override: true
 id: 54521fd725e721e32a72eec6
 maintenance: true
-maintenance-content: New versions of the destination are available. See [Intercom Web (Actions)](/docs/connections/destinations/catalog/actions-intercom-web/) and [Intercom Cloud Mode (Actions)](/docs/connections/destinations/catalog/actions-intercom-cloud/) for more information.
+maintenance-content: New versions of the destination are available. See [Intercom Cloud Mode (Actions)](/docs/connections/destinations/catalog/actions-intercom-cloud/) and [Intercom Web (Actions)](/docs/connections/destinations/catalog/actions-intercom-web/) for more information.
 ---
 [Intercom](https://www.intercom.com/) makes customer messaging apps for sales, marketing, and support, connected on one platform. The Intercom Destination is open-source. You can browse the code for [analytics.js](https://github.com/segment-integrations/analytics.js-integration-intercom), [iOS](https://github.com/segment-integrations/analytics-ios-integration-intercom) and [Android](https://github.com/segment-integrations/analytics-android-integration-intercom) on GitHub.
 

--- a/src/connections/destinations/catalog/intercom/index.md
+++ b/src/connections/destinations/catalog/intercom/index.md
@@ -5,6 +5,7 @@ hide-personas-partial: true
 cmode-override: true
 id: 54521fd725e721e32a72eec6
 maintenance: true
+maintenance-content: New versions of the destination are available. See [Intercom Web (Actions)](/docs/connections/destinations/catalog/actions-intercom-web/) and [Intercom Cloud Mode (Actions)](/docs/connections/destinations/catalog/actions-intercom-cloud/) for more information.
 ---
 [Intercom](https://www.intercom.com/) makes customer messaging apps for sales, marketing, and support, connected on one platform. The Intercom Destination is open-source. You can browse the code for [analytics.js](https://github.com/segment-integrations/analytics.js-integration-intercom), [iOS](https://github.com/segment-integrations/analytics-ios-integration-intercom) and [Android](https://github.com/segment-integrations/analytics-android-integration-intercom) on GitHub.
 

--- a/src/connections/destinations/catalog/pardot/index.md
+++ b/src/connections/destinations/catalog/pardot/index.md
@@ -3,6 +3,7 @@ title: Salesforce Pardot Destination
 strat: salesforce
 id: 54521fd925e721e32a72eee1
 maintenance: true
+actions-slug: actions-pardot
 ---
 
 ## Getting Started


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Updating the way we autogenerate maintenace mode blurbs to allow us to manually specify the slug of 
the related Actions destination.

Also update HubSpot and Intercom classic pages to include the maintenance blurb so we can point to 
both Cloud and Web actions destinations.


<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
