### PR TITLE
Update GA4 Cloud name on strat nav

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -54,7 +54,7 @@ sections:
   - path: /connections/destinations/catalog/google-analytics
     title: Google Universal Analytics destination
   - path: /connections/destinations/catalog/actions-google-analytics-4
-    title: Google Analytics 4 destination
+    title: Google Analytics 4 Cloud destination
   - path: /connections/destinations/catalog/actions-google-analytics-4-web
     title: Google Analytics 4 Web destination
   - path: /connections/destinations/catalog/google-tag-manager


### PR DESCRIPTION
### Proposed changes
Adds "Cloud" to the Google Analytics 4 destination name given recent name update.

### Merge timing
- ASAP once approved - ideally the March 7 deploy.

### Related issues (optional)

