### PR TITLE
Add actions event testing information

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -96,6 +96,21 @@ To delete a destination action: click the action to select it, and click **Delet
 
 This takes effect within minutes, and removes the action completely. Any data that would have gone to the destination is not delivered. Once deleted, the saved action cannot be restored.
 
+## Test a destination action
+To test a destination action, follow the instructions in our [testing conections documentation](https://segment.com/docs/connections/test-connections/). A mapping must be enabled in order to be tested. If it is not enabled, or there is not a mapping to match the event being tested, you will see an error in the event tester that states: **'You may not have any subscriptions that match this event.'**
+
+A second option is to test within the mapping itslef. Click an individual mapping to edit. In step 2 of the mapping, you can add a test event from the source, or a sampe event:
+
+<img width="915" alt="Screenshot of test or sample event load in mappings" src="https://user-images.githubusercontent.com/78318468/217881329-05546b7c-80f1-4641-b201-f755f6afa1f7.png">
+
+From there you can scroll to step 4 to test the mapping and receive a response from the destination:
+
+<img width="878" alt="Screenshot of event testing section of mapping" src="https://user-images.githubusercontent.com/78318468/217882013-508af07d-8b5d-4d4d-bb48-0ec986306418.png">
+
+<img width="877" alt="Screenshot of test event response in mapping" src="https://user-images.githubusercontent.com/78318468/217882104-b0b4dac3-9f8f-4034-a374-7adb171153f2.png">
+
+
+
 
 ## Customize mappings
 

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -100,10 +100,10 @@ This takes effect within minutes, and removes the action completely. Any data th
 To test a destination action, follow the instructions in [Testing Connections](/docs/connections/test-connections/). You must enable a mapping in order to test the destination. Otherwise, this error occurs: *You may not have any subscriptions that match this event.*
 
 You can also test within the mapping itself. To test the mapping:
-1. Navigate to the *Mappings** tab of your destination. 
-2. Select a mapping and click the **...*** and select **Edit Mapping**. 
-3. In step 2 of the mappings edit page, click **Load Test Event from Source** to add a test event from the source or you can add your own sample event. 
-4. Go to step 4 on the mappings edit page, and click **Test Mapping** to test the mapping and view the response from the destination. 
+1. Navigate to the **Mappings** tab of your destination. 
+2. Select a mapping and click the **...** and select **Edit Mapping**. 
+3. In step 2 of the mappings edit page, click **Load Test Event from Source** to add a test event from the source, or you can add your own sample event. 
+4. Scroll to step 4 on the page, and click **Test Mapping** to test the mapping and view the response from the destination. 
 
 ## Customize mappings
 

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -99,15 +99,15 @@ This takes effect within minutes, and removes the action completely. Any data th
 ## Test a destination action
 To test a destination action, follow the instructions in [Testing Connections](/docs/connections/test-connections/). You must enable a mapping in order to test the destination. Otherwise, this error occurs: *You may not have any subscriptions that match this event.*
 
-You can also test within the mapping itself. Click an individual mapping to edit. In step 2 of the mapping, you can add a test event from the source, or a sample event:
+You can also test within the mapping itself. To test the mapping:
+1. Navigate to the *Mappings** tab of your destination. 
+2. Select a mapping and click the **...*** and select **Edit Mapping**. 
+3. In step 2 of the mappings edit page, click **Load Test Event from Source** to add a test event from the source or you can add your own sample event. 
+4. Go to step 4 on the mappings edit page, and click **Test Mapping** to test the mapping and view the response from the destination. 
 
-<img width="915" alt="Screenshot of test or sample event load in mappings" src="https://user-images.githubusercontent.com/78318468/217881329-05546b7c-80f1-4641-b201-f755f6afa1f7.png">
 
-From there you can scroll to step 4 to test the mapping and view the response from the destination.
 
-<img width="878" alt="Screenshot of event testing section of mapping" src="https://user-images.githubusercontent.com/78318468/217882013-508af07d-8b5d-4d4d-bb48-0ec986306418.png">
 
-<img width="877" alt="Screenshot of test event response in mapping" src="https://user-images.githubusercontent.com/78318468/217882104-b0b4dac3-9f8f-4034-a374-7adb171153f2.png">
 
 
 

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -105,13 +105,6 @@ You can also test within the mapping itself. To test the mapping:
 3. In step 2 of the mappings edit page, click **Load Test Event from Source** to add a test event from the source or you can add your own sample event. 
 4. Go to step 4 on the mappings edit page, and click **Test Mapping** to test the mapping and view the response from the destination. 
 
-
-
-
-
-
-
-
 ## Customize mappings
 
 If you use the default mappings for a destination action, you don't *need* to customize the mapping template for the action. You can edit the fields later if you find that the defaults no longer meet your needs.

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -97,13 +97,13 @@ To delete a destination action: click the action to select it, and click **Delet
 This takes effect within minutes, and removes the action completely. Any data that would have gone to the destination is not delivered. Once deleted, the saved action cannot be restored.
 
 ## Test a destination action
-To test a destination action, follow the instructions in our [testing conections documentation](https://segment.com/docs/connections/test-connections/). A mapping must be enabled in order to be tested. If it is not enabled, or there is not a mapping to match the event being tested, you will see an error in the event tester that states: **'You may not have any subscriptions that match this event.'**
+To test a destination action, follow the instructions in [Testing Connections](/docs/connections/test-connections/). You must enable a mapping in order to test the destination. Otherwise, this error occurs: *You may not have any subscriptions that match this event.*
 
-A second option is to test within the mapping itslef. Click an individual mapping to edit. In step 2 of the mapping, you can add a test event from the source, or a sampe event:
+You can also test within the mapping itself. Click an individual mapping to edit. In step 2 of the mapping, you can add a test event from the source, or a sample event:
 
 <img width="915" alt="Screenshot of test or sample event load in mappings" src="https://user-images.githubusercontent.com/78318468/217881329-05546b7c-80f1-4641-b201-f755f6afa1f7.png">
 
-From there you can scroll to step 4 to test the mapping and receive a response from the destination:
+From there you can scroll to step 4 to test the mapping and view the response from the destination.
 
 <img width="878" alt="Screenshot of event testing section of mapping" src="https://user-images.githubusercontent.com/78318468/217882013-508af07d-8b5d-4d4d-bb48-0ec986306418.png">
 


### PR DESCRIPTION
### Proposed changes

Added a section to the destination actions to discuss testing events. Examples of how to test within the mapping as well as information on a common response from the event tester that is due to a missing mapping or a mapping being disabled. 

### Merge timing

- ASAP once approved


### Related issues (optional)

n/a
