### PR TITLE
Update user-deletion-and-suppression.md

### DIFF
--- a/src/privacy/user-deletion-and-suppression.md
+++ b/src/privacy/user-deletion-and-suppression.md
@@ -52,6 +52,22 @@ You will also need to contact any unsupported Destinations separately to manage 
 
 Note that if you later **UNSUPPRESS** a user, the deletion functionality does not clean up data sent after removing the user from the suppression list.
 
+### Supported Destinations
+
+In addition to Raw Data destinations (Amazon S3 and Data Warehouses), we can forward requests to the following streaming destinations:
+
+- Amplitude
+- Iterable
+- Braze
+- Intercom
+- Webhooks
+- tray.io
+- Appcues
+- Vero
+- Google Analytics
+- Customer.io
+- Optimizely Full Stack
+
 ## Suppressed users
 
 The Suppressed Users tab shows an up-to-date list of **actively** suppressed `userId`s. Segment blocks data about these users across all sources.


### PR DESCRIPTION
### Proposed changes
I've encountered numerous tickets like this one - https://segment.zendesk.com/agent/tickets/497681. Where customers ask about user deletion. Currently the information lives here: https://segment.com/docs/privacy/user-deletion-and-suppression/#deletion-support-and-the-right-to-be-forgotten. Which could get lost. So I propose to update the placement of the information and a

### Merge timing
<!-- When should this get merged/published?
 once approved


### Related issues (optional)

    Or paste full URLs to issues or pull requests in other Github projects -->

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
