### PR TITLE
Add note highlighting at least one mapping must be configured and enabled in Actions destination

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -64,6 +64,9 @@ To set up a new Actions-framework destination for the first time:
     You can choose **Quick Setup** to use the default mappings, or choose **Customized Setup** (if available) to create new mappings and conditions from a blank state. You can always edit these mappings later.
 7. Once you're satisfied with your mappings, click **Create Destination**.
 
+> info ""
+> At least one mapping to handle a connected source's event(s) must be configured and enabled in an Actions-framework destination in order for data to be sent downstream.
+
 ## Migrate a classic destination to an actions-based destination
 
 {% include content/ajs-upgrade.md %}


### PR DESCRIPTION
### Proposed changes

Customers frequently write in asking why data is not sending from an actions destination - in most cases, it's because there aren't any mappings configured/enabled to handle events. Another question that comes in related to this is when the customer tries sending a test event and is met with a Validation error that surfaces in response to a lack of a mapping to handle the event:
![image](https://user-images.githubusercontent.com/93934274/214914787-000a786b-063f-4922-b4cd-f422db9c8933.png)

It isn't currently mentioned in the Destination Actions docs that at least one mapping to handle the connected source's event(s) *must* be configured and enabled in order for data to reach the destination, so adding a note to highlight this should help to inform customers on what's required. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
