### PR TITLE
Can't send null values to GA4

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -152,7 +152,7 @@ The Segment Google Analytics 4 Cloud destination supports sending mobile app eve
 
 ### Reserved Names
 
-Google reserves certain event names, parameters, and user properties. Google silently drops any events that include [these reserved names](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#reserved_names){:target="_blank"}. Google also will not except events where event or user property names have spaces in them. If you notice that your data isn't appearing in Google, please check that you're not using a reserved name. 
+Google reserves certain event names, parameters, and user properties. Google silently drops any events that include [these reserved names](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#reserved_names){:target="_blank"}. Google also will not except events where event or user property names have spaces in them. If you notice that your data isn't appearing in Google, please check that you're not using a reserved name. You also cannot send fields with `null` values to Google. 
 
 ### Data taking a long time to appear in Google's reports
 


### PR DESCRIPTION
### Proposed changes

This addition lets customers know that `null` values can't be sent to Google.

### Merge timing
ASAP is fine

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
