### PR TITLE
Describe latency with data appearing in Google Analytics

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -150,4 +150,4 @@ Google reserves certain event names, parameters, and user properties. Google sil
 
 ### Data taking a long time to appear in Google's reports
 
-Please be aware that Google may take [24-48 hours to process data on their end](https://support.google.com/analytics/answer/9333790) so you may not see it in some places in the Google UI immediately. That said, Google's Realtime view will update fairly quickly (typically within a minute). 
+Google may take [24-48 hours](https://support.google.com/analytics/answer/9333790)  to process data sent to Google Analytics. As a result, the Google Analytics user interface may not reflect the most current data. The Google Analytics [Realtime report](https://support.google.com/analytics/answer/9271392){:target="_blank"} displays activity on your site as it happens.

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -147,3 +147,7 @@ Google recommends use of their Firebase SDKs to send mobile data to Google Analy
 ### Reserved Names
 
 Google reserves certain event names, parameters, and user properties. Google silently drops any events that include [these reserved names](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#reserved_names){:target="_blank"}. If you notice that your data isn't appearing in Google, please check that you're not using a reserved name.
+
+### Data taking a long time to appear in Google's reports
+
+Please be aware that Google may take [24-48 hours to process data on their end](https://support.google.com/analytics/answer/9333790) so you may not see it in some places in the Google UI immediately. That said, Google's Realtime view will update fairly quickly (typically within a minute). 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Google doesn't immediately process events into their reports which can be confusing for customers. According to Google, it can take 24-48 hours for data to appear in their reports. This change adds a reference into our documentation about that: https://support.google.com/analytics/answer/9333790. 

### Merge timing
ASAP once approved

### Related issues (optional)
https://segment.zendesk.com/agent/tickets/496083
