### PR TITLE
update to reflect source ID > secret ID change

### DIFF
--- a/src/connections/destinations/catalog/amazon-kinesis-firehose/index.md
+++ b/src/connections/destinations/catalog/amazon-kinesis-firehose/index.md
@@ -39,8 +39,8 @@ To get started:
 	  1. Follow [these instructions](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user.html#roles-creatingrole-user-console) to create an IAM role to allow Segment permission to write to your Kinesis Firehose Stream.
 	  2. When prompted to enter an Account ID, enter `595280932656`.
 	  3. Select the checkbox to enable **Require External ID**.
-	  4. Enter your Segment Source ID as the **External ID**. This can be found in Segment by navigating to **Connections > Sources** and choosing the source you want to connect to your Kinesis Firehose destination. Click the **Settings** tab and choose **API Keys**.
-    - **Note:** If you have multiple sources using Kinesis, enter one of their source IDs here for now and then follow the procedure outlined in the [Multiple Sources](#best-practices) section at the bottom of this doc once you've completed this step and saved your IAM role.
+	  4. Enter your Secret ID as the **External ID**. This can be found in Segment by navigating to your Amazon Kinesis Firehose destination in Segment, going to the Settings tab, and clicking the Secret ID setting.
+    - **Note:** If you have multiple sources using Kinesis, enter one of their Secret IDs here for now and then follow the procedure outlined in the [Multiple Sources](#best-practices) section at the bottom of this doc once you've completed this step and saved your IAM role.
       5. When adding permissions to your new role, find the policy you created in step 2 and attach it.
 
 4. Create a new Kinesis Firehose Destination.
@@ -149,7 +149,7 @@ To attach multiple sources to your IAM role:
           "Action": "sts:AssumeRole",
           "Condition": {
             "StringEquals": {
-              "sts:ExternalId": "YOUR_SEGMENT_SOURCE_ID"
+              "sts:ExternalId": "YOUR_SECRET_ID"
             }
           }
         }
@@ -157,7 +157,7 @@ To attach multiple sources to your IAM role:
     }
     ```
 
-4. Replace that snippet with the following, and replace the contents of the array with all of your source IDs.
+4. Replace that snippet with the following, and replace the contents of the array with all of your Secret IDs.
 
     ```json
     {
@@ -171,7 +171,7 @@ To attach multiple sources to your IAM role:
           "Action": "sts:AssumeRole",
           "Condition": {
             "StringEquals": {
-              "sts:ExternalId": ["YOUR_SEGMENT_SOURCE_ID", "ANOTHER_SOURCE_ID", "A_THIRD_SOURCE_ID"]
+              "sts:ExternalId": ["YOUR_SECRET_ID", "ANOTHER_SECRET_ID", "A_THIRD_SECRET_ID"]
             }
           }
         }
@@ -203,14 +203,14 @@ To set this value for a Secret ID:
           "Action": "sts:AssumeRole",
           "Condition": {
             "StringEquals": {
-              "sts:ExternalId": "YOUR_SEGMENT_SOURCE_ID"
+              "sts:ExternalId": "YOUR_SECRET_ID"
             }
           }
         }
       ]
     }
     ```
-6. Replace the value of `sts:ExternalId` ( "YOUR_SEGMENT_SOURCE_ID") with the Secret ID value from the previous step. In the case of requiring the use of multiple secretIds, replace the `sts:ExternalId` setting above with:
+6. Replace the value of `sts:ExternalId` ( "YOUR_SECRET_ID") with the Secret ID value from the previous step. In the case of requiring the use of multiple secretIds, replace the `sts:ExternalId` setting above with:
 
    ```
     "sts:ExternalId": ["A_SECRET_ID", "ANOTHER_SECRET_ID"]


### PR DESCRIPTION
### Proposed changes

Segment used to connect to Amazon Kinesis Firehose via `sourceId`. Recently, an update was made for security reasons to use a Secret ID that is automatically created in the Settings for each Amazon Kinesis Firehose destination in Segment instead. Our documentation doesn't reflect this which leads to confusion for customers. This change updates our documentation to reflect the new way Segment connects to Firehose through Secret ID.

### Merge timing
ASAP is fine