### PR TITLE
Add Ripe cloud mode docs

### DIFF
--- a/src/connections/destinations/catalog/actions-ripe-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-ripe-cloud/index.md
@@ -1,0 +1,37 @@
+---
+title: Ripe Cloud (Actions) Destination
+hide-boilerplate: true
+hide-dossier: true
+private: true
+---
+
+[Ripe](https://www.getripe.com/){:target="_blank"} is a product-led sales 
+platform that empowers you to unlock revenue pipeline with product data. By identifying and showing which prospects to focus efforts on, you can convert leads into meetings inside your product.
+
+This destination enables you to send product data to Ripe. Sales teams can identify who decision-makers and product champions are by understanding what properties they have and what events they have triggered. The Ripe destination is built as an alternative to directly adding Ripe’s SDK script to your app or site.
+
+The Ripe Segment integration is an [Actions-based Destination in cloud mode](/docs/connections/destinations/#connection-modes) that lets you send your backend events directly to Ripe.
+
+{% include content/ajs-upgrade.md %}
+
+## Benefits of Ripe
+
+Ripe provides the following benefits:
+
+- **Be relevant**. The Ripe destination understands key events in Segment to identify relevant leads, and shows its widget selectively to them.
+- **Quick integration**. Using the Ripe destination is the fastest way to start combining key product events with sales data and start targeting ripe leads.
+- **More control**. You can customize the conditions under which the events are sent to Ripe.
+
+## Getting started
+
+> info ""
+> Before you begin, create an API key in Ripe which you'll use to configure the integration.
+
+
+1. From the Segment web app, navigate to **Connections > Catalog**, then click the **Destinations** tab at the top of the catalog.
+2. Search for *Ripe Cloud Mode (Actions)* in the left navigation, and click it.
+3. Click **Configure Ripe Cloud Mode (Actions)**.
+4. Select an existing Source to connect to Ripe (Actions).
+5. Enter your Ripe API key in the API key field.
+
+{% include components/actions-fields.html %}

--- a/src/connections/destinations/catalog/actions-ripe-web/index.md
+++ b/src/connections/destinations/catalog/actions-ripe-web/index.md
@@ -1,5 +1,5 @@
 ---
-title: Ripe Destination (Actions)
+title: Ripe Web (Actions) Destination
 hide-boilerplate: true
 hide-dossier: true
 id: 63913b2bf906ea939f153851
@@ -29,8 +29,8 @@ Ripe provides the following benefits:
 
 
 1. From the Segment web app, navigate to **Connections > Catalog**, then click the **Destinations** tab at the top of the catalog.
-2. Search for *Ripe* in the left navigation, and click it.
-3. Click **Configure Ripe**.
+2. Search for *Ripe Device Mode (Actions)* in the left navigation, and click it.
+3. Click **Configure Ripe Device Mode (Actions)**.
 4. Select an existing Source to connect to Ripe (Actions).
 5. Enter your Ripe API key in the API key field.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Added documentation for the Ripe cloud mode integration and updated the documentation for the device mode integration accordingly. See the cloud mode PR for reference: https://github.com/segmentio/action-destinations/pull/952

The device mode integration has been renamed to `Ripe Web Destination (Actions)` for clarity, and the new cloud mode one is called `Ripe Cloud Destination (Actions)`.

### Merge timing
- ASAP once approved

### Related issues (optional)

https://github.com/segmentio/action-destinations/pull/952
