### PR TITLE
add info about how data comes from Clearbit

### DIFF
--- a/src/connections/destinations/catalog/clearbit-reveal/index.md
+++ b/src/connections/destinations/catalog/clearbit-reveal/index.md
@@ -22,6 +22,8 @@ Setup within Clearbit:
 
 To verify that the destination has been set up correctly, send a page event **that includes an IP address**, check the Debugger section of your Segment Source. Assuming everything is as it should be, you should start seeing Clearbit Reveal data populate in an `identify` event – click on the specific event you're interested in to see Clearbit Reveal traits. These traits will now be available to other Segment destinations in your account. Notice that all Clearbit Reveal traits are prefixed with `reveal_` to ensure they don't conflict with existing traits. Clearbit will also send a `track` event for 'enrichment_provider'.
 
+When you make requests to Clearbit, they send events with Clearbit data back to your Segment source server-side using Segment's analytics-ruby library. If you see unexpected traffict from analytics-ruby in your Debugger, not to worry! Those are just your Clearbit events.
+
 
 ## Page
 

--- a/src/connections/destinations/catalog/clearbit-reveal/index.md
+++ b/src/connections/destinations/catalog/clearbit-reveal/index.md
@@ -22,7 +22,7 @@ Setup within Clearbit:
 
 To verify that the destination has been set up correctly, send a page event **that includes an IP address**, check the Debugger section of your Segment Source. Assuming everything is as it should be, you should start seeing Clearbit Reveal data populate in an `identify` event – click on the specific event you're interested in to see Clearbit Reveal traits. These traits will now be available to other Segment destinations in your account. Notice that all Clearbit Reveal traits are prefixed with `reveal_` to ensure they don't conflict with existing traits. Clearbit will also send a `track` event for 'enrichment_provider'.
 
-When you make requests to Clearbit, they send events with Clearbit data back to your Segment source server-side using Segment's analytics-ruby library. If you see unexpected traffict from analytics-ruby in your Debugger, not to worry! Those are just your Clearbit events.
+When you make requests to Clearbit, Clearbit send events with its own data back to your Segment source server-side using Segment's analytics-ruby library. If you see unexpected traffic from analytics-ruby in your Debugger, that traffic represents the events that Clearbit sends back.
 
 
 ## Page


### PR DESCRIPTION
Customers in the past have been confused about dataflow with Clearbit and about why they see analytics-ruby events in their Debugger. This update clarifies that a bit. 

There are past Zendesk tickets that all confirm Clearbit data comes back to Segment using analytics-ruby. In addition, Clearbit published this line about it in one of their blog posts: https://clearbit.com/blog/enterprise-grade-analytics-for-startups-2#:~:text=Segment%E2%80%99s%20robust%20API%20and%20Ruby%20library%20enabled%20our%20engineering%20team%20to%20quickly%20build%20an%20event%20emitting%20service%20that%20sends%20usage%20and%20behavioral%20data%20from%20Clearbit%20applications%20and%20services%20into%20Segment%2C%20tracking%20everything%20from%20API%20usage%20and%20page%20views%20to%20signups%20and%20subscribe%20events..

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
