### PR TITLE
what field is supposed to map to Salesforce’s required field "Bulk Update Record ID" and "Bulk Upsert External ID"

### DIFF
--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -109,8 +109,8 @@ When **Use Salesforce Bulk API** is enabled for your mapping, events are sent to
 
 For bulk `update`, if a record in a batch is missing a Bulk Update Record ID, Segment will still send it to Salesforce. Salesforce will reject the individual record because it will be unable to find a record to update. Other records in the batch that are valid will still be processed. Please note that Segment's Event Delivery tab will show the entire batch as successful as Segment cannot currently break down Event Delivery stats into individual failed/passed events.
 
-### what fields are supposed to map to Salesforce’s required fields for "Bulk Update Record ID" and "Bulk Upsert External ID"?
+### Which fields are supposed to map to Salesforce’s required fields for "Bulk Update Record ID" and "Bulk Upsert External ID"?
 
-For "Bulk Update Record ID", please refer to this [Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000385008&type=1).
-For "Bulk Upsert External ID", please refer to this [Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000383278&type=1).
+For "Bulk Update Record ID", see [Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000385008&type=1){:target="_blank"}.
+For "Bulk Upsert External ID", see[Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000383278&type=1){:target="_blank"}.
 

--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -109,3 +109,8 @@ When **Use Salesforce Bulk API** is enabled for your mapping, events are sent to
 
 For bulk `update`, if a record in a batch is missing a Bulk Update Record ID, Segment will still send it to Salesforce. Salesforce will reject the individual record because it will be unable to find a record to update. Other records in the batch that are valid will still be processed. Please note that Segment's Event Delivery tab will show the entire batch as successful as Segment cannot currently break down Event Delivery stats into individual failed/passed events.
 
+### what field is supposed to map to Salesforce’s required field "Bulk Update Record ID" and "Bulk Upsert External ID"?
+
+For "Bulk Update Record ID", please refer to this [Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000385008&type=1).
+For "Bulk Upsert External ID", please refer to this [Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000383278&type=1).
+

--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -109,7 +109,7 @@ When **Use Salesforce Bulk API** is enabled for your mapping, events are sent to
 
 For bulk `update`, if a record in a batch is missing a Bulk Update Record ID, Segment will still send it to Salesforce. Salesforce will reject the individual record because it will be unable to find a record to update. Other records in the batch that are valid will still be processed. Please note that Segment's Event Delivery tab will show the entire batch as successful as Segment cannot currently break down Event Delivery stats into individual failed/passed events.
 
-### what field is supposed to map to Salesforce’s required field "Bulk Update Record ID" and "Bulk Upsert External ID"?
+### what fields are supposed to map to Salesforce’s required fields for "Bulk Update Record ID" and "Bulk Upsert External ID"?
 
 For "Bulk Update Record ID", please refer to this [Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000385008&type=1).
 For "Bulk Upsert External ID", please refer to this [Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000383278&type=1).


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

### what fields are supposed to map to Salesforce’s required fields for "Bulk Update Record ID" and "Bulk Upsert External ID"?

For "Bulk Update Record ID", please refer to this [Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000385008&type=1).
For "Bulk Upsert External ID", please refer to this [Salesforce’s help documentation](https://help.salesforce.com/s/articleView?id=000383278&type=1).

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
