### PR TITLE
Update mapping info with unsupported characters

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -170,6 +170,9 @@ The available operators depend on the property's data type:
 
 You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY to “subscribe” to multiple conditions. Use ALL when you need to filter for very specific conditions. You can only create one group condition per destination action. You cannot created nested conditions.
 
+> info "Unsupported Special Characters"
+> Mappings do not support the use of double quotes " or a tilde ~ in the trigger fields.
+
 > info "Destination Filters"
 > Destination filters are compatible with Destination Actions. Consider a Destination Filter when:
 > - You need to remove properties from the data sent to the destination


### PR DESCRIPTION

### Proposed changes

There are a few unsupported characters that will not save triggers in Actions mappings including double quotes and the tilde. A note has been made in the conditions section to ensure customers are aware. 

### Merge timing

- ASAP once approved

### Related issues (optional)

n/a
