### PR TITLE
add example for removing userId

### DIFF
--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -138,7 +138,7 @@ There are certain destinations to which you may not want to send the `userId`. T
 {
     "sourceId": "<sourceId>",
     "destinationId": "<destinationId>",
-    "title": "Don'\''t send userId at all",
+    "title": "Don't send userId at all",
     "description": "Drop userId on all requests",
     "if": "all",
     "actions": [

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -134,7 +134,7 @@ Use the [Public API](https://docs.segmentapis.com/tag/Destination-Filters/){:tar
 
 There are certain destinations to which you may not want to send the `userId`. To accomplish this, you can use the [Public API](https://docs.segmentapis.com/tag/Destination-Filters/) to create a Filter that will target and remove the `userId` (or any other top-level field) like this:
 
-```
+```json
 {
     "sourceId": "<sourceId>",
     "destinationId": "<destinationId>",

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -69,6 +69,7 @@ The following examples illustrate common destinations filters use cases:
 * [Sample a percentage of events](#sample-a-percentage-of-events)
 * [Drop events](#drop-events)  
 * [Only send events with userId](#only-send-events-with-userid) 
+* [Remove userId from payload](#remove-userid-from-payload) 
 
 ### PII management
 
@@ -128,6 +129,30 @@ Use the [Public API](https://docs.segmentapis.com/tag/Destination-Filters/){:tar
     "enabled": true
   }
 ```
+
+### Remove userId from payload
+
+There are certain destinations to which you may not want to send the `userId`. To accomplish this, you can use the [Public API](https://docs.segmentapis.com/tag/Destination-Filters/) to create a Filter that will target and remove the `userId` (or any other top-level field) like this:
+
+```
+{
+    "sourceId": "<sourceId>",
+    "destinationId": "<destinationId>",
+    "title": "Don'\''t send userId at all",
+    "description": "Drop userId on all requests",
+    "if": "all",
+    "actions": [
+       {
+        "type": "DROP_PROPERTIES",
+          "fields": {
+            "":["userId"]
+            }
+       }
+      ],
+      "enabled": true
+}
+```
+
 
 ## Important notes
 


### PR DESCRIPTION
### Proposed changes

Some customers over time have reached out wanting to remove the `userId` from their payloads for certain destinations. This was previously not possible but now the Public API allows for this functionality. This example will help customers achieve this solution.

### Merge timing
ASAP is fine
