### PR TITLE
removing self service customer part from Custom object

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/salesforce/index.md
+++ b/src/connections/sources/catalog/cloud-apps/salesforce/index.md
@@ -99,9 +99,6 @@ Collections are the groupings of resources Segment pulls from your source. In yo
 
 Select and add custom objects from the Selective Sync page in the Salesforce source settings. 
 
-Self service customers, please contact Segment Support with the [API names](https://help.salesforce.com/articleView?id=000007594&language=en_US&type=1) of the custom objects you want to add.
-
-
 ### Deleting Records
 
 Segment supports the use of soft deletes in Salesforce. If you perform a soft delete on a record in Salesforce, your next one to two warehouses syncs will change the value of `is_deleted` for the associated record to `True`.


### PR DESCRIPTION
Updating custom objects section of the documentation.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Now all the customers are able to add/remove custom objects using selective sync. So, removing self-service customer section from the documentation.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
