### PR TITLE
Identifier should be available in ID resolution settings to update the trait value on profile.

### DIFF
--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -250,4 +250,4 @@ Segment added the compute schedule feature on Feb 8, 2021, so traits created pri
 
 ### why do the SQL traits value showing in preview is not reflecting over the profile even after a successful sync?
 
-The identifier which will uniquely identify the user in a SQL query (user_id or anonymous_id or email (or group_id for account traits)) should be configured in Identity resolution settings as an identifier. So the trait will be updated to the user profile using this identifier. If the identifier is not part of Identity resolution settings, then the trait value will not be updated to the user profile.
+The identifier which will uniquely identify the user in a SQL query (user_id or anonymous_id or email (or group_id for account traits)) should be configured in Identity resolution settings as an identifier. So the trait will be updated to the user profile using this identifier. If the identifier is not part of Identity resolution settings, then the trait value will not be updated to the user profile. This will be one of the potential reason for the trait not updated on user profile.

--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -248,6 +248,7 @@ If you see only question marks in the preview, and have already tracked data his
 
 Segment added the compute schedule feature on Feb 8, 2021, so traits created prior to this date will not have this option. If your trait lacks this feature, recreating it will make it available.
 
-### why do the SQL traits value showing in preview is not reflecting over the profile even after a successful sync?
+### Why do the SQL traits value showing in preview is not reflecting over the profile even after a successful sync?
+### Why doesn't the value of a SQL trait show in a user profile after a successful sync?
 
-The identifier which will uniquely identify the user in a SQL query (user_id or anonymous_id or email (or group_id for account traits)) should be configured in Identity resolution settings as an identifier. So the trait will be updated to the user profile using this identifier. If the identifier is not part of Identity resolution settings, then the trait value will not be updated to the user profile. This will be one of the potential reason for the trait not updated on user profile.
+Check that you've configured the identifier that uniquely identifies users in a SQL query (`user_id`, `anonymous_id`, `email`, or `group_id` for account traits) in Identity Resolution settings as an identifier. This ensures the trait is added to the user's profile with the correct identifier. If you don't configure the identifier in Identity Resolution settings, the trait's value is not added to the user profile.

--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -247,3 +247,7 @@ If you see only question marks in the preview, and have already tracked data his
 ### Why do some SQL Trait settings not have the “Compute schedule” option?
 
 Segment added the compute schedule feature on Feb 8, 2021, so traits created prior to this date will not have this option. If your trait lacks this feature, recreating it will make it available.
+
+### why do the SQL traits value showing in preview is not reflecting over the profile even after a successful sync?
+
+The identifier which will uniquely identify the user in a SQL query (user_id or anonymous_id or email (or group_id for account traits)) should be configured in Identity resolution settings as an identifier. So the trait will be updated to the user profile using this identifier. If the identifier is not part of Identity resolution settings, then the trait value will not be updated to the user profile.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

### why do the SQL traits value showing in preview is not reflecting over the profile even after a successful sync?

The identifier which will uniquely identify the user in a SQL query (user_id or anonymous_id or email (or group_id for account traits)) should be configured in Identity resolution settings as an identifier. So the trait will be updated to the user profile using this identifier. If the identifier is not part of Identity resolution settings, then the trait value will not be updated to the user profile.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
