### PR TITLE
Update replay considerations

### DIFF
--- a/src/guides/what-is-replay.md
+++ b/src/guides/what-is-replay.md
@@ -28,7 +28,8 @@ For more information, [Contact us](https://segment.com/help/contact/) and our Su
 
 Replays are currently only available for Business Tier customers, and due to their complex nature are not self-serve. [Contact us](https://segment.com/help/contact/) to learn more, or to request a replay for your workspace. When requesting a replay, include the workspace, the source to replay from, the destination tool or tools, and the time period.
 
-Replays can process an unlimited amount of data, however they are rate limited to respect the limitations in downstream partner tools. The replay time depends on the tool we're replaying to, and the amount of data included in the replay.
+Replays can process an unlimited amount of data, however they are rate limited to respect the limitations in downstream partner tools. If you're also sending data to the destination being replayed to in realtime, then when determining your replay's limit you'll want to take into account the rate limit being used by realtime events, and you'll want to also account for a small margin of your rate limit to allow events to be retried. 
+The replay time depends on the tool we're replaying to, and the amount of data included in the replay.
 
 Replays do not affect your [MTU count](/docs/guides/usage-and-billing/mtus-and-throughput/), unless you are using a [Repeater destination](/docs/connections/destinations/catalog/repeater/). Notify your team before initiating a Replay if you're using a Repeater destination.
 


### PR DESCRIPTION
Update replay considerations to take into account realtime events as well as a margin for retries.

If you're also sending data to the destination being replayed to in realtime, then when determining your replay's limit you'll want to take into account the rate limit being used by realtime events, and you'll want to also account for a small margin of your rate limit to allow events to be retried.

### Proposed changes

It's good for both customers who are requesting replays and CSE's who'll be running the replays to take these additional parameters in mind when determining the replay limit. Clarifying the rate limit can be the difference of all realtime events failing due to there being no margin for retries, as the replay could be taking up the entire allotted rate limit.

### Merge timing
- ASAP once approved?

### Related issues (optional)

n/a