### PR TITLE
Add note mentioning need to configure at least one mapping

### DIFF
--- a/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
@@ -42,7 +42,7 @@ HubSpot Cloud Mode (Actions) provides the following benefits over the classic Hu
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customize-mappings).
 7. Enable the destination and configured mappings.
 
-> note ""
+> info ""
 > To ensure that data is sent downstream, configure and enable at least one mapping to handle a connected sources event(s).
 
 {% include components/actions-fields.html %}

--- a/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
@@ -43,7 +43,7 @@ HubSpot Cloud Mode (Actions) provides the following benefits over the classic Hu
 7. Enable the destination and configured mappings.
 
 > note ""
-> At least one mapping to handle a connected source's event(s) must be configured and enabled in an Actions-framework destination in order for data to be sent downstream.
+> To ensure that data is sent downstream, configure and enable at least one mapping to handle a connected sources event(s).
 
 {% include components/actions-fields.html %}
 

--- a/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
@@ -42,6 +42,9 @@ HubSpot Cloud Mode (Actions) provides the following benefits over the classic Hu
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customize-mappings).
 7. Enable the destination and configured mappings.
 
+> note ""
+> At least one mapping to handle a connected source's event(s) must be configured and enabled in an Actions-framework destination in order for data to be sent downstream.
+
 {% include components/actions-fields.html %}
 
 ## FAQ & Troubleshooting


### PR DESCRIPTION
### Proposed changes

Since this destination does not currently offer pre-configured mappings upon creating a new destination instance, add note to Getting Started steps that mentions the need for at least one configured and enabled mapping in an Actions framework destination in order for data to reach downstream. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
