### PR TITLE
Updated Identifier breakdown information 

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -215,7 +215,7 @@ Before you can download the CSV, you will need to generate it. There are three d
 
 ## Identifier Breakdown
 
-The audience summary is a breakdown of the percentages of external_ids of users in the audience. These are the default IDs that Segment includes in your Identity resolution configuration. Segment displays the percentage of the audience with each identifier, which you can use to verify the audience size and profiles are correct.
+The audience summary is a breakdown of the percentages of external_ids of users in the audience. These are the default IDs that Segment includes in the Identity resolution configuration. Segment displays the percentage of the audience with each identifier, which you can use to verify the audience size and profiles are correct.
 
 > info ""
 > The Identifier Breakdown won't show custom IDs included in your Identity resolution configuration. Segment only displays external IDs in the breakdown.

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -215,7 +215,7 @@ Before you can download the CSV, you will need to generate it. There are three d
 
 ## Identifier Breakdown
 
-The audience summary is a breakdown of the percentages of external_ids of users in the audience. These are the default ID's that have been included in Identity resolution configuration. It shows the portion of the audience that has each identifier, and is used to verify the audience size/profiles are correct and as expected.
+The audience summary is a breakdown of the percentages of external_ids of users in the audience. These are the default IDs that Segment includes in your Identity resolution configuration. Segment displays the percentage of the audience with each identifier, which you can use to verify the audience size and profiles are correct.
 
 > info ""
 > The Identifier breakdown won't show custom ID's included in identity resolution configuration. Only default external IDs will be shown in the breakdown.

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -218,4 +218,4 @@ Before you can download the CSV, you will need to generate it. There are three d
 The audience summary is a breakdown of the percentages of external_ids of users in the audience. These are the default IDs that Segment includes in your Identity resolution configuration. Segment displays the percentage of the audience with each identifier, which you can use to verify the audience size and profiles are correct.
 
 > info ""
-> The Identifier breakdown won't show custom ID's included in identity resolution configuration. Only default external IDs will be shown in the breakdown.
+> The Identifier Breakdown won't show custom IDs included in your Identity resolution configuration. Segment only displays external IDs in the breakdown.

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -218,4 +218,4 @@ Before you can download the CSV, you will need to generate it. There are three d
 The audience summary is a breakdown of the percentages of external_ids of users in the audience. These are the default IDs that Segment includes in the Identity resolution configuration. Segment displays the percentage of the audience with each identifier, which you can use to verify the audience size and profiles are correct.
 
 > info ""
-> The Identifier Breakdown won't show custom IDs included in your Identity resolution configuration. Segment only displays external IDs in the breakdown.
+> The Identifier Breakdown won't show custom IDs included in the Identity resolution configuration. Segment only displays external IDs in the breakdown.

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -215,7 +215,7 @@ Before you can download the CSV, you will need to generate it. There are three d
 
 ## Identifier Breakdown
 
-The audience summary gives a breakdown of the percentages of external_ids of users in the audience. These are the default ID's that has been included in Identity resolution configuration. It helps us by showing the portion of the audience has which identities on it and is used to verify the audience size/profiles are correct and as expected.
+The audience summary is a breakdown of the percentages of external_ids of users in the audience. These are the default ID's that have been included in Identity resolution configuration. It shows the portion of the audience that has each identifier, and is used to verify the audience size/profiles are correct and as expected.
 
 > info ""
-> The Identifier breakdown won't show custom ID's which has been included in identity resolution configuration. Only default external IDs will be shown in Identifier breakdown.
+> The Identifier breakdown won't show custom ID's included in identity resolution configuration. Only default external IDs will be shown in the breakdown.

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -212,3 +212,10 @@ Before you can download the CSV, you will need to generate it. There are three d
     (If the audience recalculates between when you click Generate and when you download the file, you might want to regenerate the file. The CSV is a snapshot from when you clicked Generate, and could be outdated.)</td>
   </tr>
 </table>
+
+## Identifier Breakdown
+
+The audience summary gives a breakdown of the percentages of external_ids of users in the audience. These are the default ID's that has been included in Identity resolution configuration. It helps us by showing the portion of the audience has which identities on it and is used to verify the audience size/profiles are correct and as expected.
+
+> info ""
+> The Identifier breakdown won't show custom ID's which has been included in identity resolution configuration. Only the default external IDs can be added in Identifier breakdown. Same applies for engage generated events sent to the destination.

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -218,4 +218,4 @@ Before you can download the CSV, you will need to generate it. There are three d
 The audience summary gives a breakdown of the percentages of external_ids of users in the audience. These are the default ID's that has been included in Identity resolution configuration. It helps us by showing the portion of the audience has which identities on it and is used to verify the audience size/profiles are correct and as expected.
 
 > info ""
-> The Identifier breakdown won't show custom ID's which has been included in identity resolution configuration. Only the default external IDs can be added in Identifier breakdown. Same applies for engage generated events sent to the destination.
+> The Identifier breakdown won't show custom ID's which has been included in identity resolution configuration. Only default external IDs will be shown in Identifier breakdown.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

## Identifier Breakdown

The audience summary gives a breakdown of the percentages of external_ids of users in the audience. These are the default ID's that has been included in Identity resolution configuration. It helps us by showing the portion of the audience has which identities on it and is used to verify the audience size/profiles are correct and as expected.

> info ""
> The Identifier breakdown won't show custom ID's which has been included in identity resolution configuration. Only default external IDs will be shown in Identifier breakdown.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
