### PR TITLE
Remove beta note from Segment Profiles Destination

### DIFF
--- a/src/connections/destinations/catalog/actions-segment-profiles/index.md
+++ b/src/connections/destinations/catalog/actions-segment-profiles/index.md
@@ -9,9 +9,6 @@ The Segment Profiles destination allows you to send your warehouse data back to 
 > success "Source compatibility"
 > This destination supports connections from Reverse ETL warehouse sources, and is not compatible with other source types.
 
-> info ""
-> The Segment Profiles destination is in beta and is in active development. Some functionality may change before it becomes generally available.
-
 ## Getting started
 
 ### Create a Profile space


### PR DESCRIPTION
### Proposed changes
The Segment Profiles destination is going to General Availability next Tuesday (March 28). This PR removes the beta note ahead of that GA.

### Merge timing
- On a specific date: Merge and deploy on the Tues, March 28 docs deploy. Thanks!
