### PR TITLE
Update FAQ section with solution for data not sending to Google

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -128,6 +128,10 @@ For a complete map of Universal Analytics functionality to corresponding Google 
 
 ## FAQ & Troubleshooting
 
+### Data not sending to Google
+
+Ensure that at least one mapping has been configured and enabled in the destination mappings for an event that you would like to reach Google. Without any mappings enabled to trigger on an event that has been ingested by the connected source, the destination will not send events downstream.
+
 ### Attribution Reporting
 
 Google doesn't currently support passing certain reserved fields to the Google Analytics 4 Measurement Protocol API. This includes attribution data, like UTM parameters. If you rely on attribution reporting, you can either send this data as [custom dimensions](/docs/connections/destinations/catalog/actions-google-analytics-4/#custom-dimensions-and-metrics) or implement a parallel client-side integration to collect this data with gtag.js.


### PR DESCRIPTION
### Proposed changes

Many customers have written in to support asking why the GA4 destination is not sending events to Google - in most cases, it's because they did not configure and enable any mappings. 

Added a snippet under FAQ & Troubleshooting that explains and solves this common question. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
