### PR TITLE
Remove alias documentation

### DIFF
--- a/src/connections/destinations/catalog/actions-ripe-web/index.md
+++ b/src/connections/destinations/catalog/actions-ripe-web/index.md
@@ -107,20 +107,6 @@ analytics.page('Home')
 
 Segment sends Page calls to Ripe as a `pageview` event.
 
-### Alias
-
-Connects a new unique id to an existing identified user.
-
-If you aren't familiar with the Segment Spec, take a look at
-the [Alias method documentation](/docs/connections/spec/alias/) to learn about
-what it does. An example call would look like:
-
-```js
-analytics.alias('507f191e81')
-```
-
-Segment sends Page calls to Ripe as a `alias` event.
-
 ### Segment session
 
 Ripe will use the `userId`, `anonymous` and `groupId` set in Segment and the Ripe SDK keeps track of the current ids.


### PR DESCRIPTION
Alias was removed in a recent update of the browser destination

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

We've removed the `alias` from the Ripe browser destination and are updating the docs accordingly (see this [commit](https://github.com/segmentio/action-destinations/pull/968/commits/761bb0023df670dbf3b15fd97935eb080203e0ae)).

### Merge timing
- ASAP once approved

### Related issues (optional)
https://github.com/segmentio/action-destinations/pull/968
