### PR TITLE
Include a FAQ & Troubleshooting section

### DIFF
--- a/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
+++ b/src/connections/destinations/catalog/facebook-pixel-server-side/index.md
@@ -324,3 +324,12 @@ minutes. You can confirm that Facebook received them:
 > **Note**: It might take a few minutes before events appear in the Events Manager.
 
 ![Verify events in the Overview tab of the Events Manager](images/image2.png)
+
+## FAQ & Troubleshooting
+
+We're setting up Facebook Conversions API and have the following error message 
+"Unsupported post request. Object with ID 'XXXX' does not exist, cannot be loaded due to missing permissions, or does not support this operation. Please read the Graph API documentation at https://developers.facebook.com/docs/graph-api\". Any advice what we can do from here to integrate successfully?
+
+Usually, when this error appears, it is either an incorrect Pixel ID, or insufficient permissions. You would need to confirm the Pixel ID is right and that you have added Segment as a partner in your pixel as detailed here in the [Option 2 - Configure an existing pixel]([url](https://segment.com/docs/connections/destinations/catalog/facebook-pixel-server-side/#option-2---configure-an-existing-pixel))?
+
+


### PR DESCRIPTION
We get quite a few requests that are similar to this and believe that including this common error message will create more transparency for clients to understand the issue and how to resolve it. A customer also responded back to a csat mentioning how beneficial it would be for them in the docs; ” That was the perfect answer and should be included in the FAQ of the Destination (with the ID stripped out)”. This is the 
”From the error provided by FB, this appears to be an issue where the Pixel ID provided does not exist or there is a permissions' problem.

Unsupported post request. Object with ID 'XXXX' does not exist, cannot be loaded due to missing permissions, or does not support this operation. Please read the Graph API documentation at https://developers.facebook.com/docs/graph-api\

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
