### PR TITLE
Add link for CleverTap server-side support

### DIFF
--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -9,7 +9,7 @@ Once the Segment library is integrated, toggle CleverTap on in your Segment dest
 
 You can integrate CleverTap using a server-side or mobile destination (iOS or Android). If you are interested in using CleverTap's push notifications or in-app notifications products, you should use the mobile destinations.
 
-All server-side destination requests require both the Segment `anonymousId` and `userId` in the payload. This is a requirement from CleverTap. The server-side integration is maintained by CleverTap. For any issues with the server-side integration, [contact the CleverTap Support team](https://help.clevertap.com/hc/en-us/requests/new).
+All server-side destination requests require both the Segment `anonymousId` and `userId` in the payload. This is a requirement from CleverTap. CleverTap maintains the server-side integration. For any issues with the server-side integration, [contact the CleverTap Support team](https://help.clevertap.com/hc/en-us/requests/new){:target="_blank"}.
 
 CleverTap supports the `identify`, `track`, `page` (server-side only), and `screen` (iOS and server-side only) methods.
 

--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -9,7 +9,7 @@ Once the Segment library is integrated, toggle CleverTap on in your Segment dest
 
 You can integrate CleverTap using a server-side or mobile destination (iOS or Android). If you are interested in using CleverTap's push notifications or in-app notifications products, you should use the mobile destinations.
 
-All server-side destination requests require both the Segment `anonymousId` and `userId` in the payload. This is a requirement from CleverTap.
+All server-side destination requests require both the Segment `anonymousId` and `userId` in the payload. This is a requirement from CleverTap. The server-side integration is maintained by CleverTap. For any issues with the server-side integration, [contact the CleverTap Support team](https://help.clevertap.com/hc/en-us/requests/new).
 
 CleverTap supports the `identify`, `track`, `page` (server-side only), and `screen` (iOS and server-side only) methods.
 


### PR DESCRIPTION
### Proposed changes

[Partner portal](https://app.segment.com/partner-portal/integration/clevertap/components) shows that the server-side integration is owned by CleverTap, but docs do not currently mention this: 
![Screen Shot 2023-03-20 at 3 32 06 PM](https://user-images.githubusercontent.com/93934274/226446454-07013dd1-dbdd-4c4f-861a-92c48cd2c86e.png)

Added this detail to the top of docs, along with a link to CleverTap's customer support page to help customers experiencing issues with the server-side integration. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
