### PR TITLE
Update the section to check for Snowflake account name

### DIFF
--- a/src/connections/storage/catalog/snowflake/index.md
+++ b/src/connections/storage/catalog/snowflake/index.md
@@ -93,11 +93,10 @@ To install and verify your accounts:
 snowsql -a <account>  -u <user>
 ```
 
-For accounts outside the US, the account ID includes the region. You can find your account name from the browser address string:
+For accounts outside the US, the account ID includes the region. You can find your account name from the browser address string.
 
-<img width="566" alt="rtaImage" src="https://user-images.githubusercontent.com/37472597/212277907-04e05f89-ae0c-4c75-a355-9ce975cb05a0.png">
+If your web address is `https://myaccountname.snowflakecomputing.com/console#/internal/worksheet`, your account name would be `myaccountname`.
 
-The text in the red box (the one before the first dot) is going to be your account name.
 
 You can also find part of your account name by running the following query on your worksheet in Snowflake:
 

--- a/src/connections/storage/catalog/snowflake/index.md
+++ b/src/connections/storage/catalog/snowflake/index.md
@@ -97,7 +97,6 @@ For accounts outside the US, the account ID includes the region. You can find yo
 
 If your web address is `https://myaccountname.snowflakecomputing.com/console#/internal/worksheet`, your account name would be `myaccountname`.
 
-
 You can also find part of your account name by running the following query on your worksheet in Snowflake:
 
 ```

--- a/src/connections/storage/catalog/snowflake/index.md
+++ b/src/connections/storage/catalog/snowflake/index.md
@@ -93,7 +93,13 @@ To install and verify your accounts:
 snowsql -a <account>  -u <user>
 ```
 
-For accounts outside the US, the account ID includes the region. You can also find part of your account name by running the following query on your worksheet in Snowflake:
+For accounts outside the US, the account ID includes the region. You can find your account name from the browser address string:
+
+<img width="566" alt="rtaImage" src="https://user-images.githubusercontent.com/37472597/212277907-04e05f89-ae0c-4c75-a355-9ce975cb05a0.png">
+
+The text in the red box (the one before the first dot) is going to be your account name.
+
+You can also find part of your account name by running the following query on your worksheet in Snowflake:
 
 ```
 SELECT CURRENT_ACCOUNT();


### PR DESCRIPTION
### Proposed changes

I was connecting to Snowflake by using this command: `snowsql -a <account>  -u <user>`

However, I was getting the invalid account name returned from this query: `SELECT CURRENT_ACCOUNT();`

By checking the docs/post from Snowflake, there is another way to retrieve the account name:
- https://community.snowflake.com/s/article/How-to-check-for-current-account-name
- https://community.snowflake.com/s/question/0D53r0000BpaPdpCQE/hi-all-im-trying-to-install-snowsql-in-my-personal-laptop-im-getting-error-as-250001-08001-failed-to-connect-to-db-verify-the-account-name-is-correct-dl44000snowflakecomputingcom443-000403-403-http-403-forbidden-thanksdivakar


### Merge timing
- ASAP once approved
