### PR TITLE
Fix link to Reset section

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/index.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/index.md
@@ -331,7 +331,7 @@ The Analytics.js utility methods help you change how Segment loads on your page.
 - [Debug](#debug)
 - [On (Emitter)](#emitter)
 - [Timeout](#extending-timeout)
-- [Reset (Logout)](#reset-or-logout)
+- [Reset (Logout)](#reset-or-log-out)
 
 ### Load
 


### PR DESCRIPTION
### Proposed changes

The link to the _Reset (Logout)_  section didn't do anything. The issue was that it was linking to `#reset-or-logout` while the anchor was `#reset-or-log-out`. This PR fixes the link by using the correct anchor. I could have changed the anchor but that would have caused existing links to it to break and just end up at the top of the page.

### Merge timing

- ASAP once approved
