### PR TITLE
Adding FAQ of filtering unsupported events.

### DIFF
--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -216,4 +216,4 @@ Use the destination filter tester during setup to verify that you're filtering o
 
 #### Can I use destination filters to drop events unsupported by a destination?
 
-The check for unsupported events types is performed before any destination filter checks and not after. As a result, you cannot prevent unsupported event type errors with a Destination Filter. To filter these events, you will need to use the [Integrations Object](https://segment.com/docs/guides/filtering-data/#filtering-with-the-integrations-object).
+The check for unsupported events types happens before any destination filter checks. As a result, Destination Filters can't prevent unsupported event type errors. To filter these events, use the [Integrations Object](/docs/guides/filtering-data/#filtering-with-the-integrations-object).

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -213,3 +213,7 @@ You must have write access to save and edit filters. Read permission access only
 #### How can I test my filter?
 
 Use the destination filter tester during setup to verify that you're filtering out the right events. Filtered events show up on the schema page but aren't counted in event deliverability graphs.
+
+#### Can I use destination filters to drop events unsupported by a destination?
+
+The check for unsupported events types is performed before any destination filter checks and not after. As a result, you cannot prevent unsupported event type errors with a Destination Filter. To filter these events, you will need to use the [Integrations Object](https://segment.com/docs/guides/filtering-data/#filtering-with-the-integrations-object).


### PR DESCRIPTION
This is a very common question where clients try to drop events using destination filters, but this is not possible

### Proposed changes
Adding FAQ:

Can I use destination filters to drop events unsupported by a destination?
The check for unsupported events types is performed before any destination filter checks and not after. As a result, you cannot prevent unsupported event type errors with a Destination Filter. To filter these events, you will need to use the [Integrations Object]


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
