### PR TITLE
PROT-4465: remove matchers and add new default matchers

### DIFF
--- a/src/privacy/portal.md
+++ b/src/privacy/portal.md
@@ -138,16 +138,14 @@ Below is a full list of automatically detected restricted fields.
 | Matcher                | Classification |
 | ---------------------- | -------------- |
 | social security number | red            |
-| health                 | red            |
 | password               | red            |
 | visa                   | red            |
 | veteran                | red            |
 | disability             | red            |
 | credit card            | red            |
-| genetic                | red            |
-| race                   | red            |
 | passport               | red            |
 | token                  | red            |
+| race                   | yellow         |
 | birthdate              | yellow         |
 | phone                  | yellow         |
 | address                | yellow         |
@@ -172,7 +170,11 @@ Below is a full list of automatically detected restricted fields.
 | sex                    | yellow         |
 | gender                 | yellow         |
 | sexual orientation     | yellow         |
-
+| medication             | yellow         |
+| allergy                | yellow         |
+| condition              | yellow         |
+| diagnosis              | yellow         |
+| procedure              | yellow         |
 
 When Segment detects data that meets the criteria for one of the default
 matchers (in the list above) in properties in your Web, Mobile, Server, or Cloud


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

Made changes to match the changes in this [pii-classifier PR](https://github.com/segmentio/pii-classifier/pull/158). 
Removed health and genetic as default matchers. changed race to a yellow matcher. And added 5 new yellow matchers: meditation, allergy, diagnosis, procedure, condition. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

ASAP once approved

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
