### PR TITLE
Add info about GA4 web page views

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -64,10 +64,7 @@ Ensure that at least one mapping has been configured and enabled in the destinat
 
 ### Page Views
 
-The 'Page Views' advanced setting prevents the `page_view` included in the gtag.js snippet from being sent, not Segment's `analytics.page()` event available in the Analytics.js snippet by default. If you keep this setting enabled, it is expected that once the page loads, two `page_view` events will still be sent to the GA4 SDK, one from the Segment snippet and one from gtag.js snippet. If you are seeing duplicate `page_view` events in your GA4 dashboard, you need to:
+The **Page Views** advanced setting prevents sending the `page_view` included in the gtag.js snippet, not Segment's `analytics.page()` event available in the Analytics.js snippet by default. If you enable this setting, once the page loads, two `page_view` events will still send to the GA4 SDK, one from the Segment snippet and one from the gtag.js snippet. If you see duplicate `page_view` events in your GA4 dashboard, you need to either:
 
-1. Disable the 'Page Views' advanced setting (set to False) so only Segment's `analytics.page()` is sent to the GA4 SDK.
-
-Or
-
-2.  Edit or disable the preset 'Set Configuration Fields' mapping so only the `page_view` included in the gtag.js snippet is sent to GA4 SDK.
+1. Disable the **Page Views** advanced setting (set it to *False*) so only Segment's `analytics.page()` sends to the GA4 SDK. Or,
+2.  Edit or disable the preset **Set Configuration Fields** mapping so only the `page_view` included in the gtag.js snippet sends to the GA4 SDK.

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -64,4 +64,10 @@ Ensure that at least one mapping has been configured and enabled in the destinat
 
 ### Page Views
 
-The 'Page Views' advanced setting prevent page_views included in the gtag.js snippet from being sent, not the Segment snippet. If you are seeing duplicate page_views in your GA4 dashboard, you need to enable this setting. If you enable this setting it is expected that page_views will still be sent from the Segment snippet. In order to prevent these page views, you will need to edit or disable the preset 'Set Configuration Fields' mapping. 
+The 'Page Views' advanced setting prevents the `page_view` included in the gtag.js snippet from being sent, not Segment's `analytics.page()` event available in the Analytics.js snippet by default. If you keep this setting enabled, it is expected that once the page loads, two `page_view` events will still be sent to the GA4 SDK, one from the Segment snippet and one from gtag.js snippet. If you are seeing duplicate `page_view` events in your GA4 dashboard, you need to:
+
+1. Disable the 'Page Views' advanced setting (set to False) so only Segment's `analytics.page()` is sent to the GA4 SDK.
+
+Or
+
+2.  Edit or disable the preset 'Set Configuration Fields' mapping so only the `page_view` included in the gtag.js snippet is sent to GA4 SDK.

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -61,3 +61,7 @@ Google may take [24-48 hours](https://support.google.com/analytics/answer/933379
 ### Data is not sent to Google
 
 Ensure that at least one mapping has been configured and enabled in the destination mappings for an event you want to send to Google Analytics. If no mappings are enabled, the destination does not send events.
+
+### Page Views
+
+The 'Page Views' advanced setting prevent page_views included in the gtag.js snippet from being sent, not the Segment snippet. If you are seeing duplicate page_views in your GA4 dashboard, you need to enable this setting. If you enable this setting it is expected that page_views will still be sent from the Segment snippet. In order to prevent these page views, you will need to edit or disable the preset 'Set Configuration Fields' mapping. 


### PR DESCRIPTION

### Proposed changes

Added an FAQ about Page Views - 

We've received multiple messages about duplicate page views from the GA4 web actions destination. The available preset to disable page views is meant for the page call included in the gtag snippet, not the segment snippet.[ Code here](https://github.com/segmentio/action-destinations/blob/main/packages/browser-destinations/src/destinations/google-analytics-4-web/index.ts#L164). Testing confirms this. 

### Merge timing

- ASAP once approved

### Related issues (optional)

n/a
