### PR TITLE
Add example product list on Warehouse Schema page

### DIFF
--- a/src/connections/storage/warehouses/schema.md
+++ b/src/connections/storage/warehouses/schema.md
@@ -94,7 +94,10 @@ properties: {
 
 <tr>
 <td><b>Array (Any):</b> Stringify</td>
-<td markdown="1">
+<td markdown="1" colspan="2">
+<table>
+<tr>
+<td width="10%">
 
 ```json
 products: {
@@ -103,14 +106,51 @@ products: {
   ]
 }
 ```
-
 </td>
 <td>
-    <b>Column Name:</b> <br/>
+<b>Column Name:</b> <br/>
     product_id <br/><br/>
     <b>Value:</b>
     "[507f1, 505bd]"
-</td> 
+</td>
+</tr>
+<tr>
+<td>
+
+```json
+products: [
+    {
+      product_id: '507f1f77bcf86cd799439011',
+      sku: '45790-32',
+      name: 'Monopoly: 3rd Edition',
+      price: 19,
+      position: 1,
+      category: 'Games',
+      url: 'https://www.example.com/product/path',
+      image_url: 'https://www.example.com/product/path.jpg'
+    },
+    {
+      product_id: '505bd76785ebb509fc183733',
+      sku: '46493-32',
+      name: 'Uno Card Game',
+      price: 3,
+      position: 2,
+      category: 'Games'
+    }
+  ]
+```
+</td>
+<td>
+
+<b>Column Name:</b> <br/>
+    products <br/><br/>
+    <b>Value:</b>
+    '[{"product_id":"507f1f77bcf86cd799439011","sku":"45790-32","name":"Monopoly: 3rd Edition","price":19,"position":1,"category":"Games","url":"https://www.example.com/product/path","image_url":"https://www.example.com/product/path.jpg"},{"product_id":"505bd76785ebb509fc183733","sku":"46493-32","name":"Uno Card Game","price":3,"position":2,"category":"Games"}]'
+
+</td>
+</tr>
+</table>
+</td>
 </tr>
 </table>
 

--- a/src/connections/storage/warehouses/schema.md
+++ b/src/connections/storage/warehouses/schema.md
@@ -93,11 +93,8 @@ properties: {
 </tr>
 
 <tr>
-<td><b>Array (Any):</b> Stringify</td>
-<td markdown="1" colspan="2">
-<table>
-<tr>
-<td width="10%">
+<td><b>Array (Simple):</b> Stringify</td>
+<td markdown="1">
 
 ```json
 products: {
@@ -113,8 +110,8 @@ products: {
     <b>Value:</b>
     "[507f1, 505bd]"
 </td>
-</tr>
 <tr>
+<td><b>Array (Complex):</b> Stringify</td>
 <td>
 
 ```json
@@ -144,12 +141,11 @@ products: [
 
 <b>Column Name:</b> <br/>
     products <br/><br/>
-    <b>Value:</b>
-    '[{"product_id":"507f1f77bcf86cd799439011","sku":"45790-32","name":"Monopoly: 3rd Edition","price":19,"position":1,"category":"Games","url":"https://www.example.com/product/path","image_url":"https://www.example.com/product/path.jpg"},{"product_id":"505bd76785ebb509fc183733","sku":"46493-32","name":"Uno Card Game","price":3,"position":2,"category":"Games"}]'
+    <b>Value:</b> <br />
+    '[{"product_id":"507f1f77bcf86cd799439011","sku":"45790-32", <br /> "name":"Monopoly: 3rd Edition","price":19,"position":1,"category":"Games",<br /> "url":"https://www.example.com/product/path", <br /> "image_url":"https://www.example.com/product/path.jpg"},{"product_id":"505bd76785ebb509fc183733","sku":"46493-32",<br /> "name":"Uno Card Game","price":3,"position":2,"category":"Games"}]'
 
 </td>
 </tr>
-</table>
 </td>
 </tr>
 </table>


### PR DESCRIPTION
### Proposed changes

It may be easier for customers to understand how we stringify (flatten) the array with an example on the warehouse schema page, in addition to the explanation on Segment Spec page

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

