### PR TITLE
Update information that Engage generated source cannot be deleted

### DIFF
--- a/src/profiles/debugger.md
+++ b/src/profiles/debugger.md
@@ -7,7 +7,7 @@ redirect_from:
 
 The Engage Source Debugger enables you to inspect and monitor events that Engage sends downstream
 
-Because Engage generates a unique Source for every Destination connected to a Space, the Debugger gives you insight into how Engage sends events before they reach their Destination.
+Because Engage generates a unique Source for every Destination connected to a Space, the Debugger gives you insight into how Engage sends events before they reach their Destination. This automatically generated source cannot be deleted even when the destination is removed, in order for Engage to function as designed. The source will be reused by Engage as needed.
 
 The Debugger provides you with the payload information you need to troubleshoot potential formatting issues and ensure Engage sends events as your Destinations expect.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Added the following statement to indicate that this source generated by Engage cannot be deleted as there were a few tickets raise to request that such source be deleted:

"This automatically generated source cannot be deleted even when the destination is removed, in order for Engage to function as designed. The source will be reused by Engage as needed."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
