### PR TITLE
Engage Events Source GA

### DIFF
--- a/src/_data/sidenav/main.yml
+++ b/src/_data/sidenav/main.yml
@@ -320,6 +320,8 @@ sections:
       title: Set User Subscriptions
     - path: /engage/user-subscriptions/subscription-states
       title: Subscription States
+    - path: /engage/user-subscriptions/engage-source
+      title: Engage Events Source
   - section_title: Profiles
     description: "See how to create audiences based on data."
     section:

--- a/src/engage/user-subscriptions/engage-source.md
+++ b/src/engage/user-subscriptions/engage-source.md
@@ -1,11 +1,7 @@
 ---
 title: Engage Events Source
 plan: engage-foundations
-hidden: true
 ---
-
-> info ""
-> The Engage Events Source is in beta.
 
 Use the Engage Events Source to sync Engage subscription states to downstream Destinations.
 


### PR DESCRIPTION
### Proposed changes

- Removed beta flag for the Engage Events Source page.
- Changed filed name to `engage-source.md`.
- Added page to side navigation.

### Merge timing

- 14 December 2022.