### PR TITLE
Fix broken link to Destination filters

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
@@ -448,7 +448,7 @@ analytics.reset()
 >
 > Destination filters on mobile device-mode destinations are in beta and only supports Analytics-Kotlin, [Analytics-Swift](/docs/connections/sources/catalog/libraries/mobile/swift-ios/), and [Analytics-React-Native 2.0](/docs/connections/sources/catalog/libraries/mobile/react-native/).
 
-Use Analytics-Kotlin (Android) to configure [destination filters](docs/connections/destinations/destination-filters/) on your mobile device-mode destinations.
+Use Analytics-Kotlin (Android) to configure [destination filters](/docs/connections/destinations/destination-filters/) on your mobile device-mode destinations.
 
 > warning ""
 > Keep [these limitations](/docs/connections/destinations/destination-filters/#limitations) in mind when using destination filters.

--- a/src/connections/sources/catalog/libraries/mobile/react-native/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/index.md
@@ -543,7 +543,7 @@ These are the example plugins you can use and alter to meet your tracking needs:
 >
 > Destination filters on mobile device-mode destinations are in beta and only supports Analytics-React-Native 2.0, [Analytics-Swift](/docs/connections/sources/catalog/libraries/mobile/swift-ios/) and [Analytics-Kotlin](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/).
 
-Use Analytics-React-Native 2.0 to set up [destination filters](docs/connections/destinations/destination-filters/) on your mobile device-mode destinations.
+Use Analytics-React-Native 2.0 to set up [destination filters](/docs/connections/destinations/destination-filters/) on your mobile device-mode destinations.
 
 > warning ""
 > You must use Analytics-React-Native version 2.9 or higher to implement destination filters.

--- a/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/swift-ios/index.md
@@ -413,7 +413,7 @@ analytics.flush()
 >
 > Destination filters on mobile device-mode destinations are in beta and only supports Analytics-Swift, [Analytics-Kotlin](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/), and [Analytics-React-Native 2.0](/docs/connections/sources/catalog/libraries/mobile/react-native/).
 
-Use Analytics-Swift to set up [destination filters](docs/connections/destinations/destination-filters/) on your mobile device-mode destinations.
+Use Analytics-Swift to set up [destination filters](/docs/connections/destinations/destination-filters/) on your mobile device-mode destinations.
 
 > warning ""
 > Keep [these limitations](/docs/connections/destinations/destination-filters/#limitations) in mind when using destination filters.


### PR DESCRIPTION
### Proposed changes
Fix the broken links to Destination Filters documentation on RN2.0, Swift, and Kotlin pages.

### Merge timing
ASAP once approved?
