### PR TITLE
Update Klaviyo docs link for Identify

### DIFF
--- a/src/connections/destinations/catalog/klaviyo/index.md
+++ b/src/connections/destinations/catalog/klaviyo/index.md
@@ -149,7 +149,7 @@ When you call `track` on `analytics.js`, Segment calls Klaviyo's `track` with th
 
 When you call make a Track call from one of Segment's mobile or server-side libraries, Segment keys the user with the `userId` and also provides the Klaviyo `$email` `customer_property` if your `userId` is an email, or you provide `email` as one of your event `properties`.
 
-Segment also maps the following Segment spec'd properties to Klaviyo's [special people properties](http://www.klaviyo.com/docs){:target="_blank"}:
+Segment also maps the following Segment spec'd properties to Klaviyo's [special people properties](https://developers.klaviyo.com/en/docs/javascript_api#identify-people){:target="_blank"}:
 
 ### Ecommerce
 

--- a/src/connections/destinations/catalog/klaviyo/index.md
+++ b/src/connections/destinations/catalog/klaviyo/index.md
@@ -149,7 +149,7 @@ When you call `track` on `analytics.js`, Segment calls Klaviyo's `track` with th
 
 When you call make a Track call from one of Segment's mobile or server-side libraries, Segment keys the user with the `userId` and also provides the Klaviyo `$email` `customer_property` if your `userId` is an email, or you provide `email` as one of your event `properties`.
 
-Segment also maps the following Segment spec'd properties to Klaviyo's [special people properties](https://developers.klaviyo.com/en/docs/javascript_api#identify-people){:target="_blank"}:
+Segment also maps the following Segment spec'd properties to Klaviyo's [special people properties](https://developers.klaviyo.com/en/docs/javascript_api#identify-people){:target="_blank"}:.
 
 ### Ecommerce
 


### PR DESCRIPTION
### Proposed changes

The link was pointing to Klaviyo's main docs page (https://developers.klaviyo.com/en), but it might be easier for customers to find the right page if we link the exact page in the Klaviyo docs we're referencing (https://developers.klaviyo.com/en/docs/javascript_api#identify-people)

### Merge timing
- ASAP once approved?

