### PR TITLE
add info about using base64 encoding

### DIFF
--- a/src/profiles/profile-api.md
+++ b/src/profiles/profile-api.md
@@ -163,7 +163,7 @@ The Profile API uses basic authentication for authorization — with the **Acces
 
 You can create your Access Secret in your Profiles Settings page. Segment recommends that you name your tokens with the name of your app and its environment, such as `marketing_site/production`. Access tokens are shown once — you won't be able to see it again. In the event of a security incident, you can revoke and cycle the access token.
 
-When you make requests to the Profile API, use the Access Token as the basic authentication username and keep the password blank. Be sure to base64 encode your Access Token as is a general requirement for basic authentication.
+When you make requests to the Profile API, use the Access Token as the basic authentication username and keep the password blank. Be sure to base64 encode your Access Token as is a general requirement for basic authentication. The encoding will happen automatically if you're using a tool like Postman or if you use the `-u` flag in a cURL request. Otherwise, you'll need to ensure it happens manually.
 
 ```bash
 curl https://profiles.segment.com/v1/spaces/<space_id>/collections/users/profiles

--- a/src/profiles/profile-api.md
+++ b/src/profiles/profile-api.md
@@ -163,7 +163,7 @@ The Profile API uses basic authentication for authorization — with the **Acces
 
 You can create your Access Secret in your Profiles Settings page. Segment recommends that you name your tokens with the name of your app and its environment, such as `marketing_site/production`. Access tokens are shown once — you won't be able to see it again. In the event of a security incident, you can revoke and cycle the access token.
 
-When you make requests to the Profile API, use the Access Token as the basic authentication username and keep the password blank.
+When you make requests to the Profile API, use the Access Token as the basic authentication username and keep the password blank. Be sure to base64 encode your Access Token as is a general requirement for basic authentication.
 
 ```bash
 curl https://profiles.segment.com/v1/spaces/<space_id>/collections/users/profiles

--- a/src/profiles/profile-api.md
+++ b/src/profiles/profile-api.md
@@ -163,7 +163,7 @@ The Profile API uses basic authentication for authorization — with the **Acces
 
 You can create your Access Secret in your Profiles Settings page. Segment recommends that you name your tokens with the name of your app and its environment, such as `marketing_site/production`. Access tokens are shown once — you won't be able to see it again. In the event of a security incident, you can revoke and cycle the access token.
 
-When you make requests to the Profile API, use the Access Token as the basic authentication username and keep the password blank. Be sure to base64 encode your Access Token as is a general requirement for basic authentication. The encoding will happen automatically if you're using a tool like Postman or if you use the `-u` flag in a cURL request. Otherwise, you'll need to ensure it happens manually.
+When you make requests to the Profile API, use the Access Token as the basic authentication username and keep the password blank. Base64 is a requirement for authentication. If you use a tool like Postman, or if you use the `-u` flag in a cURL request, this encoding occurs automatically. Otherwise, you'll need to use Base64 to manually encode your Access Token.
 
 ```bash
 curl https://profiles.segment.com/v1/spaces/<space_id>/collections/users/profiles


### PR DESCRIPTION
### Proposed changes
A customer was confused about using the Profile API and the issue ended up being that they didn't base64 encode their Access Token which is always needed for basic authentication. This change adds that in as a reminder so customers have an easier time makes Profile API requests.

### Merge timing
ASAP 
