### PR TITLE
Adding note for automatically track deep links

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/index.md
@@ -221,6 +221,8 @@ configuration.trackDeepLinks = YES;
 {% endcodeexampletab %}
 {% endcodeexample %}
 
+Please note that you'll still need to call the `continueUserActivity` and `openURL` methods on the analytics client.
+
 ### Flushing
 
 You can set the number of events that should queue before flushing. Setting this to `1` will send events as they come in (i.e. not send batched events) and will use more battery. `20` by default.

--- a/src/connections/sources/catalog/libraries/mobile/ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/index.md
@@ -221,7 +221,8 @@ configuration.trackDeepLinks = YES;
 {% endcodeexampletab %}
 {% endcodeexample %}
 
-Please note that you'll still need to call the `continueUserActivity` and `openURL` methods on the analytics client.
+> note ""
+> **Note:** You still need to call the `continueUserActivity` and `openURL` methods on the analytics client.
 
 ### Flushing
 


### PR DESCRIPTION
### Proposed changes
Adding note in our public doc to remind our users to call the `continueUserActivity` and `openURL` methods on the analytics client, to trigger the Deep Link events. As a few customers have enabled the Automatic Deep Link Tracking, but they do not see any Deep Link Opened events triggered on iOS.
 

### Merge timing
ASAP once approved
