### PR TITLE
Add info about clearing schema properties

### DIFF
--- a/src/connections/schema-unique-limits.md
+++ b/src/connections/schema-unique-limits.md
@@ -10,17 +10,16 @@ While you can technically track unlimited events with Segment, only the first 4,
 
 While you can track unlimited event properties with Segment, the event details page for a specific event can only show the first 300 properties. After you hit the 300 property limit, future properties are still tracked and sent to your Destinations, but they won't appear on the event details page. This limit includes nested properties in an event's `properties` object.
 
-These limits can also affect the traits and properties that you can see in the Computed Trait and Audience builder tools in Engage. If expected traits or properties do not appear in these tools, contact the [Segment Support team](https://segment.com/help/contact/).
+These limits can also affect the traits and properties that you can see in the Computed Trait and Audience builder tools in Engage. If expected traits or properties do not appear in these tools, contact the [Segment Support team](https://segment.com/help/contact/){:target="blank"}.
 
 
 **How can I clear the Schema if I have hit the limits?**
 
 If you hit any of the limits or would like to clear out old events or properties, you can clear the Schema data from your Source Settings. In your Source, navigate to Settings, then Schema Configuration. Scroll down to the **Clear Schema History** setting.
 
-![](images/schema_config_clear_schema.png)
+![Clear your Schema data with Clear Schema History](images/schema_config_clear_schema.png)
 
 
 **How can I clear/archive properties in my source schema?**
 
-Unfortunately, at this time you cannot clear or archive old event properties individually. The best alternative for this would be to archive the event itself, and then clear the archive. After it has been cleared, the event will re-populate in the schema with only the current properties. 
-
+At this time, you cannot clear or archive old event properties individually. An alternative for this is to archive the event itself, and then clear the archive. After you clear the archive, the event will re-populate in the schema with only the current properties.

--- a/src/connections/schema-unique-limits.md
+++ b/src/connections/schema-unique-limits.md
@@ -18,3 +18,9 @@ These limits can also affect the traits and properties that you can see in the C
 If you hit any of the limits or would like to clear out old events or properties, you can clear the Schema data from your Source Settings. In your Source, navigate to Settings, then Schema Configuration. Scroll down to the **Clear Schema History** setting.
 
 ![](images/schema_config_clear_schema.png)
+
+
+**How can I clear/archive properties in my source schema?**
+
+Unfortunately, at this time you cannot clear or archive old event properties individually. The best alternative for this would be to archive the event itself, and then clear the archive. After it has been cleared, the event will re-populate in the schema with only the current properties. 
+


### PR DESCRIPTION
### Proposed changes

Added information to let customers know that they cannot clear/archive schema properties alone. Included a workaround that would involve archive the event itself and then clear it. 

### Merge timing

- ASAP once approved

### Related issues (optional)

n/a
