### PR TITLE
Update context.network fields

### DIFF
--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -125,7 +125,8 @@ Context is a dictionary of extra information that provides useful context about 
 | `ip`        | String  | Current user's IP address.     |
 | `library`   | Object  | Dictionary of information about the library making the requests to the API, containing `name` and `version`.       |
 | `locale`    | String  | Locale string for the current user, for example `en-US`.        |               
-| `network`   | Object  | Dictionary of information about the current network connection, containing `bluetooth`, `carrier`, `cellular`, and `wifi`.               |
+| `network`   | Object  | Dictionary of information about the current network connection, containing `bluetooth`, `carrier`, `cellular`, and `wifi`. 
+If context.network.celluar and context.network.wifi fields are empty, then it means the user is offline |
 | `os`        | Object  | Dictionary of information about the operating system, containing `name` and `version`.               |
 | `page`      | Object  | Dictionary of information about the current page in the browser, containing `path`, `referrer`, `search`, `title` and `url`. This is automatically collected by [Analytics.js](/docs/connections/sources/catalog/libraries/website/javascript/#context--traits).    |
 | `referrer`  | Object  | Dictionary of information about the way the user was referred to the website or app, containing `type`, `name`, `url`, and `link`.                                                |

--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -126,7 +126,7 @@ Context is a dictionary of extra information that provides useful context about 
 | `library`   | Object  | Dictionary of information about the library making the requests to the API, containing `name` and `version`.       |
 | `locale`    | String  | Locale string for the current user, for example `en-US`.        |               
 | `network`   | Object  | Dictionary of information about the current network connection, containing `bluetooth`, `carrier`, `cellular`, and `wifi`. 
-If context.network.cellular and context.network.wifi fields are empty, then it means the user is offline |
+If the `context.network.cellular` and `context.network.wifi` fields are empty, then the user is offline. |
 | `os`        | Object  | Dictionary of information about the operating system, containing `name` and `version`.               |
 | `page`      | Object  | Dictionary of information about the current page in the browser, containing `path`, `referrer`, `search`, `title` and `url`. This is automatically collected by [Analytics.js](/docs/connections/sources/catalog/libraries/website/javascript/#context--traits).    |
 | `referrer`  | Object  | Dictionary of information about the way the user was referred to the website or app, containing `type`, `name`, `url`, and `link`.                                                |

--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -126,7 +126,7 @@ Context is a dictionary of extra information that provides useful context about 
 | `library`   | Object  | Dictionary of information about the library making the requests to the API, containing `name` and `version`.       |
 | `locale`    | String  | Locale string for the current user, for example `en-US`.        |               
 | `network`   | Object  | Dictionary of information about the current network connection, containing `bluetooth`, `carrier`, `cellular`, and `wifi`. 
-If context.network.celluar and context.network.wifi fields are empty, then it means the user is offline |
+If context.network.cellular and context.network.wifi fields are empty, then it means the user is offline |
 | `os`        | Object  | Dictionary of information about the operating system, containing `name` and `version`.               |
 | `page`      | Object  | Dictionary of information about the current page in the browser, containing `path`, `referrer`, `search`, `title` and `url`. This is automatically collected by [Analytics.js](/docs/connections/sources/catalog/libraries/website/javascript/#context--traits).    |
 | `referrer`  | Object  | Dictionary of information about the way the user was referred to the website or app, containing `type`, `name`, `url`, and `link`.                                                |


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

There are cases where the context.network.celluar and context.network.wifi are empty and that means that the user is offline, and nowhere in our docs we seem to mention it. 
I have not seen many tickets of this type, but updating our docs would save time in case of a similar request in the future.

### Merge timing
<!-- When should this get merged/published?
NA

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    NA
