### PR TITLE
Remove beta note on Braze Cohorts docs ahead of GA

### DIFF
--- a/src/connections/destinations/catalog/actions-braze-cohorts/index.md
+++ b/src/connections/destinations/catalog/actions-braze-cohorts/index.md
@@ -10,9 +10,6 @@ hide-dossier: false
 
 Segment's Braze Cohorts destination syncs Engage audiences to Braze as cohorts. This is a more scalable alternative to storing audience subscription in user-level attributes in Braze. It also is more efficient as audiences are uploaded as a list, as opposed to individual events.
 
-> info ""
-> The Braze Cohorts destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 ## Getting started
 
 Before connecting to the Braze Cohorts destination, you must have a [Braze](https://dashboard-01.braze.com/sign_in){:target="_blank"} account and an Ad Account ID.


### PR DESCRIPTION
### Proposed changes
Braze Cohorts is going to General Availability next Tuesday (March 28). This PR removes the beta note ahead of that GA.

### Merge timing
- On a specific date: Merge and deploy on the Tues, March 28 docs deploy. Thanks!
