### PR TITLE
Add example to only send events with userId

### DIFF
--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -68,7 +68,7 @@ The following examples illustrate common destinations filters use cases:
 * [Remove internal and test events from production tools](#remove-internal-and-test-events-from-production-tools)
 * [Sample a percentage of events](#sample-a-percentage-of-events)
 * [Drop events](#drop-events)  
-* [Only send event with userId](#only-send-events-with-userid) 
+* [Only send events with userId](#only-send-events-with-userid) 
 
 ### PII management
 
@@ -111,7 +111,7 @@ Using the [destination filters API](https://docs.segmentapis.com/tag/Destination
 
 ### Only send events with userId
 
-You may only want to send some events downstream to your destinations if they contain a `userId`. You won't be able to configure a filter like that in the Destination Filter UI, but you can use the [Public API](https://docs.segmentapis.com/tag/Destination-Filters/){:target="_blank"} to achieve this. Here is an example of how you might format such a request:
+Use the [Public API](https://docs.segmentapis.com/tag/Destination-Filters/){:target="_blank"} to only send events to your destination if they contain a `userId`. Here's an example of how you might format this request:
 
 ```json
 {

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -68,6 +68,7 @@ The following examples illustrate common destinations filters use cases:
 * [Remove internal and test events from production tools](#remove-internal-and-test-events-from-production-tools)
 * [Sample a percentage of events](#sample-a-percentage-of-events)
 * [Drop events](#drop-events)  
+* [Only send event with userId](#only-send-events-with-userid) 
 
 ### PII management
 
@@ -107,6 +108,26 @@ Using the [destination filters API](https://docs.segmentapis.com/tag/Destination
 ### Drop events
 
 [Watch this destination filters walkthrough](https://www.youtube.com/watch?v=47dhAF1Hoco){:target="_blank"} to learn how to use event names to filter events sent to destinations.
+
+### Only send events with userId
+
+You may only want to send some events downstream to your destinations if they contain a `userId`. You won't be able to configure a filter like that in the Destination Filter UI, but you can use the [Public API](https://docs.segmentapis.com/tag/Destination-Filters/){:target="_blank"} to achieve this. Here is an example of how you might format such a request:
+
+```json
+{
+    "sourceId": "<SOURCE_ID>",
+    "destinationId": "<DESTIANTION_ID>",
+    "title": "Don't send event if userId is null",
+    "description": "Drop event if there is no userId on the request",
+    "if": "length( userId ) < 1 or typeof( userId ) != 'string'",
+    "actions": [
+      {
+        "type": "DROP"
+      }
+    ],
+    "enabled": true
+  }
+```
 
 ## Important notes
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Added example to demonstrate how to use the Public API to filter events without a userId. Customers routinely write in asking about how to filter out anonymous events, expecting that this should be possible in the destination filter UI. As such, it makes sense to explain how to do this here in the destination filters article, along with the other examples of common use cases.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
