### PR TITLE
Hull deprecation note

### DIFF
--- a/src/connections/destinations/catalog/hull/index.md
+++ b/src/connections/destinations/catalog/hull/index.md
@@ -3,7 +3,7 @@ title: Hull Destination
 id: 5728ed9c80412f644ff132d9
 ---
 > warning "Hull Deprecation"
-> Hull was deprecated on December 31, 2022 and the Segment Hull Destination is no longer operational. For more information, see [Hull documentation](https://www.hull.io/faq/){:target="_blank"}.
+> Hull was deprecated on December 31, 2022 and the Segment Hull destination is no longer operational. For more information, see [Hull documentation](https://www.hull.io/faq/){:target="_blank"}.
 
 Hull is the one place to collect, transform, enrich, filter, search and segment customer data in all your tools.
 

--- a/src/connections/destinations/catalog/hull/index.md
+++ b/src/connections/destinations/catalog/hull/index.md
@@ -2,7 +2,7 @@
 title: Hull Destination
 id: 5728ed9c80412f644ff132d9
 ---
-> warning "Hull End of Life"
+> warning "Hull Deprecation"
 > Hull was deprecated on December 31, 2022 and the Segment Hull Destination is no longer operational. For more information, see [Hull documentation](https://www.hull.io/faq/){:target="_blank"}.
 
 Hull is the one place to collect, transform, enrich, filter, search and segment customer data in all your tools.

--- a/src/connections/destinations/catalog/hull/index.md
+++ b/src/connections/destinations/catalog/hull/index.md
@@ -2,6 +2,9 @@
 title: Hull Destination
 id: 5728ed9c80412f644ff132d9
 ---
+> warning "Hull End of Life"
+> Hull was deprecated on December 31, 2022 and the Segment Hull Destination is no longer operational. For more information, see [Hull documentation](https://www.hull.io/faq/){:target="_blank"}.
+
 Hull is the one place to collect, transform, enrich, filter, search and segment customer data in all your tools.
 
 It helps you creates a single actionable profile and uniform segments that sync to all your tools and make cross-channel, end-to-end personalization easy.


### PR DESCRIPTION
### Proposed changes
Hull end of lifed their product on Dec 31, 2022. We have moved this destination to deprecated, but for customers who are still using it, we want to keep this note at the top of our docs so they are aware.

### Merge timing
- ASAP once approved

