### PR TITLE
RN 2.0 partial

### DIFF
--- a/src/_includes/content/react2-dest.md
+++ b/src/_includes/content/react2-dest.md
@@ -14,4 +14,4 @@ The {{thisDestName}} device-mode destination SDK is only available for {{thisDes
 </p></div></div>
 {%endif%}
 
-To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using Segment's new `2.0` release, please reference our supported [Destination Plugin documentation](/docs/connections/sources/catalog/libraries/mobile/react-native/#supported-destinations).
+To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using Segment's new `2.0` release, please reference the supported [Destination Plugin documentation](/docs/connections/sources/catalog/libraries/mobile/react-native/#supported-destinations).

--- a/src/_includes/content/react2-dest.md
+++ b/src/_includes/content/react2-dest.md
@@ -1,0 +1,17 @@
+<!-- Usage: `include react-dest only={ios|android}` -->
+<!-- in the file we're pulling from the API, "name" corresponds with the path to the yml blob for a specific destination.-->
+{% assign currentSlug = page.url | split: "/" | last %}
+{% assign thisDest = site.data.catalog.destinations.items | where: "slug", currentSlug | first %}
+{% assign thisDestName = thisDest.display_name %}
+{% assign thisDestRNspecific = include.only %}
+
+
+{% if thisDestRNspecific %}
+<div class="premonition info">
+<div class="fa fa-info-circle"></div>
+<div class="content"><p>
+The {{thisDestName}} device-mode destination SDK is only available for {{thisDestRNspecific}} in React Native.
+</p></div></div>
+{%endif%}
+
+To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using Segment's new `2.0` release, please reference our supported [Destination Plugin documentation](/docs/connections/sources/catalog/libraries/mobile/react-native/#supported-destinations).

--- a/src/_includes/content/react2-dest.md
+++ b/src/_includes/content/react2-dest.md
@@ -14,4 +14,4 @@ The {{thisDestName}} device-mode destination SDK is only available for {{thisDes
 </p></div></div>
 {%endif%}
 
-To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using Segment's new `2.0` release, please reference the supported [Destination Plugin documentation](/docs/connections/sources/catalog/libraries/mobile/react-native/#supported-destinations).
+To add the {{thisDestName}} device-mode SDK to a [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) project using Segment's new `2.0` release, please reference the [Destination Plugin documentation](/docs/connections/sources/catalog/libraries/mobile/react-native/#supported-destinations).

--- a/src/connections/destinations/catalog/appsflyer/index.md
+++ b/src/connections/destinations/catalog/appsflyer/index.md
@@ -62,6 +62,8 @@ To prevent this, you can enable the new **Fallback to send IDFV when advertising
 
 #### Additional React Native device-mode set up
 
+{% include content/react2-dest.md %}
+
 {% include content/react-dest.md %}
 
 ### Server

--- a/src/connections/destinations/catalog/appsflyer/index.md
+++ b/src/connections/destinations/catalog/appsflyer/index.md
@@ -64,8 +64,6 @@ To prevent this, you can enable the new **Fallback to send IDFV when advertising
 
 {% include content/react2-dest.md %}
 
-{% include content/react-dest.md %}
-
 ### Server
 
 AppsFlyer offers an **augmentative** server-side [HTTP API](https://support.appsflyer.com/hc/en-us/articles/207034486-Server-to-Server-In-App-Events-API-HTTP-API-) intended for use along side the AppsFlyer mobile SDK. Use the cloud-mode destination _with_ the mobile SDK to link out-of-app events (such as website or offline purchases) with attributed users and devices.


### PR DESCRIPTION
### Proposed changes
Integrations that include the old RN partial link to the deprecated 1.X library can cause customer confusion. Removing this partial and creating a new one for the RN 2.0 destinations.
Old RN docs:
![Screenshot 2023-04-21 at 17 03 09](https://user-images.githubusercontent.com/16934916/233682736-c7220c51-a3e1-48a3-97dc-e58c4cb13006.png)

New 2.0 docs:
![Screenshot 2023-04-21 at 17 03 27](https://user-images.githubusercontent.com/16934916/233682791-46881c28-5613-49df-a384-7b84ec837b81.png)

**Note:**
Is the name of the new partial okay? 
```
src/_includes/content/react2-dest.md
```