### PR TITLE
Adding a note for Tracking Plan Labels

### DIFF
--- a/src/protocols/tracking-plan/create.md
+++ b/src/protocols/tracking-plan/create.md
@@ -71,6 +71,8 @@ You can apply `key:value` labels to each event to help organize your tracking pl
 For consistency purposes, it's best that you create a standard way of labeling events and share it with all parts of your organization that will use Segment.
 
 ![](./images/labels.png)
+> info ""
+> **Note:** Tracking Plan Labels are only available for Track and Page events. 
 
 ### Filter track calls in the Tracking Plan
 You can filter the Tracking Plan events by keyword or by label. The applied filter generates a permanent link so you can share specific events with teammates. Label filters also persist after you leave the Tracking Plan.


### PR DESCRIPTION
Adding a note to indicate the Tracking Plan Labels are only available for Track and Page events. As we have a customer who is trying to add label for Identify/Group events in tracking plan.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
