### PR TITLE
Update contact link to point to Impact contact page

### DIFF
--- a/src/connections/destinations/catalog/impact-partnership-cloud/index.md
+++ b/src/connections/destinations/catalog/impact-partnership-cloud/index.md
@@ -5,7 +5,7 @@ id: 5ed96e0b97e7ba0c0346cc04
 ---
 [Impact Partnership Cloud](https://impact.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners) lets you expand your program and scale every type of partnership by managing the partnership lifecycle - from discovery, contracting and payments through tracking and optimization.
 
-This destination is maintained by Impact. For any issues with the destination, contact the [Impact Partnership Cloud team](https://app.impact.com/) or check out [Impact Partnership Cloud's documentation](https://app.impact.com/secure/agency/support/customer-support-portal-flow.ihtml?execution=e3s1).
+This destination is maintained by Impact. For any issues with the destination, contact the [Impact Partnership Cloud team](https://impact.com/contact/) or check out [Impact Partnership Cloud's documentation](https://app.impact.com/secure/agency/support/customer-support-portal-flow.ihtml?execution=e3s1).
 
 ## Getting Started
 


### PR DESCRIPTION
### Proposed changes

Small change - the link that directs customers to reach out to the Impact Partnership Cloud team just directs to the app.

Updated the link to point to their actual contact page.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
