### PR TITLE
Platfrom data available.md

### DIFF
--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -124,9 +124,8 @@ To enable session tracking in Amplitude when using the [Segment Android library]
 The classic Amplitude destination captures the following user fields in device-mode (when it runs on the user's device):
 
 - Device Type (for example, Mac, PC, mobile device)
-- Platform (for example iOS or Android)
 
-Amplitude (Actions) runs in cloud-mode, and does not capture these fields.
+Amplitude (Actions) runs in cloud-mode, and does not capture this field.
 {% capture log-event-details %}
 #### Track Revenue Per Product
 

--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -121,11 +121,10 @@ To enable session tracking in Amplitude when using the [Segment Android library]
 
 ## Important differences from the classic Amplitude destination
 
-The classic Amplitude destination captures the following user fields in device-mode (when it runs on the user's device):
+The classic Amplitude destination captures the Device Type (for example, Mac, PC, mobile devices) user field in device-mode (when it runs on the user's device).
 
-- Device Type (for example, Mac, PC, mobile device)
 
-Amplitude (Actions) runs in cloud-mode, and does not capture this field.
+Amplitude (Actions) runs in cloud-mode, and doesn't capture this field.
 {% capture log-event-details %}
 #### Track Revenue Per Product
 


### PR DESCRIPTION
Amplitude is capturing the capturing Platform field in cloud mode

### Proposed changes

Around August 2022, we shifted towards using Segment's Amplitude Actions API (instead of classic Amplitude). As part of this shift, it looks like the OS property for Web browsers had changed.

The documentation implied that we would no longer track the Amplitude Platform property, if using Amplitude Actions
However, it seems that Platform is still tracked.

Found that we made an update when Actions came out to parse the user agent (if one was provided in the payload to Segment) to more closely align with how Amplitude would pull data from the browser.

### Merge timing
<!-- When should this get merged/published?
ASAP once approved?


### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
