### PR TITLE
Change name in integrations object in payload

### DIFF
--- a/src/connections/destinations/catalog/marketo-v2/index.md
+++ b/src/connections/destinations/catalog/marketo-v2/index.md
@@ -207,7 +207,7 @@ We do our best to limit the amount of API calls that we are making to Marketo bu
         firstName: 'Alex'
       },
       integrations: {
-        'Marketo': false,
+        'Marketo V2': false,
         'Google Analytics': true
       }
     })


### PR DESCRIPTION
The payload in the Marketo API Limits section is incorrect, as the destination name is Marketo V2 and not just Marketo. As mentioned at the top of the document: "Refer to it as Marketo V2 in the Integrations object"

Changed "Marketo" to "Marketo V2" in the payload


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
