### PR TITLE
Renamed space name can't be reflected in URL.

### DIFF
--- a/src/profiles/quickstart.md
+++ b/src/profiles/quickstart.md
@@ -71,3 +71,6 @@ Once you validate that your data is flowing through Profiles, you're ready to cr
 
 > success ""
 > If you're using Engage, view additional steps to complete your space set up in the [Engage Foundations Onboarding Guide](/docs/engage/quickstart).
+
+> info ""
+> The created Segment space name can be renamed later but in the URL(which retrieves the Space page) the old space name remains the same.

--- a/src/profiles/quickstart.md
+++ b/src/profiles/quickstart.md
@@ -73,4 +73,4 @@ Once you validate that your data is flowing through Profiles, you're ready to cr
 > If you're using Engage, view additional steps to complete your space set up in the [Engage Foundations Onboarding Guide](/docs/engage/quickstart).
 
 > info ""
-> The created Segment space name can be renamed later but in the URL(which retrieves the Space page) the old space name remains the same.
+> The Segment space UI name can be renamed later, but the space slug cannot be modified. As a consequence, the URL of the space cannot be changed.

--- a/src/profiles/quickstart.md
+++ b/src/profiles/quickstart.md
@@ -73,4 +73,4 @@ Once you validate that your data is flowing through Profiles, you're ready to cr
 > If you're using Engage, view additional steps to complete your space set up in the [Engage Foundations Onboarding Guide](/docs/engage/quickstart).
 
 > info ""
-> The Segment space UI name can be renamed later, but the space slug cannot be modified. As a consequence, the URL of the space cannot be changed.
+> You can rename the Segment space UI name, but can't modify the space slug. As a result, you can't change the URL of a space.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

> info ""
> The Segment space UI name can be renamed later, but the space slug cannot be modified. As a consequence, the URL of the space cannot be changed.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
