### PR TITLE
Added note on SLA for deletion requests

### DIFF
--- a/src/privacy/user-deletion-and-suppression.md
+++ b/src/privacy/user-deletion-and-suppression.md
@@ -44,6 +44,8 @@ Segment deletes messages with this `userId` from connected raw data Destinations
 
 Segment forwards these deletion requests to a growing list of supported partners.
 
+Note that Segment has a 30-day SLA for submitted deletion requests. Additionally, Segment's deletion manager can only accommodate 100,000 users within a 30-day period and cannot guarantee 30-day SLA if there are more than 100,000 deletion requests submitted within that 30-day period.
+
 **Segment cannot guarantee that data is deleted from your Destinations.**
 
 Segment forwards deletion requests to supported streaming Destinations (such as Braze, Intercom, and Amplitude) but you should confirm that each partner fulfills the request.
@@ -73,8 +75,6 @@ This creates an `UNSUPPRESS` regulation, and removes the `userId` from your supp
 The deletion requests tab shows a log of all regulations with a deletion element along with status.
 
 Click a deletion to view its status across Segment and your connected destinations.
-
-Note that Segment has a 30-day SLA for submitted deletion requests. Additionally, Segment's deletion manager can only accommodate 100,000 users within a 30-day period and cannot guarantee 30-day SLA if there are more than 100,000 deletion requests submitted within that 30-day period.
 
 
 ## Programmatic User Deletion and Suppression using the API

--- a/src/privacy/user-deletion-and-suppression.md
+++ b/src/privacy/user-deletion-and-suppression.md
@@ -74,6 +74,8 @@ The deletion requests tab shows a log of all regulations with a deletion element
 
 Click a deletion to view its status across Segment and your connected destinations.
 
+Note that Segment has a 30-day SLA for submitted deletion requests. Additionally, Segment's deletion manager can only accommodate 100,000 users within a 30-day period and cannot guarantee 30-day SLA if there are more than 100,000 deletion requests submitted within that 30-day period.
+
 
 ## Programmatic User Deletion and Suppression using the API
 

--- a/src/privacy/user-deletion-and-suppression.md
+++ b/src/privacy/user-deletion-and-suppression.md
@@ -44,7 +44,7 @@ Segment deletes messages with this `userId` from connected raw data Destinations
 
 Segment forwards these deletion requests to a growing list of supported partners.
 
-Note that Segment has a 30-day SLA for submitted deletion requests. Additionally, Segment's deletion manager can only accommodate 100,000 users within a 30-day period and cannot guarantee 30-day SLA if there are more than 100,000 deletion requests submitted within that 30-day period.
+Note that Segment has a 30-day SLA for submitted deletion requests. Additionally, Segment's deletion manager can only accommodate 100,000 users within a 30-day period and cannot guarantee a 30-day SLA if there are more than 100,000 deletion requests submitted within those 30 days.
 
 **Segment cannot guarantee that data is deleted from your Destinations.**
 


### PR DESCRIPTION


### Proposed changes

Added a note on the SLA for completing deletion requests. Customers write in to support often inquiring about the duration it takes to process their deletion requests or wondering why the events associated with a user are flowing in to Segment even after submitting a deletion regulation recently. Therefore, I believe it would be helpful for the customers to know about the SLA stipulated and the conditions when that SLA does not apply.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
