### PR TITLE
Remove beta note from GA4 Web docs ahead of GA

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -15,9 +15,6 @@ versions:
 
 When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. When you use the Google Analytics 4 Web destination, Segment loads the [gtag.js library](https://support.google.com/analytics/answer/9310895?hl=en#zippy=%2Cin-this-article){:target="_blank"}  for you. 
 
-> info ""
-> The Google Analytics 4 Web destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 ## Getting started
 
 Before you connect Segment to Google Analytics 4, configure a Google Analytics 4 property in your Analytics account. For more information, see Google's article [Set up Analytics for a website and/or app](https://support.google.com/analytics/answer/9304153){:target='_blank'}.
@@ -60,7 +57,6 @@ Google Analytics 4 collects events triggered by basic interactions with your sit
 ### Data takes a long time to appear in Google's reports
 
 Google may take [24-48 hours](https://support.google.com/analytics/answer/9333790){:target="_blank"} to process data sent to Google Analytics. As a result, the Google Analytics user interface may not reflect the most current data. The Google Analytics [Realtime report](https://support.google.com/analytics/answer/9271392){:target="_blank"} displays activity on your site as it happens.
-
 
 ### Data is not sent to Google
 


### PR DESCRIPTION
### Proposed changes
GA4 Web is going to General Availability next Tuesday (March 28). This PR removes the beta note ahead of that GA.

### Merge timing
- On a specific date: Merge and deploy on the Tues, March 28 docs deploy. Thanks!
