### PR TITLE
Suggested note for Regional Segment doc's

### DIFF
--- a/src/guides/regional-segment.md
+++ b/src/guides/regional-segment.md
@@ -14,6 +14,9 @@ The default region for all users is in Oregon, United States. Workspaces can be 
 ## Existing Workspaces
 To ensure a smooth transition from a US-based Segment workspace to an EU workspace, Segment will provide additional support and tooling to help with the transition later this year. Use the form link below to provide more information about your current setup and goals for transitioning.
 
+(suggested Note)
+Please Note: Transferring workspaces between regions is not supported.
+
 {% include components/ajs-cookie.html %}
 
 ## Regional Data Ingestion

--- a/src/guides/regional-segment.md
+++ b/src/guides/regional-segment.md
@@ -14,8 +14,8 @@ The default region for all users is in Oregon, United States. Workspaces can be 
 ## Existing Workspaces
 To ensure a smooth transition from a US-based Segment workspace to an EU workspace, Segment will provide additional support and tooling to help with the transition later this year. Use the form link below to provide more information about your current setup and goals for transitioning.
 
-(suggested Note)
-Please Note: The Segment UI does not support moving workspaces between regions. To request help with this move, please complete the Data Residency Workspace Provisioning Flow form. (Link to form: https://segment.typeform.com/to/k5ADnN5e?typeform-source=segment.com#user_id=9hLQ2NuvaCLxFbdkMYbjFp) 
+> info ""
+> The Segment UI doesn't support moving workspaces between regions. To request help with this move, [complete the Data Residency Workspace Provisioning Flow form](https://segment.typeform.com/to/k5ADnN5e?typeform-source=segment.com#user_id=9hLQ2NuvaCLxFbdkMYbjFp){:target="_blank"}.
 
 {% include components/ajs-cookie.html %}
 

--- a/src/guides/regional-segment.md
+++ b/src/guides/regional-segment.md
@@ -15,7 +15,7 @@ The default region for all users is in Oregon, United States. Workspaces can be 
 To ensure a smooth transition from a US-based Segment workspace to an EU workspace, Segment will provide additional support and tooling to help with the transition later this year. Use the form link below to provide more information about your current setup and goals for transitioning.
 
 (suggested Note)
-Please Note: Transferring workspaces between regions is not supported.
+Please Note: The Segment UI does not support moving workspaces between regions. To request help with this move, please complete the Data Residency Workspace Provisioning Flow form. (Link to form: https://segment.typeform.com/to/k5ADnN5e?typeform-source=segment.com#user_id=9hLQ2NuvaCLxFbdkMYbjFp) 
 
 {% include components/ajs-cookie.html %}
 


### PR DESCRIPTION
It's not made clear to customers that they cannot transfer workspaces between regions on our doc's. 

Suggested Note: Please Note: Transferring workspaces between regions is not supported.

### Proposed changes
When investigating ticket: https://segment.zendesk.com/agent/tickets/492849 

We found that:

When testing a customer write key, and it appears to have an issue with apiHost setting, which we read to send to the correct API endpoint.
{"integrations":{"Mixpanel (Actions)":{"versionSettings":{"componentTypes":[]}},"AWS S3":{"versionSettings":{"componentTypes":[]}},"Intercom Cloud Mode (Actions)":{"versionSettings":{"componentTypes":[]}},"Segment.io":{"apiKey":"V7XLWTDEYT5CKj2jdgjWdtOiifAkqJHk","unbundledIntegrations":[],"addBundledMetadata":true,"maybeBundledConfigIds":{},"versionSettings":{"version":"4.4.7","componentTypes":["browser"]}}},"plan":{"track":{"__default":{"enabled":true,"integrations":{}}},"identify":{"__default":{"enabled":true}},"group":{"__default":{"enabled":true}}},"edgeFunction":{},"analyticsNextEnabled":true,"middlewareSettings":{},"enabledMiddleware":{},"metrics":{"sampleRate":0.1},"legacyVideoPluginsEnabled":false,"remotePlugins":[]}
Above is the customers workspace settings and it does not appear. 

For comparison, here's the workspace we tested on settings: 
{"integrations":{"Segment.io":{"apiKey":"8cjl7Z85hryP7JFh8ruAoDsIr850Lm2S","unbundledIntegrations":[],"addBundledMetadata":true,"maybeBundledConfigIds":{},"versionSettings":{"version":"4.4.7","componentTypes":["browser"]},"apiHost":"events.eu1.segmentapis.com/v1"}},"plan":{"track":{"__default":{"enabled":true,"integrations":{}}},"identify":{"__default":{"enabled":true}},"group":{"__default":{"enabled":true}}},"edgeFunction":{},"analyticsNextEnabled":false,"middlewareSettings":{},"enabledMiddleware":{},"metrics":{"sampleRate":0.1,"host":"events.eu1.segmentapis.com/v1"},"legacyVideoPluginsEnabled":false,"remotePlugins":[]}
 
The issue is related to a transferred workspace. When you transfer a workspace to an EU workspace, then the source becomes unsupported.  
 
If you transferred the source from a regular workspace to EU workspace, then the API host remains the default one ([api.segment.io](http://api.segment.io/)), which means no API host is added to the CDN file to override the US endpoint.

### Merge timing
- ASAP once approved?

