### PR TITLE
Add correct actions slug for customer.io

### DIFF
--- a/src/connections/destinations/catalog/customer-io/index.md
+++ b/src/connections/destinations/catalog/customer-io/index.md
@@ -5,6 +5,7 @@ redirect_from: "/connections/destinations/catalog/customer.io/"
 hide-personas-partial: true
 maintenance: true
 id: 54521fd525e721e32a72eea8
+actions-slug: "customer-io-actions"
 ---
 [Customer.io](https://customer.io/) helps you send automated email, push, SMS, and webhooks based on your customers' activities in your app or product. It makes conversion tracking, optimization and re-marketing easier. The `analytics.js` Customer.io Destination is open-source. You can browse the code [on GitHub](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/customerio).
 


### PR DESCRIPTION
### Proposed changes
The custoemr.io destination does not correctly link to the actions destination: https://segment.com/docs/connections/destinations/catalog/customer-io/#:~:text=See%20Customer.io%20(Actions)

This takes you to a 404 page. https://segment.com/docs/connections/destinations/catalog/actions-Customer.io

Add a page property to link to the correct URL.
