### PR TITLE
Select new fields on selective sync page for SFDC

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/salesforce/index.md
+++ b/src/connections/sources/catalog/cloud-apps/salesforce/index.md
@@ -107,7 +107,7 @@ Segment does not support hard deletes in Salesforce. Use of hard deletes will re
 
 ## Collection Properties
 
-Segment performs a one-to-one mapping of all publicly available fields (standard and custom) from Salesforce. To see the full list of the standard fields refer to the Salesforce field documentation linked in each collection above. If you've added custom fields to an existing collection, [contact Segment Support](https://segment.com/help/contact/) to configure them to sync. You do not need to include the field names.
+Segment performs a one-to-one mapping of all publicly available fields (standard and custom) from Salesforce. To see the full list of the standard fields refer to the Salesforce field documentation linked in each collection above. If you've added and selected custom fields to an existing collection, [contact Segment Support](https://segment.com/help/contact/) to configure them to sync. You do not need to include the field names.
 
 ## Adding Destinations
 


### PR DESCRIPTION
Make sure customer are selecting their new fields on selective sync page for SFDC in order for them to be sync'd to the warehouse.


### Proposed changes

Update documentation to make sure customers are actually selecting their new fields on selective sync page for SFDC in order for them to be sync'd to the warehouse.

### Merge timing
- ASAP once approved?

