### PR TITLE
Update integrations object info on Filtering Your Segment Data page

### DIFF
--- a/src/guides/filtering-data.md
+++ b/src/guides/filtering-data.md
@@ -13,7 +13,7 @@ The Integrations object is the only filtering method that cannot be edited using
 
 Use this option when you absolutely, for sure, 100% know that you *always*, or *never* want this data in a specific destination or set of destinations. You can also build logic in your app or site to conditionally enable or disable destinations by rewriting this object, however this is not recommended as it is time consuming to change, especially for mobile apps.
 
-The Integrations object filters track, page, group, identify, and screen events from both client and cloud based sources, and routes or prevents them from getting to the listed destinations. Data from these calls still enters into and is stored in the Segment systems, and is passed downstream to your warehouse(s) if you have them.
+The Integrations object filters `track`, `page`, `group`, `identify`, and `screen` events from both client and cloud based sources, and routes or prevents them from getting to the listed destinations. 
 
 You can use the `integrations` JSON object as part of your Segment payloads to control how Segment routes your data to specific destinations. An example payload is below:
 
@@ -35,13 +35,13 @@ You can use the `integrations` JSON object as part of your Segment payloads to c
 }
 ```
 
-By *default*, the `integrations` object is set to `'All': true`. You do not need to include this flag in the object to use this behavior, but if you'll be using the integrations object frequently to control destination filtering, you might want to do this to make it explicit for later readers. Change this to `'All': false` to prevent both Segment and any downstream destinations from receiving data. You can also add destinations to the object by key, and provide a `true` or `false` value to allow or disallow data to flow to them on an individual basis.
+By *default*, the `integrations` object is set to `'All': true`. You do not need to include this flag in the object to use this behavior, but if you'll be using the integrations object frequently to control destination filtering, you might want to do this to make it explicit for later readers. Change this to `'All': false` to prevent both Segment and any downstream destinations from receiving data. If you set `'Segment.io': false` in the integrations object, Analytics.js 2.0 drops the event before it reaches your Source Debugger. You can also add destinations to the object by key, and provide a `true` or `false` value to allow or disallow data to flow to them on an individual basis. The Destination Info box at the top of each destination page lets you know how to refer to each destination in the Integrations object. 
 
 If you are using [multiple instances of a destination](/docs/connections/destinations/add-destination/#connecting-one-source-to-multiple-instances-of-a-destination), any settings you set in the integrations object are applied to all instances of the destination. You cannot specify an instance of a destination to apply Integrations object settings to. 
 
 Note that destination flags are **case sensitive** and match the destination's name in the docs (for example, "AdLearn Open Platform", "awe.sm", or "MailChimp").
 
-Your data is sent to your warehouse (if you have one) and into the Segment backend systems regardless of what is in the integrations object.
+Your data is sent to your warehouse (if you have one) regardless of what is in the integrations object.
 
 ## Destination filters
 


### PR DESCRIPTION
### Proposed changes
Update to reflect Analytics 2.0 library behavior with the integrations object. 

Specifically, remove this line "Data from these calls still enters into and is stored in the Segment systems, and is passed downstream to your warehouse(s) if you have them.". If 'Segment.io:' is set to false in the integrations object, Analytics.js 2.0 drops the event before it reaches the Source Debugger.

### Merge timing
- ASAP once approved?

