### PR TITLE
Update import statement to explicitly call segment.analytics

### DIFF
--- a/src/connections/sources/catalog/libraries/server/python/quickstart.md
+++ b/src/connections/sources/catalog/libraries/server/python/quickstart.md
@@ -33,7 +33,7 @@ If you're using a system for managing dependencies, you'll want to pin the libra
 Then inside your app, you'll want to set your `write_key` before making any analytics calls:
 
 ```python
-import analytics
+import segment.analytics as analytics
 
 analytics.write_key = 'YOUR_WRITE_KEY'
 ```


### PR DESCRIPTION
### Proposed changes

- Update python import statement to explicitly call segment.analytics due to the fact that there are multiple analytics packages with the same name "analytics"

### Related issues 

- Closes #3505.
