### PR TITLE
Add plan availability - Regional Segment Page

### DIFF
--- a/src/guides/regional-segment.md
+++ b/src/guides/regional-segment.md
@@ -1,5 +1,6 @@
 ---
 title: Regional Segment
+plan: papi
 redirect_from:
   - '/connections/regional-segment/'
   - '/docs/connections/regional-segment-eu/'


### PR DESCRIPTION
Similar to the Public API page add in the plan availability (Free, Add-on, BT)- so customers can easily identify if they are eligible for this feature

### Proposed changes

Similar to the Public API page add in the plan availability (Free, Add-on, BT)- so customers can easily identify if they are eligible for this feature
Using a tick feature or whiting out the plans that are not eligible.

### Merge timing
- ASAP once approved?
