### PR TITLE
Adding section for new feature - useQueryString

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/querystring.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/querystring.md
@@ -32,16 +32,16 @@ analytics.user().anonymousId('abc123');
 Each trigger parameter is optional. You can pass up to **one of each trigger parameter** as shown in the example above.
 
 
-## How can I turn off the query string processing or add a condition to when it should be tracked?
+## How can I control query string processing?
 
-Using `useQueryString` option enable you to control the query parameters behaviour. For example, you can entirely disable query string processing by setting `useQueryString` to `false`:
-```
+The `useQueryString` option allows you to control the behavior of the query parameters. For example, you can entirely disable query string processing by setting `useQueryString` to `false`:
+```js
 analytics.load('<WRITE_KEY>', {
   useQueryString: false
 })
 ```
-It is also possible to keep query string processing on, but enforce validation rules. For example:
-```
+You can also keep query string processing on, but enforce validation rules. For example:
+```js
 analytics.load('<WRITE_KEY>', {
   useQueryString: {
     // set a pattern for anonymous id 
@@ -53,4 +53,4 @@ analytics.load('<WRITE_KEY>', {
 ```
 
 > info ""
-> Currently, the `useQueryString` option is **only** available when you load analytics.js through the [NPM package](https://www.npmjs.com/package/@segment/analytics-next){:target="_blank"}.
+> The `useQueryString` option is **only** available when you load analytics.js through the [NPM package](https://www.npmjs.com/package/@segment/analytics-next){:target="_blank"}.

--- a/src/connections/sources/catalog/libraries/website/javascript/querystring.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/querystring.md
@@ -30,3 +30,23 @@ analytics.user().anonymousId('abc123');
 ```
 
 Each trigger parameter is optional. You can pass up to **one of each trigger parameter** as shown in the example above.
+
+
+## useQueryString option
+Using `useQueryString` option enable you to control the query parameters behaviour. For example, you can entirely disable query string processing by setting `useQueryString` to `false`:
+```
+analytics.load('<WRITE_KEY>', {
+  useQueryString: false
+})
+```
+It is also possible to keep query string processing on, but enforce validation rules. For example:
+```
+analytics.load('<WRITE_KEY>', {
+  useQueryString: {
+    // set a pattern for anonymous id 
+    aid: /([A-Z]{10})/,
+    // set a pattern for user id
+    uid: /([A-Z]{6})/
+  }
+})
+```

--- a/src/connections/sources/catalog/libraries/website/javascript/querystring.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/querystring.md
@@ -33,6 +33,9 @@ Each trigger parameter is optional. You can pass up to **one of each trigger par
 
 
 ## useQueryString option
+> info ""
+> Currently, the `useQueryString` option is only available when you load analytics.js through the [NPM package](https://www.npmjs.com/package/@segment/analytics-next){:target="_blank"}.
+
 Using `useQueryString` option enable you to control the query parameters behaviour. For example, you can entirely disable query string processing by setting `useQueryString` to `false`:
 ```
 analytics.load('<WRITE_KEY>', {

--- a/src/connections/sources/catalog/libraries/website/javascript/querystring.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/querystring.md
@@ -32,9 +32,7 @@ analytics.user().anonymousId('abc123');
 Each trigger parameter is optional. You can pass up to **one of each trigger parameter** as shown in the example above.
 
 
-## useQueryString option
-> info ""
-> Currently, the `useQueryString` option is only available when you load analytics.js through the [NPM package](https://www.npmjs.com/package/@segment/analytics-next){:target="_blank"}.
+## How can I turn off the query string processing or add a condition to when it should be tracked?
 
 Using `useQueryString` option enable you to control the query parameters behaviour. For example, you can entirely disable query string processing by setting `useQueryString` to `false`:
 ```
@@ -53,3 +51,6 @@ analytics.load('<WRITE_KEY>', {
   }
 })
 ```
+
+> info ""
+> Currently, the `useQueryString` option is **only** available when you load analytics.js through the [NPM package](https://www.npmjs.com/package/@segment/analytics-next){:target="_blank"}.

--- a/src/connections/sources/catalog/libraries/website/javascript/querystring.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/querystring.md
@@ -35,6 +35,7 @@ Each trigger parameter is optional. You can pass up to **one of each trigger par
 ## How can I control query string processing?
 
 The `useQueryString` option allows you to control the behavior of the query parameters. For example, you can entirely disable query string processing by setting `useQueryString` to `false`:
+
 ```js
 analytics.load('<WRITE_KEY>', {
   useQueryString: false

--- a/src/connections/sources/catalog/libraries/website/javascript/querystring.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/querystring.md
@@ -40,7 +40,9 @@ analytics.load('<WRITE_KEY>', {
   useQueryString: false
 })
 ```
+
 You can also keep query string processing on, but enforce validation rules. For example:
+
 ```js
 analytics.load('<WRITE_KEY>', {
   useQueryString: {


### PR DESCRIPTION
### Proposed changes
The Engineering team has just released a new feature for Querystring API - useQueryString which allows customers to optionally add constraints to how parameters from query string are processed. Constraints include but not limited to, maximum and/or minimum length.

Currently, it is available on the NPM version but not on the CDN version.

### Merge timing
ASAP once approved

### Related issues (optional)
- https://github.com/segmentio/analytics-next/pull/774
