### PR TITLE
Update Source function FAQs Retry Policy

### DIFF
--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -386,6 +386,12 @@ Copy and paste this URL into the upstream tool or service to send data to this s
 ##### What is the retry policy for a webhook payload?
 
 Segment retries invocations that throw RetryError or Timeout errors up to six times. After six attempts, the request is dropped.
+The initial wait time for the retried event is a random value between 1 minute to 3 minutes.
+And the wait time increases exponentially after every retry attempt with the max wait time between attempts going up to 20 minutes.
+
+##### I configured a Retry Error in my function but they're not showing in my source function error logs?
+
+Retry Errors will only show in the source function error logs if the event has exhausted all 6 retry attempts and as a result has been dropped.
 
 ##### What is the maximum payload size for the incoming webhook?
 

--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -386,12 +386,12 @@ Copy and paste this URL into the upstream tool or service to send data to this s
 ##### What is the retry policy for a webhook payload?
 
 Segment retries invocations that throw RetryError or Timeout errors up to six times. After six attempts, the request is dropped.
-The initial wait time for the retried event is a random value between 1 minute to 3 minutes.
-And the wait time increases exponentially after every retry attempt with the max wait time between attempts going up to 20 minutes.
+The initial wait time for the retried event is a random value between one and three minutes.
+Wait time increases exponentially after every retry attempt. The maximum wait time between attempts can reach 20 minutes.
 
-##### I configured a Retry Error in my function but they're not showing in my source function error logs?
+##### I configured RetryError in a function, but it doesn't appear in my source function error log.
 
-Retry Errors will only show in the source function error logs if the event has exhausted all 6 retry attempts and as a result has been dropped.
+Retry errors only appear in the source function error logs if the event has exhausted all six retry attempts and, as a result, has been dropped.
 
 ##### What is the maximum payload size for the incoming webhook?
 


### PR DESCRIPTION
### Proposed changes
I've updated the retry policy FAQ question to include information on how quickly the function computation will be retried, and how long the wait times can be.

I've also added a new section to explain that the Retry errors will not show up in the logs unless the function has retried the event 6 times, and it has failed completely.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->
