### PR TITLE
Add explanation for Privacy Portal

### DIFF
--- a/src/segment-app/iam/roles.md
+++ b/src/segment-app/iam/roles.md
@@ -93,3 +93,7 @@ To connect two resource instances, you must have access to both. You can either 
 To **view** transformations, you need `Source Read-only`, either for all Sources or the specific Sources using Protocols.
 
 To **create or edit** transformations you must have either `Source Admin` for all Sources, or for the specific Sources used with Protocols.
+
+## Role for Privacy Portal
+
+To **view, create or edit** PII related configurations in Privacy Portal, you need to have `Workspace Owner` role.

--- a/src/segment-app/iam/roles.md
+++ b/src/segment-app/iam/roles.md
@@ -94,6 +94,6 @@ To **view** transformations, you need `Source Read-only`, either for all Sources
 
 To **create or edit** transformations you must have either `Source Admin` for all Sources, or for the specific Sources used with Protocols.
 
-## Role for Privacy Portal
+## Roles for Privacy Portal
 
-To **view, create or edit** PII related configurations in Privacy Portal, you need to have `Workspace Owner` role.
+To **view, create or edit** PII related configurations in Privacy Portal, you need to have the `Workspace Owner` role.


### PR DESCRIPTION
### Proposed changes
Add explanation for Privacy Portal. When user need to access the Privacy Portal, it will require the 'Workspace Owner' role. Granting all other roles doesn't provide enough permission.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->