### PR TITLE
Add info section about client-side Klaviyo events

### DIFF
--- a/src/connections/destinations/catalog/klaviyo/index.md
+++ b/src/connections/destinations/catalog/klaviyo/index.md
@@ -143,7 +143,7 @@ analytics.track({
 When you call `track` on `analytics.js`, Segment calls Klaviyo's `track` with the same parameters.
 
 > info ""
-> When you're tracking client-side, some Klaviyo events require that an `identify` event **must** be sent first before a `track` event. 
+> When you're tracking client-side, some Klaviyo events require you send an Identify call  before a Track call. 
 
 ### Server-side Track
 

--- a/src/connections/destinations/catalog/klaviyo/index.md
+++ b/src/connections/destinations/catalog/klaviyo/index.md
@@ -142,6 +142,9 @@ analytics.track({
 
 When you call `track` on `analytics.js`, Segment calls Klaviyo's `track` with the same parameters.
 
+> info ""
+> When you're tracking client-side, some Klaviyo events require that an `identify` event **must** be sent first before a `track` event. 
+
 ### Server-side Track
 
 When you call make a Track call from one of Segment's mobile or server-side libraries, Segment keys the user with the `userId` and also provides the Klaviyo `$email` `customer_property` if your `userId` is an email, or you provide `email` as one of your event `properties`.


### PR DESCRIPTION
### Proposed changes

Let customers know that some Klaviyo client-side events (such as Added to Cart) require that a user be identified first (i.e. cookied) in order to track a subsequent event.

### Merge timing
- ASAP once approved

