### PR TITLE
Remove Manual Upgrade and Automatic Migration AJS

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2.md
@@ -6,7 +6,7 @@ strat: ajs
 Analytics.js 2.0 is fully backward compatible with Analytics.js Classic when you use the default Segment snippet in a standard implementation. To upgrade your sources, follow the manual upgrade steps below, or see the schedule for automatic migration. As with all upgrades, Segment recommends that you start development on a non-production source to test the upgrade process and outcome, prior to upgrading your production sources.
 
 > warning "Deprecation of Analytics.js Classic"
-> Analytics.js Classic was deprecated on February 28, 2023. At this time, Segment is upgrading all sources not yet upgraded to [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/). The upgrade process will complete for all users by the end of March 2023. 
+> Analytics.js Classic was deprecated on February 28, 2023. As of March 2023, Segment upgraded all sources to [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/). 
 
 ## Revert to Analytics.js Classic
 

--- a/src/connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2.md
@@ -8,31 +8,13 @@ Analytics.js 2.0 is fully backward compatible with Analytics.js Classic when you
 > warning "Deprecation of Analytics.js Classic"
 > Analytics.js Classic was deprecated on February 28, 2023. At this time, Segment is upgrading all sources not yet upgraded to [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/). The upgrade process will complete for all users by the end of March 2023. 
 
-## Manual upgrade
-
-To upgrade a source to Analytics.js 2.0:
-
-1. In your Segment workspace, open the **Connections** page.
-2. Open the JavaScript source you will upgrade.
-3. On the **Settings** tab, open the **Analytics.js** category.
-4. Enable the flag for Analytics 2.0.
-5. Within 5 minutes, the source receives Analytics.js 2.0. No code or tag changes required.
-6. Open the Debugger to ensure that events are flowing as expected.
-
-> info ""
-> If you set `'Segment.io:' false` in the integrations object, Analytics.js 2.0 drops the event before it reaches the Source Debugger.
-
-## Automatic migration
-
-On February 28, 2023, all Analytics.js Classic sources will automatically upgrade to Analytics.js 2.0.
-
 ## Revert to Analytics.js Classic
 
-Once a source moves to Analytics.js 2.0, you can follow the steps above in [Manual migration](#manual-migration) to roll back to Analytics.js Classic.
+It is no longer possible to revert to Analytics.js Classic. If you are experiencing technical issues after the automatic upgrade to Analytics.js 2.0, please see below for cases that may require additional intervention. If you are still having issues after reading through the section below, please reach out to the Segment support team. 
 
 ## Cases that require additional intervention
 
-In some cases, upgrading to Analytics.js 2.0 requires manual effort beyond enabling the Analytics.js 2.0 toggle.
+In some cases, upgrading to Analytics.js 2.0 may require some additional intervention. This only applies to customers who are experiencing these specific issues and do not apply to all customers. In most cases, upgrading to Analytics.js 2.0 should not cause technical issues. 
 
 ### Using in-domain instrumentation CDN aliasing
 


### PR DESCRIPTION
### Proposed changes

- Remove Manual Upgrade section because the flag to toggle Analytics.js on is no longer available in the customer's workspace
- Remove Automatic Migration section because it mentions it in the yellow box directly above that so it seems redundant 
- Update section about reverting to AJS Classic to let customer know that it is no longer possible to revert to AJS Classic themselves (I intentionally didn't add anything about it being possible to revert to AJS Classic by request, because I worry this will encourage customers to use this as a temporary solution instead of upgrading to AJS 2.0 now)
- Add sentence about how Cases That Require Additional intervention do not necessarily apply to every customer and remove reference to toggle

### Merge timing
- ASAP once approved?
