### PR TITLE
Make Wisepops destination appear in catalog list

### DIFF
--- a/src/connections/destinations/catalog/actions-wisepops/index.md
+++ b/src/connections/destinations/catalog/actions-wisepops/index.md
@@ -3,7 +3,6 @@ title: Wisepops Destination
 hide-boilerplate: true
 hide-dossier: true
 id: 6372e1e36d9c2181f3900834
-private: true
 ---
 
 {% include content/plan-grid.md name="actions" %}

--- a/src/connections/destinations/catalog/wisepops/index.md
+++ b/src/connections/destinations/catalog/wisepops/index.md
@@ -1,7 +1,0 @@
----
-title: 'Wisepops Destination'
-hidden: true
-id: 6372e1e36d9c2181f3900834
-published: false
-beta: true
----


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

wisepops is currently not showing in it's categories sections. by deleting this hidden entry I was able to see wisepops show on the page locally: 
![Screen Shot 2023-04-04 at 9 56 19 AM](https://user-images.githubusercontent.com/64277654/229816255-2791e809-9e92-41a4-9573-9387f61e0851.png)



### Merge timing
asap

