### PR TITLE
Add to FAQ on SQL traits returning arrays

### DIFF
--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -205,7 +205,7 @@ Yes, Segment limits request sizes to a maximum of 16KB. Records larger than this
 
 ### Do SQL Traits support arrays?
 
-It is not possible to pull in an array object with SQL Traits, only strings and numeric traits are supported. Arrays can instead be cast as a comma-separated string - if you were to use this later while building an audience, you would then be able to check whether the array contains a certain value by using the “contains” operator, but the value would be sent to any connected destinations as a string.
+No, SQL Traits supports string and numeric data types. You can cast arrays as a comma-separated string. In this case, if you used this trait to build an audience, you could check if the array contains a certain value with the "contains" operator, but the value is sent to any connected destinations as a string.
 
 ## Troubleshooting
 

--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -205,7 +205,7 @@ Yes, Segment limits request sizes to a maximum of 16KB. Records larger than this
 
 ### Do SQL Traits support arrays?
 
-It is not possible to pull in an array object via SQL Traits, only strings and numeric traits are supported. Arrays can instead be cast as a comma-separated string - if you were to use this later while building an audience, you would then be able to check whether the array contains a certain value by using the “contains” operator, but the value would be sent to any connected destinations as a string.
+It is not possible to pull in an array object with SQL Traits, only strings and numeric traits are supported. Arrays can instead be cast as a comma-separated string - if you were to use this later while building an audience, you would then be able to check whether the array contains a certain value by using the “contains” operator, but the value would be sent to any connected destinations as a string.
 
 ## Troubleshooting
 

--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -203,6 +203,10 @@ If you're importing a large list of users and traits, you'll need to consider yo
 
 Yes, Segment limits request sizes to a maximum of 16KB. Records larger than this are discarded.
 
+### Do SQL Traits support arrays?
+
+It is not possible to pull in an array object via SQL Traits, only strings and numeric traits are supported. Arrays can instead be cast as a comma-separated string - if you were to use this later while building an audience, you would then be able to check whether the array contains a certain value by using the “contains” operator, but the value would be sent to any connected destinations as a string.
+
 ## Troubleshooting
 
 ### I'm getting a permissions error.


### PR DESCRIPTION
### Proposed changes

SQL traits docs do not currently mention that returning arrays via SQL traits is not supported. Added info in FAQ section that pulling in array objects via SQL traits is not supported, along with an alternative option to achieve a similar result. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
