### PR TITLE
Update Environment string format example to match field description in UI

### DIFF
--- a/src/connections/destinations/catalog/google-tag-manager/index.md
+++ b/src/connections/destinations/catalog/google-tag-manager/index.md
@@ -88,4 +88,4 @@ If you are seeing `404` error on the JavaScript console of your page and it is a
 By default Segment pushes the `anonymousId` and `userId`(if exists) into the `dataLayer` for each `page` or `track` call. Since the `anonymousId` is created by Segment, namespaces that property in the `dataLayer` as `segmentAnonymousId`.
 
 ### Environments
-If you're using an 'environment' variable for `gtm_preview` in your tag's query string, you can set that string in the **Environment** of your Optional Settings. IMPORTANT: Make sure the string includes the `gtm_auth` variable. For example, your string should look like: `env-xxxxx&gtm_auth=xxxxx`.
+If you're using an 'environment' variable for `gtm_preview` in your tag's query string, you can set that string in the **Environment** of your Optional Settings. IMPORTANT: Make sure the string includes the `gtm_auth` variable. For example, your string should look like: `env-xx&gtm_auth=xxxxx`.


### PR DESCRIPTION
### Proposed changes

Under **Appendices > Environment**, this section currently shows `env-xxxxx&gtm_auth=xxxxx` as an example of the format of an environment string to be used in the relevant setting, with 5 x's that can be interpreted as the necessary length of the characters following`env-`. 

This field as it appears in the Segment app UI provides a different format, `env-xx&gtm_auth=xxxxx`, as the example.

![image](https://user-images.githubusercontent.com/93934274/218197902-2c264c7b-daec-458a-8c42-c6241e380a66.png)

The Settings section of these docs also uses the format `env-xx&gtm_auth=xxxxx`

Reduced the x's in the example provided in the **Appendices > Environment** section to match the format of this example as it appears in the app, which should help to alleviate customer confusion on the necessary length. From another support ticket, it looks like the format for this string matches the shorter example:
![env_string_example](https://user-images.githubusercontent.com/93934274/218199084-4e088e71-d51e-41d9-8342-2e71d09a8c1f.png)

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)
KCS-112
<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
