### PR TITLE
Added information on recording userId for mailchimp - not to use trait.id

### DIFF
--- a/src/connections/destinations/catalog/mailchimp/index.md
+++ b/src/connections/destinations/catalog/mailchimp/index.md
@@ -90,7 +90,7 @@ Once Mailchimp has processed the new subscriber you'll see it show up in your li
 
 ### Recording userId
 
-To record a Segment `userId` in Mailchimp, you must pass the userID as a trait on your `identify()` calls. Segment doesn't automatically map the userID to any Mailchimp properties.
+To record a Segment `userId` in Mailchimp, you must pass the userID as a trait on your `identify()` calls. One thing to take note is not to pass 'userId' as 'id' in trait as trait.id is a reserved trait. You can pass 'userId' in a trait name with a corresponding merge field in MailChimp. Segment doesn't automatically map the userID to any Mailchimp properties.
 
 ### Overriding List ID (Also now referred to as Audience ID)
 

--- a/src/connections/destinations/catalog/mailchimp/index.md
+++ b/src/connections/destinations/catalog/mailchimp/index.md
@@ -90,7 +90,7 @@ Once Mailchimp has processed the new subscriber you'll see it show up in your li
 
 ### Recording userId
 
-To record a Segment `userId` in Mailchimp, you must pass the userID as a trait on your `identify()` calls. One thing to take note is not to pass 'userId' as 'id' in trait as trait.id is a reserved trait. You can pass 'userId' in a trait name with a corresponding merge field in MailChimp. Segment doesn't automatically map the userID to any Mailchimp properties.
+To record a Segment `userId` in Mailchimp, pass the user ID as a trait on your `identify()` calls. Don't pass the `userId` as a trait ID because the  `trait.id` is a reserved trait. Instead, pass the `userId` in a trait name with the corresponding merge field in Mailchimp. Segment doesn't automatically map the user ID to a Mailchimp property.
 
 ### Overriding List ID (Also now referred to as Audience ID)
 


### PR DESCRIPTION
### Proposed changes

Modify the "Recording userId" section, add in information to indicate userId should not be pass as 'Id' in trait as trait.id is a reserved trait. Customer has tried to pass 'userId' as 'Id' in trait and it does not get sent to MailChimp. 

Added in the following sentences to "Recording UserId" section: "One thing to take note is not to pass 'userId' as 'id' in trait as trait.id is a reserved trait. You can pass 'userId' in a trait name with a corresponding merge field in MailChimp."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

[<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->](https://segment.zendesk.com/agent/tickets/497343)
