### PR TITLE
Mixpanel requirement on sending anonymousID in UUID V4 format.

### DIFF
--- a/src/connections/destinations/catalog/actions-mixpanel/index.md
+++ b/src/connections/destinations/catalog/actions-mixpanel/index.md
@@ -113,8 +113,8 @@ The group id that Mixpanel will use is `12345`.
 
 {% include components/actions-fields.html content1=track_purchase_details section1="trackPurchase" content2=group_identify_user_details section2="groupIdentifyUser" content3=identify_user_details section3="identifyUser" %}
 
-> info ""
-> [Mixpanel](https://developer.mixpanel.com/reference/create-identity#create-identity) does have a specific requirement for the anonymousId. Using Analytics.js library to generate anonymousIds, there should not be a problem once identifying a user with a userId. And if the anonymousIds are manually assigned then it should be sent with UUID v4 format. All Segment assigned anonymousIds are in UUID V4 format.
+> info "Anonymous ID format"
+> [Mixpanel](https://developer.mixpanel.com/reference/create-identity#create-identity){:target="_blank"} requires that values it receives for the anonymous identifier (`anonymousId` in Segment) must be in the UUID v4 format. Analytics.js sends `anonymousId` in this format by default. If you manually send anonymous identifiers to Mixpanel, ensure they are in the correct format.
 
 ## Migration from Mixpanel Classic
 

--- a/src/connections/destinations/catalog/actions-mixpanel/index.md
+++ b/src/connections/destinations/catalog/actions-mixpanel/index.md
@@ -112,6 +112,10 @@ The group id that Mixpanel will use is `12345`.
 {% endcapture %}
 
 {% include components/actions-fields.html content1=track_purchase_details section1="trackPurchase" content2=group_identify_user_details section2="groupIdentifyUser" content3=identify_user_details section3="identifyUser" %}
+
+> info ""
+> Mixpanel does have a specific requirement for the anonymousId. Using Analytics.js library to generate anonymousIds, there should not be a problem once identifying a user with a userId. And if the anonymousIds are manually assigned from your end then it should be sent with UUID v4 format. All Segment assigned anonymousIds are in UUID V4 format.
+
 ## Migration from Mixpanel Classic
 
 {% include content/ajs-upgrade.md %}

--- a/src/connections/destinations/catalog/actions-mixpanel/index.md
+++ b/src/connections/destinations/catalog/actions-mixpanel/index.md
@@ -114,7 +114,7 @@ The group id that Mixpanel will use is `12345`.
 {% include components/actions-fields.html content1=track_purchase_details section1="trackPurchase" content2=group_identify_user_details section2="groupIdentifyUser" content3=identify_user_details section3="identifyUser" %}
 
 > info ""
-> Mixpanel does have a specific requirement for the anonymousId. Using Analytics.js library to generate anonymousIds, there should not be a problem once identifying a user with a userId. And if the anonymousIds are manually assigned from your end then it should be sent with UUID v4 format. All Segment assigned anonymousIds are in UUID V4 format.
+> [Mixpanel](https://developer.mixpanel.com/reference/create-identity#create-identity) does have a specific requirement for the anonymousId. Using Analytics.js library to generate anonymousIds, there should not be a problem once identifying a user with a userId. And if the anonymousIds are manually assigned then it should be sent with UUID v4 format. All Segment assigned anonymousIds are in UUID V4 format.
 
 ## Migration from Mixpanel Classic
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Mixpanel requirement on sending anonymousID in UUID V4 format.

> info ""
> Mixpanel does have a specific requirement for the anonymousId. Using Analytics.js library to generate anonymousIds, there should not be a problem once identifying a user with a userId. And if the anonymousIds are manually assigned from your end then it should be sent with UUID v4 format. All Segment assigned anonymousIds are in UUID V4 format.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
