### PR TITLE
Add FAQ & Troubleshooting section to Destination Actions docs

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -173,8 +173,8 @@ You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY
 
 ### Validation error when using the Event Tester
 
-A validation error with the description "You may not have any subscriptions that match this event" will surface when sending an event with an Actions destination's Event Tester that does not match the trigger of any configured and enabled mappings. To resolve this, either a mapping must be created with a trigger to handle the event being tested, or the test event's payload must be updated to match the trigger of any existing mappings. 
+When you send an event with an actions destination Event Tester that doesn't match the trigger of any configured and enabled mappings, you'll see an error message that states, *You may not have any subscriptions that match this event.* To resolve the error, create a mapping with a trigger to handle the event being tested, or update the test event's payload to match the trigger of any existing mappings. 
 
 ### Multiple mappings triggered by the same event
 
-A request will be generated for each mapping that's configured to trigger on an event. For example, with an event named "Subscription Updated", if two mappings are enabled and both have conditions defined to trigger on "Subscription Updated" events, two requests will be generated and sent to the destination for each "Subscription Updated" event. 
+When the same event triggers multiple mappings, a request will be generated for each mapping that's configured to trigger on an event. For example, for the *Subscription Updated* event, if two mappings are enabled and both have conditions defined to trigger on the *Subscription Updated* event, the two requests will be generated and sent to the destination for each *Subscription Updated* event. 

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -168,3 +168,13 @@ You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY
 > - You need to filter data from multiple types of call (for example, Track, Page, and Identify calls)
 >
 > If your use case does not match these criteria, you might benefit from using Mapping-level Triggers to match only certain events.
+
+## FAQ & Troubleshooting
+
+### Validation error when using the Event Tester
+
+A validation error with the description "You may not have any subscriptions that match this event" will surface when sending an event with an Actions destination's event tester that does not match the trigger of any configured and enabled mappings. To resolve this, either a mapping must be created with a trigger to handle the event being tested, or the test event's payload must be updated to match the trigger of any existing mappings. 
+
+### Multiple mappings triggered by the same event
+
+A request will be generated for each mapping that's configured to trigger on an event. For example, with an event named "Subscription Updated", if two mappings are enabled and both have conditions defined to trigger on "Subscription Updated" events, two requests will be generated and sent to the destination for each "Subscription Updated" event. 

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -173,7 +173,7 @@ You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY
 
 ### Validation error when using the Event Tester
 
-A validation error with the description "You may not have any subscriptions that match this event" will surface when sending an event with an Actions destination's event tester that does not match the trigger of any configured and enabled mappings. To resolve this, either a mapping must be created with a trigger to handle the event being tested, or the test event's payload must be updated to match the trigger of any existing mappings. 
+A validation error with the description "You may not have any subscriptions that match this event" will surface when sending an event with an Actions destination's Event Tester that does not match the trigger of any configured and enabled mappings. To resolve this, either a mapping must be created with a trigger to handle the event being tested, or the test event's payload must be updated to match the trigger of any existing mappings. 
 
 ### Multiple mappings triggered by the same event
 


### PR DESCRIPTION
### Proposed changes

These docs do not currently have a FAQ & Troubleshooting section - added this to cover two scenarios that customers have written in about. 

1. Validation error when using the Event Tester - a validation error with the description "You may not have any subscriptions that match this event" will surface when sending an event with an Actions destination's event tester that does not match the trigger of any configured and enabled mappings:
![Screen Shot 2023-02-07 at 3 39 13 PM](https://user-images.githubusercontent.com/93934274/217360810-8b5d14ec-7a21-4f93-856a-816bca2d27ff.png)

Added a bullet that covers this error along with options for resolving it (creating a new mapping to handle the event being tested or using a test event that matches an existing mapping)

2. Multiple mappings triggered by the same event - this has been asked by several customers, and couldn't find another location for this information, so created a bullet for this as well. 

For example, in my own workspace's GA4 destination instance I have two custom event mappings, one generates an event called "event_one", and the other generates an event called "event_two". Both are configured to trigger on an event called "Segment Test Event Name": 

![two_mappings_same_event](https://user-images.githubusercontent.com/93934274/217360948-b1dde1f2-6899-48be-b0de-11c83f1ddcd2.png)

By using the destination's event tester, I can see that multiple requests are made to Google, and can cycle through them by clicking the arrows at the top by the "Event Lifecycle" heading:

First request sent for custom event event_one:
![first_ga4_request](https://user-images.githubusercontent.com/93934274/217360969-3b35b407-692d-4fe9-8a9f-d9bf749b05cf.png)

Second request sent for custom event event_two:
![second_ga4_request](https://user-images.githubusercontent.com/93934274/217360984-e575e4a0-f38d-41e0-9f3c-cdbea8870ef9.png)

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
