### PR TITLE
Update how to navigate to custom field names

### DIFF
--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -58,7 +58,7 @@ analytics.identify('user1234', {
 
 HubSpot does not accept any trait keys that contain upper case letters or spaces. Segment converts any custom traits you send to lower case, and replaces spaces with an underscore.
 
-HubSpot removes from the request any traits that aren't contact fields in HubSpot. To find out which fields you can set, check out the custom field names in **Settings > Data Management > Objects > Contacts > Manage contact properties**. Example field names are `firstname`, `lastname`, `company`, and `phone`.
+HubSpot removes from the request any traits that aren't contact fields in HubSpot. To find out which fields you can set, navigate to **Settings > Data Management > Objects > Contacts** and select **Manage contact properties** under the **Setup** tab. Example field names are `firstname`, `lastname`, `company`, and `phone`.
 
 If you specify a company name (using `traits.company.name`), it appears as a *property* of the contact (you can find it in HubSpot's UI using **About [contact] > View > View All Properties**), but it does not appear as the user's company under **[contact]'s Company**.
 

--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -58,7 +58,7 @@ analytics.identify('user1234', {
 
 HubSpot does not accept any trait keys that contain upper case letters or spaces. Segment converts any custom traits you send to lower case, and replaces spaces with an underscore.
 
-HubSpot removes from the request any traits that aren't contact fields in HubSpot. To find out which fields you can set, check out the custom field names in **Contacts > Contact Settings**. Example field names are `firstname`, `lastname`, `company`, and `phone`.
+HubSpot removes from the request any traits that aren't contact fields in HubSpot. To find out which fields you can set, check out the custom field names in **Settings > Data Management > Objects > Contacts > Manage contact properties**. Example field names are `firstname`, `lastname`, `company`, and `phone`.
 
 If you specify a company name (using `traits.company.name`), it appears as a *property* of the contact (you can find it in HubSpot's UI using **About [contact] > View > View All Properties**), but it does not appear as the user's company under **[contact]'s Company**.
 


### PR DESCRIPTION
### Proposed changes

Under the section for Identify calls, the current information on finding/setting custom field names for contact properties does not lead anywhere, it should be updated to navigate to the correct place: Settings > Data Management > Objects > Contacts > Manage contact properties
![Screen Shot 2023-01-23 at 4 29 57 PM](https://user-images.githubusercontent.com/93934274/214155404-a290833f-b406-4ef2-ad60-5db33700d3ac.png)

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
