### PR TITLE
Add info note specifying supported data types for mapping operators

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -127,15 +127,29 @@ The following type filters and operators are available to help you build conditi
 
 - **Event type** (`is`/`is not`). This allows you to filter by the [event types in the Segment Spec](/docs/connections/spec).
 - **Event name** (`is`, `is not`, `contains`, `does not contain`, `starts with`, `ends with`). Use these filters to find events that match a specific name, regardless of the event type.
-- **Event property** (`is`, `is not`, `less than`, `less than or equal to`, `greater than`, `greater than or equal to`, `contains`,  `does not contain`, `starts with`, `ends with`, `exists`, `does not exist`).  Use these filters to trigger the action only when an event with a specific property occurs. You can specify nested properties using dot notation, for example `context.app.name`. If the property might appear in more than one format or location, you can use an ANY statement and add conditions for each of those formats. For example, you might filter for both `context.device.type = ios`  as well as `context.os.name = "iPhone OS``"`
-    The `does` `not exist` operator matches both a `null` value or a missing property.
+- **Event property** (`is`, `is not`, `less than`, `less than or equal to`, `greater than`, `greater than or equal to`, `contains`,  `does not contain`, `starts with`, `ends with`, `exists`, `does not exist`).  Use these filters to trigger the action only when an event with a specific property occurs. 
 
+    You can specify nested properties using dot notation, for example `context.app.name`. If the property might appear in more than one format or location, you can use an ANY statement and add conditions for each of those formats. For example, you might filter for both `context.device.type = ios`  as well as `context.os.name = "iPhone OS``"`
+    The `does` `not exist` operator matches both a `null` value or a missing property.
+{% comment %}
 > info "Event property operators and supported data types"
-> The following operators only support matching on values with a **string** data type:
+> Operators support matching on values with a **string** data type:
 > - `is`, `is not`, `contains`,  `does not contain`, `starts with`, `ends with`
-> Operators that support matching on values with either a **string** or **numeric** data type are as follows:
+> 
+> Operators that support matching on values with either a **string** or **numeric** data type:
 > - `is less than`, `is less than or equal to`, `is greater than`, `is greater than or equal to`
-> `is true`, `is false` operators support matching on values with a **boolean** data type.
+> 
+> Operators that support matching on values with a **boolean** data type:
+> - `is true`, `is false`
+{% endcomment %}
+
+The available operators depend on the property's data type:
+
+| Data Type         | Supported Operators                                                                          |
+| ----------------- | -------------------------------------------------------------------------------------------- |
+| string            | `is`, `is not`, `contains`,  `does not contain`, `starts with`, `ends with`                  |
+| string or numeric | `is less than`, `is less than or equal to`, `is greater than`, `is greater than or equal to` |
+| boolean           | `is true`, `is false`                                                                        |
 
 You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY to “subscribe” to multiple conditions. Use ALL when you need to filter for very specific conditions. You can only create one group condition per destination action. You cannot created nested conditions.
 

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -127,8 +127,15 @@ The following type filters and operators are available to help you build conditi
 
 - **Event type** (`is`/`is not`). This allows you to filter by the [event types in the Segment Spec](/docs/connections/spec).
 - **Event name** (`is`, `is not`, `contains`, `does not contain`, `starts with`, `ends with`). Use these filters to find events that match a specific name, regardless of the event type.
-- **Event property** (`is`, `is not`, `less than`, `less than or equal to`, `greater than`, `greater than or equal to`, `contains`,  `does not contain`, `starts with`, `ends with`, `exists`, `does not exist`).  Use these filters to trigger the action only when an event with a specific property occurs.  You can specify nested properties using dot notation, for example `context.app.name`. If the property might appear in more than one format or location, you can use an ANY statement and add conditions for each of those formats. For example, you might filter for both `context.device.type = ios`  as well as `context.os.name = "iPhone OS``"`
+- **Event property** (`is`, `is not`, `less than`, `less than or equal to`, `greater than`, `greater than or equal to`, `contains`,  `does not contain`, `starts with`, `ends with`, `exists`, `does not exist`).  Use these filters to trigger the action only when an event with a specific property occurs. You can specify nested properties using dot notation, for example `context.app.name`. If the property might appear in more than one format or location, you can use an ANY statement and add conditions for each of those formats. For example, you might filter for both `context.device.type = ios`  as well as `context.os.name = "iPhone OS``"`
     The `does` `not exist` operator matches both a `null` value or a missing property.
+
+> info "Event property operators and supported data types"
+> The following operators only support matching on values with a **string** data type:
+> - `is`, `is not`, `contains`,  `does not contain`, `starts with`, `ends with`
+> Operators that support matching on values with either a **string** or **numeric** data type are as follows:
+> - `is less than`, `is less than or equal to`, `is greater than`, `is greater than or equal to`
+> `is true`, `is false` operators support matching on values with a **boolean** data type.
 
 You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY to “subscribe” to multiple conditions. Use ALL when you need to filter for very specific conditions. You can only create one group condition per destination action. You cannot created nested conditions.
 


### PR DESCRIPTION
### Proposed changes

Several customers have written in to support expressing confusion on why certain operators in event triggers don't behave as expected in regard to matching on data types. For example, a trigger with an `is` operator will not match on a numeric data type, only a string:

Matching on string:
![match_on_str](https://user-images.githubusercontent.com/93934274/213300390-414e9631-fd42-4529-a2c0-214282733cbe.png)

Not matching on number:
![no_match_num](https://user-images.githubusercontent.com/93934274/213300434-0a4e2c1f-a50d-402f-9bed-ccca6fcd7918.png)

The expectations for these mappings aren't directly mentioned in the docs - adding a section that highlights operators and their allowed data types should help to clarify expected behavior. 

Slack thread for context: https://twilio.slack.com/archives/CC97A542H/p1674058095447979 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
