### PR TITLE
Remove beta note from Webhook (Actions)

### DIFF
--- a/src/connections/destinations/catalog/actions-webhook/index.md
+++ b/src/connections/destinations/catalog/actions-webhook/index.md
@@ -12,9 +12,6 @@ versions:
 
 Segment's Webhooks (Actions) destination uses internet protocol and HTTP callback to submit real-time user data to your own HTTP endpoints. With this destination, you can POST, PUT, or PATCH data to any webhook URL.
 
-> info ""
-> The Webhooks (Actions) destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 ## Getting Started
 
 1. From the Segment web app, navigate to **Connections > Catalog**.


### PR DESCRIPTION
### Proposed changes
Remove Beta note at top of doc as Webhook (Actions) **will move to GA on February 27**. Please don't merge in until Feb 27; totally fine if this goes out during the Feb 28 deploy.

### Merge timing
- On a specific date? February 28 docs deploy
