### PR TITLE
Add reference to custom proxy files for AJS 2.0

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
@@ -100,3 +100,8 @@ To add a CNAME record to your DNS settings:
    - **Value**: Tracking API CloudFront Distribution Domain Name
 3. Save your record. This might take some time to take effect, depending on your TTL settings.
 4. Run `curl` on your domain to check if the proxy is working correctly.
+
+
+#### Custom Proxy and Analtyics 2.0
+
+See our documenation on [using a custom proxy](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2/#using-a-custom-proxy) for files you'll need to consider in your custom proxy configuration after upgrading to Analytics 2.0. 


### PR DESCRIPTION
### Proposed changes

I added a section on files customers will need to consider in their custom proxy configuration to our Upgrading to Analytics.js 2.0 page (KCS-79), but it might help to have a reference to it in our actual custom proxy page as well.

### Merge timing
- ASAP once approved?

### Related issues (optional)

This PR is to add a reference to the section added in [KCS-79](https://segment.atlassian.net/browse/KCS-79) on the Upgrading to Analytics 2.0 page. 

Please add [KCS-109](https://segment.atlassian.net/browse/KCS-109) after this section once it's merged so that the Troubleshooting paragraph is at the bottom of the page 
