### PR TITLE
Google Analytics 4 Docs 

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -55,6 +55,8 @@ sections:
     title: Google Universal Analytics destination
   - path: /connections/destinations/catalog/actions-google-analytics-4
     title: Google Analytics 4 destination
+  - path: /connections/destinations/catalog/actions-google-analytics-4-web
+    title: Google Analytics 4 Web destination
   - path: /connections/destinations/catalog/google-tag-manager
     title: Google Tag Manager destination
   - path: /connections/destinations/catalog/actions-google-enhanced-conversions

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -1,0 +1,46 @@
+---
+title: Google Analytics 4 Web Destination
+strat: google
+hide-boilerplate: true
+hide-dossier: false
+id: 63ed446fe60a1b56c5e6f130
+---
+[Google Analytics 4](https://support.google.com/analytics/answer/10089681){:target="_blank"} is Google's new Analytics property, which you can use for both websites and applications. Google Analytics 4 has machine learning at its core to help surface insights and give you a more complete understanding of your customers across devices and platforms. 
+
+When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. When you use the Google Analytics 4 Web destination, Segment loads the [gtag javascript library](https://support.google.com/analytics/answer/9310895?hl=en#zippy=%2Cin-this-article) for you. 
+
+
+## Getting started
+
+Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
+
+To add the Google Analytics 4 Web destination: 
+
+1. From the Segment web app, click **Catalog**, then click **Destinations**.
+2. Search for “Google Analytics 4 Web” in the Destinations Catalog, and select the destination.
+3. Click **Configure Google Analytics 4 Web** in the top-right corner of the screen.
+4. Select the source that will send data to Google Analytics 4 and follow the steps to name your destination.
+5. On the **Settings** tab, under **Basic Settings**, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} associated with your GA4 Data stream.
+6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
+
+{% include components/actions-fields.html %}
+
+## FAQ & Troubleshooting
+
+### Custom Event Naming
+
+Google Analytics 4 does not accept custom event names that include spaces. Segment replaces spaces in the Event Name in the Custom Event action with an underscore. As a result, you will see custom events snakecased in Google Analytics 4.
+
+Google Analytics 4 is also case sensitive. If you would like all event names lowercased, use the `Lowercase Event Name` setting in the Custom Event action. If this setting is disabled, Google will treat event names with different casing as distinct events. For more information, see [Google Analytics 4 Event name rules](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article){:target="_blank"}.
+
+### Custom Dimensions & Metrics
+
+With Google Analytics 4, you must create custom dimensions and metrics within the Google Analytics 4 interface and link event parameters to the corresponding dimension or metric. When creating the dimension or metric, you can either select a parameter from the list of already collected fields or enter the name of the parameter you plan to collect in the future. For more information, see [Google Analytics 4 Custom dimensions and metrics](https://support.google.com/analytics/answer/10075209?hl=en){:target="_blank"}.
+
+### Debug Mode
+
+The Google Analytics 4 [debug mode](https://support.google.com/analytics/answer/7201382?hl=en){:target="_blank"} is supported. DebugView dispalys the events and user properties that Analytics collects from a user in real time. 
+
+To validate your implementation, check users and events on the Events report and User Explorer.
+
+

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -15,6 +15,9 @@ versions:
 
 When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. When you use the Google Analytics 4 Web destination, Segment loads the [gtag.js library](https://support.google.com/analytics/answer/9310895?hl=en#zippy=%2Cin-this-article){:target="_blank"}  for you. 
 
+> info ""
+> The Google Analytics 4 Web destination is in beta and is in active development. Some functionality may change before it becomes generally available.
+
 ## Getting started
 
 Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -4,26 +4,31 @@ strat: google
 hide-boilerplate: true
 hide-dossier: false
 id: 63ed446fe60a1b56c5e6f130
+versions:
+  - name: "Google Analytics 4 Cloud Mode"
+    link: '/docs/connections/destinations/catalog/actions-google-analytics-4/'
 ---
+
+{% include content/plan-grid.md name="actions" %}
+
 [Google Analytics 4](https://support.google.com/analytics/answer/10089681){:target="_blank"} is Google's new Analytics property, which you can use for both websites and applications. Google Analytics 4 has machine learning at its core to help surface insights and give you a more complete understanding of your customers across devices and platforms. 
 
-When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. When you use the Google Analytics 4 Web destination, Segment loads the [gtag javascript library](https://support.google.com/analytics/answer/9310895?hl=en#zippy=%2Cin-this-article) for you. 
-
+When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. When you use the Google Analytics 4 Web destination, Segment loads the [gtag.js library](https://support.google.com/analytics/answer/9310895?hl=en#zippy=%2Cin-this-article){:target="_blank"}  for you. 
 
 ## Getting started
 
-Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
+Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
 
-To add the Google Analytics 4 Web destination: 
+To connect the Google Analytics 4 Web destination: 
 
 1. From the Segment web app, click **Catalog**, then click **Destinations**.
 2. Search for “Google Analytics 4 Web” in the Destinations Catalog, and select the destination.
-3. Click **Configure Google Analytics 4 Web** in the top-right corner of the screen.
-4. Select the source that will send data to Google Analytics 4 and follow the steps to name your destination.
-5. On the **Settings** tab, under **Basic Settings**, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} associated with your GA4 Data stream.
+3. Click **Configure Google Analytics 4 Web**.
+4. Select the web source that will send data to Google Analytics 4 and follow the steps to name your destination. The web source chosen must use [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/){:target='_blank'}.
+5. On the **Settings** tab, under **Basic Settings**, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} associated with your GA4 web stream.
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
-{% include components/actions-fields.html %}
+{% include components/actions-fields.html settings="true"%}
 
 ## FAQ & Troubleshooting
 
@@ -39,8 +44,4 @@ With Google Analytics 4, you must create custom dimensions and metrics within th
 
 ### Debug Mode
 
-The Google Analytics 4 [debug mode](https://support.google.com/analytics/answer/7201382?hl=en){:target="_blank"} is supported. DebugView displays the events and user properties that Analytics collects from a user in real time. 
-
-To validate your implementation, check users and events on the Events report and User Explorer.
-
-
+The Google Analytics 4 [debug mode](https://support.google.com/analytics/answer/7201382?hl=en){:target="_blank"} is supported with the Google Analytics 4 Web destination. DebugView displays the events and user properties that Analytics collects from a user in real-time. This can be helpful in troubleshooting your implementation.

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -12,7 +12,7 @@ When you have Segment installed, you can use your existing tracking implementati
 
 ## Getting started
 
-Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
+Before you connect Segment to Google Analytics 4 Web, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
 
 To add the Google Analytics 4 Web destination: 
 
@@ -29,9 +29,9 @@ To add the Google Analytics 4 Web destination:
 
 ### Custom Event Naming
 
-Google Analytics 4 does not accept custom event names that include spaces. Segment replaces spaces in the Event Name in the Custom Event action with an underscore. As a result, you will see custom events snakecased in Google Analytics 4.
+Google Analytics 4 does not accept custom event names that include spaces. Segment replaces spaces in the Event Name in the Custom Event action with an underscore. As a result, you will see custom events snake cased in Google Analytics 4.
 
-Google Analytics 4 is also case sensitive. If you would like all event names lowercased, use the `Lowercase Event Name` setting in the Custom Event action. If this setting is disabled, Google will treat event names with different casing as distinct events. For more information, see [Google Analytics 4 Event name rules](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article){:target="_blank"}.
+Google Analytics 4 is also case sensitive. If you would like all event names to be lowercase, use the `Lowercase Event Name` setting in the Custom Event action. If this setting is disabled, Google will treat event names with different casing as distinct events. For more information, see [Google Analytics 4 Event name rules](https://support.google.com/analytics/answer/10085872?hl=en&ref_topic=9756175#event-name-rules&zippy=%2Cin-this-article.%2Cin-this-article){:target="_blank"}.
 
 ### Custom Dimensions & Metrics
 
@@ -39,7 +39,7 @@ With Google Analytics 4, you must create custom dimensions and metrics within th
 
 ### Debug Mode
 
-The Google Analytics 4 [debug mode](https://support.google.com/analytics/answer/7201382?hl=en){:target="_blank"} is supported. DebugView dispalys the events and user properties that Analytics collects from a user in real time. 
+The Google Analytics 4 [debug mode](https://support.google.com/analytics/answer/7201382?hl=en){:target="_blank"} is supported. DebugView displays the events and user properties that Analytics collects from a user in real time. 
 
 To validate your implementation, check users and events on the Events report and User Explorer.
 

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -12,7 +12,7 @@ When you have Segment installed, you can use your existing tracking implementati
 
 ## Getting started
 
-Before you connect Segment to Google Analytics 4 Web, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
+Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
 
 To add the Google Analytics 4 Web destination: 
 

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -5,7 +5,7 @@ hide-boilerplate: true
 hide-dossier: false
 id: 63ed446fe60a1b56c5e6f130
 versions:
-  - name: "Google Analytics 4 Cloud Mode"
+  - name: "Google Analytics 4 Cloud"
     link: '/docs/connections/destinations/catalog/actions-google-analytics-4/'
 ---
 

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -26,7 +26,7 @@ The Google Analytics 4 destination provides the following benefits:
 
 ## Getting started
 
-Before you connect Segment to Google Analytics 4 Cloud, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
+Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
 
 To add the Google Analytics 4 Cloud destination:
 

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -1,5 +1,5 @@
 ---
-title: Google Analytics 4 Destination
+title: Google Analytics 4 Cloud Destination
 strat: google
 hide-boilerplate: true
 hide-dossier: false
@@ -26,13 +26,13 @@ The Google Analytics 4 destination provides the following benefits:
 
 ## Getting started
 
-Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
+Before you connect Segment to Google Analytics 4 Cloud, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article: [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
 
-To add the Google Analytics 4 destination:
+To add the Google Analytics 4 Cloud destination:
 
 1. From the Segment web app, click **Catalog**, then click **Destinations**.
-2. Search for “Google Analytics 4” in the Destinations Catalog, and select the destination.
-3. Click **Configure Google Analytics 4** in the top-right corner of the screen.
+2. Search for “Google Analytics 4 Cloud” in the Destinations Catalog, and select the destination.
+3. Click **Configure Google Analytics 4 Cloud** in the top-right corner of the screen.
 4. Select the source that will send data to Google Analytics 4 and follow the steps to name your destination.
 5. On the **Settings** tab, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} for web streams or the [Firebase App ID](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload_query_parameters){:target='_blank'} for mobile streams. Next, enter in the API Secret associated with your GA4 stream and click **Save**. 
 	

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -4,20 +4,23 @@ strat: google
 hide-boilerplate: true
 hide-dossier: false
 id: 60ad61f9ff47a16b8fb7b5d9
+versions:
+  - name: "Google Analytics 4 Web"
+    link: '/docs/connections/destinations/catalog/actions-google-analytics-4-web/'
 ---
+
+{% include content/plan-grid.md name="actions" %}
+
 [Google Analytics 4](https://support.google.com/analytics/answer/10089681){:target="_blank"} is Google's new Analytics property, which you can use for both websites and applications. Google Analytics 4 has machine learning at its core to help surface insights and give you a more complete understanding of your customers across devices and platforms.
 
 When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. Segment will send your data server-side to [Google's Measurement Protocol API](https://developers.google.com/analytics/devguides/collection/protocol/ga4){:target='_blank'}.
 
 > warning ""
-> Google Analytics 4 doesn't officially support a pure server-to-server integration. However, Segment monitors the capabilities of the Measurement Protocol API and updates the integration accordingly to achieve a reasonable level of reporting for mutual customers.
+> Google Analytics 4 doesn't officially support a pure server-to-server integration. However, Segment monitors the capabilities of the Measurement Protocol API and updates the cloud integration accordingly to achieve a reasonable level of reporting for mutual customers. For full functionality, please see the [Google Analytics 4 Web destination](/docs/connections/destinations/catalog/actions-google-analytics-4-web/).
 
-> success "Good to know"
-> This page is about the [Actions-framework](/docs/connections/destinations/actions/) Google Analytics 4 destination. There's also a page about the [non-Actions Google Universal Analytics destination](/docs/connections/destinations/catalog/google-analytics/). Both of these destinations receive data _from_ Segment.
+## Benefits of Google Analytics 4 Cloud
 
-## Benefits of Google Analytics 4
-
-The Google Analytics 4 destination provides the following benefits:
+The Google Analytics 4 Cloud destination provides the following benefits:
 
 - **Fewer settings**. Data mapping for actions-based destinations happens during configuration, which eliminates the need for most settings.
 - **Clearer mapping of data**. Actions-based destinations enable you to define the mapping between the data Segment receives from your source and the data Segment sends to Google Analytics 4.
@@ -34,9 +37,7 @@ To add the Google Analytics 4 Cloud destination:
 2. Search for “Google Analytics 4 Cloud” in the Destinations Catalog, and select the destination.
 3. Click **Configure Google Analytics 4 Cloud** in the top-right corner of the screen.
 4. Select the source that will send data to Google Analytics 4 and follow the steps to name your destination.
-5. On the **Settings** tab, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} for web streams or the [Firebase App ID](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload_query_parameters){:target='_blank'} for mobile streams. Next, enter in the API Secret associated with your GA4 stream and click **Save**. 
-	
-	To create a new API Secret, navigate in the Google Analytics UI to Admin > Data Streams > choose your stream > Measurement Protocol > Create.
+5. On the **Settings** tab, enter in the [Measurement ID](https://support.google.com/analytics/answer/9539598){:target='_blank'} for web streams or the [Firebase App ID](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=firebase#payload_query_parameters){:target='_blank'} for mobile streams. Next, enter in the API Secret associated with your GA4 stream and click **Save**. To create a new API Secret, navigate in the Google Analytics UI to Admin > Data Streams > choose your stream > Measurement Protocol > Create.
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings).
 
 {% include components/actions-fields.html %}
@@ -56,10 +57,10 @@ Google Analytics 4 has different out-of-the-box reports. Google Analytics 4’s 
 > warning ""
 > Google announced that all standard Universal Analytics properties will stop processing new hits on July 1, 2023. 360 Universal Analytics properties will stop processing new hits on October 1, 2023.
 
-Segment’s Google Analytics 4 integration is a server-side integration with the GA4 Measurement Protocol API. This is similar to Segment’s Google Universal Analytics cloud-mode integration in that all data is sent directly to Google’s servers. Please note that this means client-side functionality, such as [Enhanced Measurement](https://support.google.com/analytics/answer/9216061){:target='_blank'}, may not be available through Segment. In addition, as Google continues to develop the GA4 Measurement Protocol API ahead of general availability of the API, there may be limitations that impact what can be seen in the Google Analytics 4 reports.
+Segment’s Google Analytics 4 Cloud integration is a server-side integration with the GA4 Measurement Protocol API. This is similar to Segment’s Google Universal Analytics cloud-mode integration in that all data is sent directly to Google’s servers. Please note that this means client-side functionality, such as [Enhanced Measurement](https://support.google.com/analytics/answer/9216061){:target='_blank'}, may not be available through Segment. In addition, as Google continues to develop the GA4 Measurement Protocol API ahead of general availability of the API, there may be limitations that impact what can be seen in the Google Analytics 4 reports.
 
 #### Recommended Events
-Google Analytics 4 requires the use of [recommended events and properties](https://support.google.com/analytics/answer/9267735){:target='_blank'} to power certain built-in reports. Segment’s Google Analytics 4 destination provides prebuilt mappings to automatically map your [Segment spec](/docs/connections/spec/ecommerce/v2) events to the corresponding Google Analytics 4 events and properties. If your Segment events don't follow the Segment spec exactly, you can modify the mappings. For example, Segment maps "Order Completed" events to the Google Analytics 4 “Purchase” event by default. If your company uses “Products Purchase” to indicate a purchase, this can be mapped in the Purchase action’s Event Trigger instead.
+Google Analytics 4 requires the use of [recommended events and properties](https://support.google.com/analytics/answer/9267735){:target='_blank'} to power certain built-in reports. Segment’s Google Analytics 4 Cloud destination provides prebuilt mappings to automatically map your [Segment spec](/docs/connections/spec/ecommerce/v2) events to the corresponding Google Analytics 4 events and properties. If your Segment events don't follow the Segment spec exactly, you can modify the mappings. For example, Segment maps "Order Completed" events to the Google Analytics 4 “Purchase” event by default. If your company uses “Products Purchase” to indicate a purchase, this can be mapped in the Purchase action’s Event Trigger instead.
 
 Segment recommends using the prebuilt mappings when possible, however the Segment spec doesn't have an equivalent event for every Google Analytics 4 recommended event. If there are other recommended events you would like to send, please use the [Custom Event action](/docs/connections/destinations/catalog/actions-google-analytics-4/#custom-event). For example, to send a `spend_virtual_currency` event, create a mapping for Custom Event, set up your Event Trigger criteria, and input a literal string of "spend_virtual_currency" as the Event Name. You can use the Event Parameters object to add fields that are in the `spend_virtual_currency` event such as `value` and `virtual_currency_name`.
 
@@ -80,18 +81,18 @@ To achieve parity with Universal Analytics, you should create the same custom di
 
 #### Tracking Active Users and Sessions
 
-##### Server-side Implementation using Google Analytics 4 Destination
+##### Server-side Implementation using Google Analytics 4 Cloud Destination
 
 The Google Analytics 4 reports only display active users who engage with your site for a non-zero amount of time. To ensure users are rendered in reports, Segment sets the `engagement_time_msec` parameter to 1 by default. If you track engagement time on your Segment events, you can use the Engagement Time in Milliseconds field mapping to set `engagement_time_msec` to a different value.
 
-Besides Engagement Time in Milliseconds, you can also generate your own `session_id` and `session_number` and pass them as event properties to Segment. These properties can then be mapped to their corresponding parameters in Segment's Google Analytics 4 destination.
+Besides Engagement Time in Milliseconds, you can also generate your own `session_id` and `session_number` and pass them as event properties to Segment. These properties can then be mapped to their corresponding parameters in Segment's Google Analytics 4 Cloud destination.
 
 > info "Session tracking limitations"
 > Session tracking server-side only supports a subset of user dimensions. Certain reserved fields such as location, demographics, other [predefined user dimensions](https://support.google.com/analytics/answer/9268042?hl=en&ref_topic=11151952){:target='_blank'} and device-specific information are not supported by Google's Measurement Protocol API.
 
-##### Using Gtag.js and Google Analytics 4 Destination
+##### Using Gtag.js and Google Analytics 4 Cloud Destination
 
-If you choose to integrate with Google Analytics 4 client-side (using Gtag outside of Segment) _and_ also use Segment's Google Analytics 4 destination to send events through the API, you will have all the reserved parameters and sessions tracking information available in Google Analytics 4 reports.
+If you choose to integrate with Google Analytics 4 client-side (either with Segment's Google Analytics 4 Web destination or outside of Segment) _and_ also use Segment's Google Analytics 4 Cloud destination to send events through the API, you will have all the reserved parameters and sessions tracking information available in Google Analytics 4 reports.
 
 When using Gtag, [Google generates a `session_id` and `session_number` when a session begins](https://support.google.com/analytics/answer/9191807?hl=en){:target='_blank'}. The `session_id` and `session_number` generated on the client can be passed as Event Parameters to stitch events sent through the API with the same session that was collected client-side. For events to stitch properly, server-side events must arrive within a 48 hour window of when the client-side events arrive.
 
@@ -118,10 +119,9 @@ The Firebase App Instance ID is the mobile equivalent of a device identifier and
 
 Segment also allows you to send a User-ID with your events. The User-ID feature lets you associate your own identifiers with individual users so you can connect their behavior across different sessions and on various devices and platforms. For more information on User-ID, see Google’s [Measure activity across platforms](https://support.google.com/analytics/answer/9213390){:target='_blank'} and [Reporting: deduplicate user counts](https://support.google.com/analytics/answer/9355949){:target='_blank'}.
 
-There are certain scenarios where sending a User-ID can be helpful. For example, if you choose to integrate with Google Analytics 4 client-side (using Gtag outside of Segment) _and_ also use Segment's Google Analytics 4 destination to send events through the API, you may consider taking the following approach:
-- **Use the Gtag-generated Client ID.** Gtag will set a Client ID automatically. The Client ID is stored in a cookie and can be fetched on the web client. To tie data between client-side and server-side, pass the Gtag-generated Client ID to Segment as a property and use that value as the Client ID in the Google Analytics 4 destination mappings.
-- **Use the Segment `userId` for User-ID.** The Segment `userId` should be your company’s canonical user identifier. By setting Google's User-ID to the same value as `userId` on client-side and server-side, you can benefit from cross-platform analytics.
-In addition, if you use [Firebase to send mobile data to Google Analytics 4](/docs/connections/destinations/catalog/actions-google-analytics-4/#mobile-data), using the same User-ID across web and mobile will ensure users are stitched together across devices.
+There are certain scenarios where sending a User-ID can be helpful. For example, if you choose to integrate with Google Analytics 4 client-side (either with Segment's Google Analytics 4 Web destination or outside of Segment) _and_ also use Segment's Google Analytics 4 Cloud destination to send events through the API, you may consider taking the following approach:
+- **Use the Gtag-generated Client ID.** Gtag will set a Client ID automatically. The Client ID is stored in a cookie and can be fetched on the web client. To tie data between client-side and server-side, pass the Gtag-generated Client ID to Segment as a property and use that value as the Client ID in the Google Analytics 4 Cloud destination mappings.
+- **Use the Segment `userId` for User-ID.** The Segment `userId` should be your company’s canonical user identifier. By setting Google's User-ID to the same value as `userId` on client-side and server-side, you can benefit from cross-platform analytics. In addition, if you use [Firebase to send mobile data to Google Analytics 4](/docs/connections/destinations/catalog/actions-google-analytics-4/#mobile-data), using the same User-ID across web and mobile will ensure users are stitched together across devices.
 
 #### Validating and Comparing Data
 Google recommends a period of dual-collection with both Universal Analytics and Google Analytics 4. This dual-collection approach lets you build a historical record in Google Analytics 4 while continuing to depend on Universal Analytics until you're ready to fully switch over.
@@ -142,13 +142,13 @@ Google doesn't currently support passing certain reserved fields to the Google A
 
 ### Debug Mode
 
-The Google Analytics 4 [debug mode](https://support.google.com/analytics/answer/7201382?hl=en){:target="_blank"} only works with a client-side implementation through gtag.js, Google Tag Manager, or Firebase. Because Segment's Google Analytics 4 integration is server-side and uses the Measurement Protocol API, debug mode is not supported.
+The Google Analytics 4 [debug mode](https://support.google.com/analytics/answer/7201382?hl=en){:target="_blank"} only works with a client-side implementation through gtag.js, Google Tag Manager, or Firebase. Because Segment's Google Analytics 4 Cloud integration is server-side and uses the Measurement Protocol API, debug mode is not supported.
 
 ### Mobile Data
 
 To achieve complete reporting, Google recommends use of their Firebase SDKs to send mobile data to Google Analytics 4. To assist in your implementation, Segment has a [Firebase destination](/docs/connections/destinations/catalog/firebase) available for mobile analytics. For more information on linking Google Analytics 4 properties to Firebase, see [Google Analytics 4 Firebase integration](https://support.google.com/analytics/answer/9289234?hl=en){:target="_blank"}.
 
-The Segment Google Analytics 4 destination supports sending mobile app events server-side to supplement your Firebase implementation. To send mobile events server-side, configure the Firebase App ID in the Destination settings. In each mapping, change the Data Stream Type to `Mobile App` and set a Firebase App Instance ID so that data routes to a mobile stream.
+The Segment Google Analytics 4 Cloud destination supports sending mobile app events server-side to supplement your Firebase implementation. To send mobile events server-side, configure the Firebase App ID in the Destination settings. In each mapping, change the Data Stream Type to `Mobile App` and set a Firebase App Instance ID so that data routes to a mobile stream.
 
 ### Reserved Names
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

This PR updates the Google Analytics 4 Docs with the destination name change to include `cloud`. This PR also adds the docs for GA4 Web, before it goes to public beta on March 7.

### Merge timing
On a specific date: Let's merge and deploy this on the Tues, March 7 docs deploy.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
