### PR TITLE
Add example to only send events with userId

### DIFF
--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -42,7 +42,7 @@ To create a destination filter:
 5. *(Optional)* Click **Load Sample Event** to see if the event passes through your filter.
 6. Click **Next Step**.
 7. Name your filter and click the toggle to enable it.
-8. Click **Save**.
+8. Click **Save**.   
 
 ## Destination filters API
 


### PR DESCRIPTION


### Proposed changes

Added example to demonstrate how to use the Public API to filter events without a userId. Customers routinely write in asking about how to filter out anonymous events, expecting that this should be possible in the destination filter UI. As such, it makes sense to explain how to do this here in the destination filters article, along with the other examples of common use cases.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
