### PR TITLE
Update index.md

### DIFF
--- a/src/connections/sources/catalog/libraries/server/java/index.md
+++ b/src/connections/sources/catalog/libraries/server/java/index.md
@@ -63,7 +63,7 @@ The following examples use [Guava's](https://github.com/google/guava) immutable 
 ## Identify
 
 > note ""
-> **Good to know**: For any of the different methods described on this page, you can replace the properties and traits in the code samples with variables that represent the data collected.
+> **Good to know**: For any of the different methods described on this page, you can replace the properties and traits in the code samples with variables that represent the data collected. Note that sending of null property or trait will not be possible as Guava’s immutable maps will reject the null value and GSON library use to serilaize the Java object will ignore the null value.  As a workaround, send an empty string instead of a null value in the property or trait.
 
 `identify` lets you tie a user to their actions and record traits about them. It includes a unique User ID and any optional traits you know about them.
 


### PR DESCRIPTION
### Proposed changes

In the past, there were some tickets on customer asking about sending null property and trait. Engineering has also confirmed that this is not possible.

Added information that sending of null property or trait is not possible.

In the following section:
> **Good to know**: For any of the different methods described on this page, you can replace the properties and traits in the code samples with variables that represent the data collected.

Added:
"Note that sending of null property or trait will not be possible as Guava’s immutable maps will reject the null value and GSON library use to serilaize the Java object will ignore the null value.  As a workaround, send an empty string instead of a null value in the property or trait."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)
(https://segment.zendesk.com/agent/tickets/498628)
