### PR TITLE
Remove 'Platform' from list of differences

### DIFF
--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -124,7 +124,6 @@ To enable session tracking in Amplitude when using the [Segment Android library]
 The classic Amplitude destination captures the following user fields in device-mode (when it runs on the user's device):
 
 - Device Type (for example, Mac, PC, mobile device)
-- Platform (for example iOS or Android)
 
 Amplitude (Actions) runs in cloud-mode, and does not capture these fields.
 {% capture log-event-details %}


### PR DESCRIPTION
Amplitude (Actions) does capture Platform, as detailed further down in the docs under "Identify User"

### Proposed changes

Amplitude (Actions) includes platform in the mapping. It's captured through Identify and Track events. The documentation stating it is not captured is contradictory. 

### Merge timing

- ASAP once approved


### Related issues (optional)

