### PR TITLE
add slug override to prevent cordial from being hidden

### DIFF
--- a/src/_data/catalog/slugs.yml
+++ b/src/_data/catalog/slugs.yml
@@ -62,3 +62,5 @@
   override: "actions-linkedin-audiences"
 - original: "salesforce-marketing-cloud-actions"
   override: "actions-salesforce-marketing-cloud"
+- original: "cordial-actions"
+  override: "actions-cordial"

--- a/src/connections/destinations/catalog/actions-cordial/index.md
+++ b/src/connections/destinations/catalog/actions-cordial/index.md
@@ -3,8 +3,6 @@ title: Cordial (Actions) Destination
 id: 61eed75ba749df7601b12186
 hide-boilerplate: true
 hide-dossier: true
-redirect_from:
-  - '/connections/destinations/catalog/cordial-actions'
 ---
 
 {% include content/plan-grid.md name="actions" %}

--- a/src/connections/destinations/catalog/cordial-actions/index.md
+++ b/src/connections/destinations/catalog/cordial-actions/index.md
@@ -1,7 +1,0 @@
----
-title: 'Cordial (Actions) Destination'
-hidden: true
-id: 61eed75ba749df7601b12186
-published: false
-beta: true
----


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Cordial (Actions) was failing to show in a few places in the catalog, due to the slug being switched from `actions-cordial` to `cordial-actions`. Adding the override will make sure that hidden is not set to true in the destinations.yml file

### Merge timing
asap