### PR TITLE
Add default mappings caveat (Amplitude Actions)

### DIFF
--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -207,7 +207,7 @@ To use Amplitude's groups with Segment, you must enable the following Action set
 Keep the following in mind if you plan to move to Amplitude (Actions) from a classic Amplitude destination.
 
 > info ""
-> Amplitude Classic uses different default mappings than Amplitude (Actions) in some cases (e.g. the `Viewed Home Page` event in Amplitude Classic will be `Viewed Home` in Amplitude Actions). Be sure to follow the steps in the Destination Actions documentation to [customize your mappings](https://segment.com/docs/connections/destinations/actions/#customizing-mappings). 
+> In some cases, Amplitude Classic uses different default mappings than Amplitude (Actions) (e.g. the Viewed Home Page event in Amplitude Classic will be Viewed Home in Amplitude Actions), unless configured to send as Viewed Home Page. Be sure to follow the steps in the Destination Actions documentation to [customize your mappings](https://segment.com/docs/connections/destinations/actions/#customizing-mappings). When customizing the mappings, make sure to review how the events appear in the destination, and configure the Actions' mappings properly to maintain continuity between Classic and Actions destinations.
 
 ### Amplitude (Actions) uses Amplitude's HTTP API v2
 

--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -206,6 +206,9 @@ To use Amplitude's groups with Segment, you must enable the following Action set
 
 Keep the following in mind if you plan to move to Amplitude (Actions) from a classic Amplitude destination.
 
+> info ""
+> Amplitude Classic uses different default mappings than Amplitude (Actions) in some cases (e.g. the `Viewed Home Page` event in Amplitude Classic will be `Viewed Home` in Amplitude Actions). Be sure to follow the steps in the Destination Actions documentation to [customize your mappings](https://segment.com/docs/connections/destinations/actions/#customizing-mappings). 
+
 ### Amplitude (Actions) uses Amplitude's HTTP API v2
 
 > warning ""

--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -207,7 +207,7 @@ To use Amplitude's groups with Segment, you must enable the following Action set
 Keep the following in mind if you plan to move to Amplitude (Actions) from a classic Amplitude destination.
 
 > info ""
-> In some cases, Amplitude Classic uses different default mappings than Amplitude (Actions) (e.g. the Viewed Home Page event in Amplitude Classic will be Viewed Home in Amplitude Actions), unless configured to send as Viewed Home Page. Be sure to follow the steps in the Destination Actions documentation to [customize your mappings](https://segment.com/docs/connections/destinations/actions/#customizing-mappings). When customizing the mappings, make sure to review how the events appear in the destination, and configure the Actions' mappings properly to maintain continuity between Classic and Actions destinations.
+> In some cases, Amplitude Classic uses different default mappings than Amplitude (Actions). For example, the `Viewed Home Page` event in Amplitude Classic will be `Viewed Home` in Amplitude Actions, unless you configure it as `Viewed Home Page`. Be sure to follow the steps in the Destination Actions documentation to [customize your mappings](/docs/connections/destinations/actions/#customizing-mappings). Review how events appear in each destination, and configure the Actions' mappings properly to maintain continuity between Classic and Actions destinations.
 
 ### Amplitude (Actions) uses Amplitude's HTTP API v2
 


### PR DESCRIPTION
### Proposed changes
- When a customer migrates from Amplitude Classic to Amplitude Actions, they should be mindful to make sure that they customize their mappings
- This is already mentioned under "Getting Started", but it might be helpful if it's mentioned under the "Migration from Amplitude Classic" section as well

### Merge timing
- ASAP once approved?

