### PR TITLE
Add example to only send events with userId

### DIFF
--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -16,7 +16,7 @@ Common use cases for destination filters include:
 - Managing PII (personally identifiable information) by blocking fields from reaching certain destinations
 - Controlling event volume by sampling or dropping unnecessary events for specific destinations
 - Increasing data relevance in your destinations by removing unused or unwanted data
-- Preventing test or internally-generated events from reaching your production tools
+- Preventing test or internally-generated events from reaching your production tools 
 
 ### Limitations
 


### PR DESCRIPTION

### Proposed changes

Added example to demonstrate how to use the Public API to filter events without a userId. Customers routinely write in asking about how to filter out anonymous events, expecting that this should be possible in the destination filter UI. As such, it makes sense to explain how to do this here in the destination filters article, along with the other examples of common use cases.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
