### PR TITLE
[CHA-1585] add user deletion, cart clearing, email under traits

### DIFF
--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -46,7 +46,7 @@ Screen events require a `url` property. If Sailthru receives a Screen call witho
 
 ### Identify
 
-Send [Identify](/docs/connections/spec/identify) calls to to create or update a Sailthru profile for any identified user on your site.
+Send [Identify](/docs/connections/spec/identify) calls to create or update a Sailthru profile for any identified user on your site.
 
 Email address passed at top level:
 ```js

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -48,6 +48,7 @@ Screen events require a `url` property. If Sailthru receives a Screen call witho
 
 Send [Identify](/docs/connections/spec/identify) calls to to create or update a Sailthru profile for any identified user on your site.
 
+Email address passed at top level:
 ```js
 analytics.identify("assigned-userId", {
  "name": "Stephen Noel",
@@ -57,6 +58,21 @@ analytics.identify("assigned-userId", {
 });
 ```
 
+Email passed under context.traits:
+```js
+analytics.identify("assigned-userId", {
+ "name": "Stephen Noel",
+ "plan": "premium",
+ "logins": 5
+},
+{
+ "traits": {"email": "snoel@sailthru.com"}
+}
+);
+```
+
+**Note:** Sailthru will also search for the email address in the identify call() under context.traits if not provided at the top-level.
+
 ### Track
 
 Send [Track](/docs/connections/spec/track) calls to:
@@ -65,6 +81,7 @@ Send [Track](/docs/connections/spec/track) calls to:
 * record abandoned carts via “Product Added” and “Product Removed” events
 * subscribe users via “Subscribed” events
 * trigger Lifecycle Optimizer journeys with all other events
+* delete users via “User Deleted” events
 
 Sailthru automatically creates and maps custom fields from Segment.
 
@@ -77,6 +94,20 @@ analytics.track("Subscribed", {
  "list": "Master List"
 });
 ```
+
+#### Delete a User
+
+For user deletion, the email needs to be included in the userId or context.traits track call, in a call like the following:
+
+```js
+analytics.track(“User Deleted”, {userId:"xxxxxx@example.com" })
+```
+
+```js
+analytics.track("User Deleted", {}, {"traits":{"email": "xxxxxxx@example.com"}})
+```
+
+If the user exists, it will be removed from both Segment and Sailthru.
 
 #### Record  a Purchase
 
@@ -118,7 +149,9 @@ analytics.track("Order Completed", {
 #### Update Cart
 Send `Product Added` and `Product Removed` Track events for Sailthru's abandoned cart messaging to enable the Cart Abandonment entry in Lifecycle Optimizer.
 
-Sailthru abandoned cart messaging requires the `url` to function properly. 
+Sailthru abandoned cart messaging requires the `url` to function properly.
+
+The timestamp of the last payload received (purchase_incomplete.time) will be compared with the clearIncompleteCartAfterNHours value to determine if cart is expired. If the cart is determined to be expired, any pre-existing products in the cart will be removed.
 
 ```js
 analytics.track('Product Added', {
@@ -128,11 +161,21 @@ analytics.track('Product Added', {
   sku: 'G-32',
   category: 'Games',
   name: 'Monopoly: 3rd Edition',
+  url: "https://www.example.com/product/monopoly",
   brand: 'Hasbro',
   variant: '200 pieces',
   price: 18.99,
   quantity: 1,
   coupon: 'MAYDEALS',
-  position: 3
+  position: 3,
+  email: "xxxxxxx@example.com",
+  clearIncompleteCartAfterNHours: 24
 });
 ```
+
+**Notes:**
+* By default the value is null
+* Requirement is for the value to be greater than 0
+* Only whole positive numbers are supported. If fractional numbers are included, the number will be truncated (e.g. 1.5 will be 1)
+* If a number id passed in a string format such as "1", it will be parsed and converted to integer
+* Non-numeric characters are not allowed

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -98,7 +98,7 @@ analytics.track("Subscribed", {
 
 #### Delete a User
 
-To delete a user, the email needs to be included in the `userId` or `context.traits` track call, in a call like the following:
+To delete a user, you need to include the email in the `userId` or `context.traits` track call, in a call like the following:
 
 ```js
 analytics.track("User Deleted", {userId:"xxxxxx@example.com" })

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -71,7 +71,8 @@ analytics.identify("assigned-userId", {
 );
 ```
 
-**Note:** Sailthru will also search for the email address in the identify call() under context.traits if not provided at the top-level.
+> note ""
+> **NOTE:** Sailthru searches for the email address in the `identify` call under `context.traits` if it isn't provided at the top-level.
 
 ### Track
 

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -178,5 +178,5 @@ analytics.track('Product Added', {
 * By default the value is null
 * Requirement is for the value to be greater than 0
 * Only whole positive numbers are supported. If fractional numbers are included, the number will be truncated (for example, 1.5 will be 1)
-* If a number is passed in a string format such as "1", it will be parsed and converted to integer
+* If a number is passed in a string format such as `"1"`, it will be parsed and converted to integer
 * Non-numeric characters are not allowed

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -100,7 +100,7 @@ analytics.track("Subscribed", {
 For user deletion, the email needs to be included in the userId or context.traits track call, in a call like the following:
 
 ```js
-analytics.track(“User Deleted”, {userId:"xxxxxx@example.com" })
+analytics.track("User Deleted", {userId:"xxxxxx@example.com" })
 ```
 
 ```js

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -152,7 +152,7 @@ Send `Product Added` and `Product Removed` Track events for Sailthru's abandoned
 
 Sailthru abandoned cart messaging requires the `url` to function properly.
 
-The timestamp of the last payload received (purchase_incomplete.time) will be compared with the clearIncompleteCartAfterNHours value to determine if cart is expired. If the cart is determined to be expired, any pre-existing products in the cart will be removed.
+To determine if the cart is expired, the timestamp of the last payload received (`purchase_incomplete.time`) is compared with the `clearIncompleteCartAfterNHours` value. If the cart is expired, any pre-existing products in the cart will be removed.
 
 ```js
 analytics.track('Product Added', {

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -98,7 +98,7 @@ analytics.track("Subscribed", {
 
 #### Delete a User
 
-For user deletion, the email needs to be included in the userId or context.traits track call, in a call like the following:
+To delete a user, the email needs to be included in the `userId` or `context.traits` track call, in a call like the following:
 
 ```js
 analytics.track("User Deleted", {userId:"xxxxxx@example.com" })

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -48,7 +48,7 @@ Screen events require a `url` property. If Sailthru receives a Screen call witho
 
 Send [Identify](/docs/connections/spec/identify) calls to create or update a Sailthru profile for any identified user on your site.
 
-Email address passed at top level:
+Pass an email address at the top level using the `identify` call:
 ```js
 analytics.identify("assigned-userId", {
  "name": "Stephen Noel",

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -58,7 +58,7 @@ analytics.identify("assigned-userId", {
 });
 ```
 
-Email passed under context.traits:
+Pass an email under `context.traits` using the identify call:
 ```js
 analytics.identify("assigned-userId", {
  "name": "Stephen Noel",

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -177,5 +177,5 @@ analytics.track('Product Added', {
 * By default the value is null
 * Requirement is for the value to be greater than 0
 * Only whole positive numbers are supported. If fractional numbers are included, the number will be truncated (e.g. 1.5 will be 1)
-* If a number id passed in a string format such as "1", it will be parsed and converted to integer
+* If a number is passed in a string format such as "1", it will be parsed and converted to integer
 * Non-numeric characters are not allowed

--- a/src/connections/destinations/catalog/sailthru-v2/index.md
+++ b/src/connections/destinations/catalog/sailthru-v2/index.md
@@ -177,6 +177,6 @@ analytics.track('Product Added', {
 **Notes:**
 * By default the value is null
 * Requirement is for the value to be greater than 0
-* Only whole positive numbers are supported. If fractional numbers are included, the number will be truncated (e.g. 1.5 will be 1)
+* Only whole positive numbers are supported. If fractional numbers are included, the number will be truncated (for example, 1.5 will be 1)
 * If a number is passed in a string format such as "1", it will be parsed and converted to integer
 * Non-numeric characters are not allowed


### PR DESCRIPTION
### Proposed changes

We would like to update the Sailthru V2 documentation to reflect recent additions to the Sailthru Destination API.  Newly documented functionality includes:
* The ability to trigger user deletion
* The ability to pass email under `context.traits`
* The ability to clear stale items from a shopping cart before new cart additions or removals are applied

### Merge timing
ASAP once approved
