### PR TITLE
Update PAPI availability to Team and BT only

### DIFF
--- a/src/_includes/content/papi-ga.html
+++ b/src/_includes/content/papi-ga.html
@@ -2,7 +2,7 @@
   <div class="fa fa-info-circle"></div>
   <div class="content">
     <p class="header">The Segment Public API is available</p>
-    <p markdown=1>Segment's [Public API](/docs/api/public-api) is available to use. You can use the Public API and Config APIs in parallel, but moving forward any API updates will come to the Public API exclusively. </p>
+    <p markdown=1>Segment's [Public API](/docs/api/public-api) is available for Team and Business tier customers to use. You can use the Public API and Config APIs in parallel, but moving forward any API updates will come to the Public API exclusively. </p>
     <p markdown=1>Please contact your account team or [friends@segment.com](mailto:friends@segment.com) with any questions.</p>
   </div>
 </div>


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Request from CS to include that only Team and BT users can access the Public API.
<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
