### PR TITLE
Update Transfer To Workspace section w/ limitation

### DIFF
--- a/src/guides/usage-and-billing/account-management.md
+++ b/src/guides/usage-and-billing/account-management.md
@@ -49,4 +49,4 @@ To move a source between workspaces, navigate to the source's **Settings** tab, 
 > Segment recommends that you disconnect Tracking Plans from Sources before you initiate a workspace transfer. Once the transfer is complete, add and reconnect your Tracking Plans in the new workspace.
 
 > warning "Sources can't be transferred to EU workspaces"
-> Though transferring sources to the EU workspace is not blocked in the UI, the transfer will not work as expected. This feature is currently unsupported for cross region migration. We recommend re-creating the source from scratch in the new workspace.  
+> Though transferring sources to the EU workspace is not blocked in the UI, the transfer will not work as expected. This feature is currently unsupported for cross region migration. Segment recommends re-creating the source from scratch in the new workspace..  

--- a/src/guides/usage-and-billing/account-management.md
+++ b/src/guides/usage-and-billing/account-management.md
@@ -49,4 +49,4 @@ To move a source between workspaces, navigate to the source's **Settings** tab, 
 > Segment recommends that you disconnect Tracking Plans from Sources before you initiate a workspace transfer. Once the transfer is complete, add and reconnect your Tracking Plans in the new workspace.
 
 > warning "Sources can't be transferred to EU workspaces"
-> Though transferring sources to the EU workspace is not blocked in the UI, the transfer will not work as expected. This feature is currently unsupported for cross region migration. Segment recommends re-creating the source from scratch in the new workspace..  
+> Though transferring sources to the EU workspace is not blocked in the UI, the transfer will not work as expected. This feature is not supported for cross region migration. Segment recommends that you re-create the source in the new workspace. 

--- a/src/guides/usage-and-billing/account-management.md
+++ b/src/guides/usage-and-billing/account-management.md
@@ -47,3 +47,6 @@ To move a source between workspaces, navigate to the source's **Settings** tab, 
 
 > warning "Tracking Plans do not transfer"
 > Segment recommends that you disconnect Tracking Plans from Sources before you initiate a workspace transfer. Once the transfer is complete, add and reconnect your Tracking Plans in the new workspace.
+
+> warning "Sources can't be transferred to EU workspaces"
+> Though transferring sources to the EU workspace is not blocked in the UI, the transfer will not work as expected. This feature is currently unsupported for cross region migration. We recommend re-creating the source from scratch in the new workspace.  


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Updated this [section](https://segment.com/docs/guides/usage-and-billing/account-management/#can-i-move-a-source-from-one-workspace-to-another) of our public documentation in order to make customers aware they aren't able to transfer sources to EU workspaces.  This is currently not supported, however, our UI doesn't prevent users from trying which has misled customers in the past. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
