### PR TITLE
update Enforce Email as Primary Identifier

### DIFF
--- a/src/connections/destinations/catalog/klaviyo/index.md
+++ b/src/connections/destinations/catalog/klaviyo/index.md
@@ -78,7 +78,7 @@ If your `userId` is an email, or you provide an email in `traits.email`, Segment
 
 #### Enforce email as primary identifier
 
-This option is enabled by default to ensure duplicate profiles are not being created inside of Klaviyo. When enabled, Segment will never set the $id field to your `userId` when you call `.identify()` or `.track()`. Instead, Segment will only set $email as the primary identifier with your `traits.email` or `properties.email`. 
+This option is enabled by default to ensure duplicate profiles are not being created inside of Klaviyo. When enabled, Segment will never set the $id field to your `userId` when you call `.identify()` or `.track()`. Instead, Segment will only set $email as the primary identifier with your `traits.email` or `properties.email`. Please note that if you have this setting toggled on you must send `email` in on your payloads or your events will not go through to Klaviyo.
 
 #### Fallback on Anonymous ID
 

--- a/src/connections/destinations/catalog/klaviyo/index.md
+++ b/src/connections/destinations/catalog/klaviyo/index.md
@@ -78,7 +78,7 @@ If your `userId` is an email, or you provide an email in `traits.email`, Segment
 
 #### Enforce email as primary identifier
 
-This option is enabled by default to ensure duplicate profiles are not being created inside of Klaviyo. When enabled, Segment will never set the $id field to your `userId` when you call `.identify()` or `.track()`. Instead, Segment will only set $email as the primary identifier with your `traits.email` or `properties.email`. Please note that if you have this setting toggled on you must send `email` in on your payloads or your events will not go through to Klaviyo.
+This option is enabled by default to ensure duplicate profiles are not being created inside of Klaviyo. When enabled, Segment will never set the $id field to your `userId` when you call `.identify()` or `.track()`. Instead, Segment will only set $email as the primary identifier with your `traits.email` or `properties.email`. Please note that if you have this setting toggled on, you must send `email` in on your payloads or your events will not go through to Klaviyo.
 
 #### Fallback on Anonymous ID
 


### PR DESCRIPTION
### Proposed changes

The Enforce Email as Primary Identifier setting requires that an email be sent in on the payload. If that setting is enabled but an email isn't sent to Klaviyo then the payload will be rejected. This update clarifies that point.

### Merge timing
ASAP is fine
