### PR TITLE
Update value mapping on Order Completed event

### DIFF
--- a/src/connections/destinations/catalog/google-ads-gtag/index.md
+++ b/src/connections/destinations/catalog/google-ads-gtag/index.md
@@ -55,7 +55,7 @@ You can map your custom `.track()` events to any **Click Conversions** you creat
 
 If you pass `properties.value`, `properties.currency`, or `properties.order_id`, Segment maps them to Google's semantic `value`, `currency`, or `transaction_id` respectively.
 
-The only exception is that for `Order Completed` events, Segment will map Google's semantic `value` field to your `properties.revenue`.
+The only exception is that for `Order Completed` events, Segment will map Google's semantic `value` field to your `properties.revenue` or `properties.total`. Note that if you pass both as properties, `properties.revenue` takes precedence.
 
 ## Troubleshooting Google Ads Conversions
 To figure out if an event is flagged for conversion, follow these steps:

--- a/src/connections/destinations/catalog/google-ads-gtag/index.md
+++ b/src/connections/destinations/catalog/google-ads-gtag/index.md
@@ -55,7 +55,7 @@ You can map your custom `.track()` events to any **Click Conversions** you creat
 
 If you pass `properties.value`, `properties.currency`, or `properties.order_id`, Segment maps them to Google's semantic `value`, `currency`, or `transaction_id` respectively.
 
-The only exception is that for `Order Completed` events, Segment will map Google's semantic `value` field to your `properties.revenue` or `properties.total`. Note that if you pass both as properties, `properties.revenue` takes precedence.
+The only exception is that for `Order Completed` events, Segment will map Google's semantic `value` field to your `properties.revenue` or `properties.total`. If you pass both as properties, `properties.revenue` takes precedence.
 
 ## Troubleshooting Google Ads Conversions
 To figure out if an event is flagged for conversion, follow these steps:


### PR DESCRIPTION
### Proposed changes
For the Order Completed event, we actually map revenue/total properties (revenue take precedence) to Google's value field when using Google Ads (Gtag) destination.

source code: https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/gtag/lib/index.js#L506-L523 

### Merge timing
ASAP once approved
