### PR TITLE
Replay Events don't show in Event delivery tab

### DIFF
--- a/src/guides/what-is-replay.md
+++ b/src/guides/what-is-replay.md
@@ -32,6 +32,8 @@ Replays can process an unlimited amount of data, however they are rate limited t
 
 Replays do not affect your [MTU count](/docs/guides/usage-and-billing/mtus-and-throughput/), unless you are using a [Repeater destination](/docs/connections/destinations/catalog/repeater/). Notify your team before initiating a Replay if you're using a Repeater destination.
 
+Please be advised once you have requested your data be replayed, and the replay starts, you will not see these events show up in the Event Delivery tab. 
+
 ### Replay-eligible destinations
 
 Replays are available for any destinations which support cloud-mode data (meaning data routed through Segment) and which also process timestamps. Destinations that are only available in device-mode (meaning where data is sent directly from the users' devices to the destination tool) cannot receive Replays.

--- a/src/guides/what-is-replay.md
+++ b/src/guides/what-is-replay.md
@@ -32,7 +32,7 @@ Replays can process an unlimited amount of data, however they are rate limited t
 
 Replays do not affect your [MTU count](/docs/guides/usage-and-billing/mtus-and-throughput/), unless you are using a [Repeater destination](/docs/connections/destinations/catalog/repeater/). Notify your team before initiating a Replay if you're using a Repeater destination.
 
-Please be advised once you have requested your data be replayed, and the replay starts, you will not see these events show up in the Event Delivery tab. 
+Once a replay starts, you will not see replayed events in the Event Delivery tab.
 
 ### Replay-eligible destinations
 


### PR DESCRIPTION
### Proposed changes

I added information that advised customers they will not see the events that are being replayed in the event delivery tab of that destination they are replaying to.
<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
