### PR TITLE
Copy a Tracking Plan into a Library

### DIFF
--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -62,6 +62,10 @@ You can search in a Tracking Plan to find a specific event, and then copy the UR
 
 Yes. [Tracking Plan Libraries](/docs/protocols/tracking-plan/libraries/) makes it easy to create groups of events or properties that can be easily imported into multiple Tracking plans.
 
+### Can I copy a Tracking Plan into a library?
+
+No. Unfortunately it's not possible yet to automatically transfer events from a Tracking Plan to Libraries. Currently the best option for importing events into a new event library would be directly from a source.
+
 ## Protocols Validation
 
 ### What is the difference between Violations Emails and the Violations page in the Segment UI?

--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -64,7 +64,7 @@ Yes. [Tracking Plan Libraries](/docs/protocols/tracking-plan/libraries/) makes i
 
 ### Can I copy a Tracking Plan into a library?
 
-No. Unfortunately it's not possible yet to automatically transfer events from a Tracking Plan to Libraries. Currently the best option for importing events into a new event library would be directly from a source.
+No. Unfortunately it's not yet possible to automatically transfer events from a Tracking Plan to Libraries. To import events into a new event library, import them directly from a source.
 
 ## Protocols Validation
 


### PR DESCRIPTION
### Proposed changes

I added a question to our Protocols FAQ. We get a number of tickets, asking if copying a Tracking Plan into a Library is possible.  

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
