### PR TITLE
Add warning about no longer being able to create Config API Tokens

### DIFF
--- a/src/api/config-api/index.md
+++ b/src/api/config-api/index.md
@@ -6,6 +6,9 @@ redirect_from:
 
 {% include content/papi-ga.html %}
 
+> warning "Config API Tokens can no longer be generated"
+> As of September 8, 2022, our Public API is in GA, and is meant to replace the Config API. As a part of the transition, new Config API token generation has ceased, but any Config API tokens issued prior to this will continue to work.
+
 The Config API enables you to programmatically manage Segment workspaces, sources, destinations and more. With the API you can:
 
 * List all your workspace Sources and Destinations to see how data flows through Segment


### PR DESCRIPTION
### Proposed changes

Customers have written in to Segment Support asking how to create a Config API token, but since September 8, 2022, new Config API token generation has ceased - relevant Slack: https://twilio.slack.com/archives/C01BJ2ZCBHC/p1662576926040749 

Adding a warning to the Config API docs that directly mentions new Config API token generation has ceased (but that previously generated tokens still work) should help to alleviate customer confusion on this. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
