### PR TITLE
Event tester limitation for destination filters

### DIFF
--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -31,6 +31,7 @@ Keep the following limitations in mind when you use destination filters:
 - *(For web device-mode)* Destination filters for web device-mode only supports the Analytics.js 2.0 source. You need to enable device mode destination filters for your Analytics.js source. To do this, go to your Javascript source and navigate to **Settings > Analytics.js** and turn the toggle on for **Destination Filters**.
 - *(For web device-mode)* Destination filters for device-mode only supports the Analytics.js 2.0 source.
 - *(For mobile device-mode)* Destination filters for mobile device-mode is currenlty not supported.
+- Destination Filters will not be applied to events sent via the destination Event Tester
 
 
 [Contact Segment](https://segment.com/help/contact/){:target="_blank"} if these limitations impact your use case.

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -31,7 +31,7 @@ Keep the following limitations in mind when you use destination filters:
 - *(For web device-mode)* Destination filters for web device-mode only supports the Analytics.js 2.0 source. You need to enable device mode destination filters for your Analytics.js source. To do this, go to your Javascript source and navigate to **Settings > Analytics.js** and turn the toggle on for **Destination Filters**.
 - *(For web device-mode)* Destination filters for device-mode only supports the Analytics.js 2.0 source.
 - *(For mobile device-mode)* Destination filters for mobile device-mode is currenlty not supported.
-- Destination Filters will not be applied to events sent via the destination Event Tester
+- Destination Filters will not be applied to events sent through the destination Event Tester
 
 
 [Contact Segment](https://segment.com/help/contact/){:target="_blank"} if these limitations impact your use case.

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -31,7 +31,7 @@ Keep the following limitations in mind when you use destination filters:
 - *(For web device-mode)* Destination filters for web device-mode only supports the Analytics.js 2.0 source. You need to enable device mode destination filters for your Analytics.js source. To do this, go to your Javascript source and navigate to **Settings > Analytics.js** and turn the toggle on for **Destination Filters**.
 - *(For web device-mode)* Destination filters for device-mode only supports the Analytics.js 2.0 source.
 - *(For mobile device-mode)* Destination filters for mobile device-mode is currenlty not supported.
-- Destination Filters will not be applied to events sent through the destination Event Tester
+- Destination Filters don't apply to events that send through the destination Event Tester.
 
 
 [Contact Segment](https://segment.com/help/contact/){:target="_blank"} if these limitations impact your use case.


### PR DESCRIPTION
Adding that the event tester does not respect destination filters

This is a very common question clients have when testing out destination filters

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
