### PR TITLE
add information about Source Function usage

### DIFF
--- a/src/connections/destinations/catalog/repeater/index.md
+++ b/src/connections/destinations/catalog/repeater/index.md
@@ -6,9 +6,11 @@ This destination is maintained by Segment and is not available to customers on t
 
 ## Getting Started
 
-The Repeater destination forwards events from a source back into another source, as though that event occurred in the second source.
+The Repeater destination forwards events from a source back into another source as though that event occurred in the second source.
 
 Events are not cached in the Repeater, so it only handles real-time events. You can specify multiple sources as Repeater destinations.
+
+If you need to send events to a Source Function, please use the [Webhooks (Actions)]([url](https://segment.com/docs/connections/destinations/catalog/actions-webhook/)) destination instead. The Repeater bypasses the code of a Source Function and sends data only to the write key. The Webhook destination will allow data to be sent through the Source Function code as expected.
 
 ## Configuration
 


### PR DESCRIPTION
### Proposed changes

Some customers will want to send data from one source in their workspace to a Source Function. If folks attempt to use the Repeater to do this, it won't work as the Repeater will send data to the source connected to the Source Function but not through the Source Function's code. 

In order to achieve this pipeline, the Webhooks destination will need to be used instead so data can be sent to the webhook supplied with each Source Function instance.

### Merge timing
ASAP is good