### PR TITLE
Adding a note on Iterable date field

### DIFF
--- a/src/connections/destinations/catalog/iterable/index.md
+++ b/src/connections/destinations/catalog/iterable/index.md
@@ -64,6 +64,9 @@ First `track` event with `userId` and `email`; user will be created
 
 Subsequent `track` with `userId`
 
+> info ""
+> If you send ISO formatted date field in your events, Segment will automatically convert it into UTC to conform to standard Iterable format: "yyyy-MM-dd HH:mm:ss ZZ" (for example, "2023-02-05 20:42:10 +00:00"). Iterable has a specific date format that must be used to segment a field by date. Read more about Iterable date field here: https://support.iterable.com/hc/en-us/articles/208183076-Data-Field-Types-in-Iterable#date
+
 ### Ecommerce
 
 Iterable also supports Segment's [ecommerce events](/docs/connections/spec/ecommerce/v2/). This works just as you would expect, using the `track` method.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Added a note on Iterable's date field in our document on Iterable destination. Iterable has a specific date format that must be used to segment a field by date. Thus, Segment converts ISO strings to UTC before sending it to iterable. 

We have had tickets on this issue where a customer is confused as why the timestamp is getting converted to UTC despite sending the local time.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
