### PR TITLE
Update sql-traits.md

### DIFF
--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -242,3 +242,7 @@ In this case, for sources connected to Engage, Segment hasn't received any event
 You might be returning a value for `user_id` that's inconsistent with how you track `user_id` elsewhere. Some customers want to return `email` as the `user_id`, or a partner's tool ID as the `user_id`. These conflict with Segment best practices and corrupt the identity graph if you then track `user_id` differently elsewhere in your apps.
 
 If you see only question marks in the preview, and have already tracked data historically with Segment, then you likely have the wrong column. If your cloud source doesn't have the database `user_id`, Segment recommends using a `JOIN` clause with an internal users table before sending the results back to Segment.
+
+### Why few SQL trait’s settings are not having “Compute Schedule” option?
+
+New SQL traits created after Feb 8, 2021 have that option enabled by default. Before that, SQL trait computation frequency was disabled and the JIRA has to be created internally to enable the same. but starting on Feb 8th, this has changed. So we can see the compute schedule option on newly created SQL traits, but not on existing traits that were created before Feb 8th, and if you'd like to change the frequency of traits created before Feb 9, 2021, you will have to delete and re-create them.

--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -243,6 +243,6 @@ You might be returning a value for `user_id` that's inconsistent with how you tr
 
 If you see only question marks in the preview, and have already tracked data historically with Segment, then you likely have the wrong column. If your cloud source doesn't have the database `user_id`, Segment recommends using a `JOIN` clause with an internal users table before sending the results back to Segment.
 
-### Why some SQL trait’s settings do not have the “Compute Schedule” option?
+### Why do some SQL Trait settings not have the “Compute schedule” option?
 
-The compute schedule feature was added on Feb 8,2021, so traits created prior to this date will not have this option available. If your trait lacks this feature, recreating it will make it available.
+Segment added the compute schedule feature on Feb 8, 2021, so traits created prior to this date will not have this option. If your trait lacks this feature, recreating it will make it available.

--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -243,6 +243,6 @@ You might be returning a value for `user_id` that's inconsistent with how you tr
 
 If you see only question marks in the preview, and have already tracked data historically with Segment, then you likely have the wrong column. If your cloud source doesn't have the database `user_id`, Segment recommends using a `JOIN` clause with an internal users table before sending the results back to Segment.
 
-### Why few SQL trait’s settings are not having “Compute Schedule” option?
+### Why some SQL trait’s settings do not have the “Compute Schedule” option?
 
-New SQL traits created after Feb 8, 2021 have that option enabled by default. Before that, SQL trait computation frequency was disabled and the JIRA has to be created internally to enable the same. but starting on Feb 8th, this has changed. So we can see the compute schedule option on newly created SQL traits, but not on existing traits that were created before Feb 8th, and if you'd like to change the frequency of traits created before Feb 9, 2021, you will have to delete and re-create them.
+The compute schedule feature was added on Feb 8,2021, so traits created prior to this date will not have this option available. If your trait lacks this feature, recreating it will make it available.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Why some SQL trait’s settings do not have the “Compute Schedule” option?

The compute schedule feature was added on Feb 8,2021, so traits created prior to this date will not have this option available. If your trait lacks this feature, recreating it will make it available.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
