### PR TITLE
Remove Iterable from the list of supported destinations

### DIFF
--- a/src/connections/reverse-etl/index.md
+++ b/src/connections/reverse-etl/index.md
@@ -9,7 +9,7 @@ Reverse ETL (Extract, Transform, Load) extracts data from a data warehouse using
 
 ## Example use cases
 Use Reverse ETL when you want to:
-* Sync audiences and other data built in the warehouse to Braze, Iterable, Hubspot, or Salesforce Marketing Cloud for personalized marketing campaigns.
+* Sync audiences and other data built in the warehouse to Braze, Hubspot, or Salesforce Marketing Cloud for personalized marketing campaigns.
 * Sync enriched data to Mixpanel for a more complete view of the customer, or enrich Segment Profiles with data from the warehouse.
 * Send data in the warehouse back into Segment as events that can be activated in all supported destinations, including Twilio Engage and other platforms.
 * Pass offline or enriched data to conversion APIs like Facebook, Google Ads, TikTok, or Snapchat.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Customers have written to CSEng inquiring why it’s not possible for them to find Iterable as a RETL destination in their workspaces when the public doc mentions it. This destination is currently on the roadmap and Iterable is still in the process of building an integration. It would be better to take this off of our doc to avoid confusion. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
