### PR TITLE
Update go module url

### DIFF
--- a/src/connections/sources/catalog/libraries/server/go/quickstart.md
+++ b/src/connections/sources/catalog/libraries/server/go/quickstart.md
@@ -27,7 +27,7 @@ When you create a Source in the Segment web app, it tells the Segment servers th
 Installing our Go library is easy, just run the following:
 
 ```bash
-go get gopkg.in/segmentio/analytics-go.v3
+go get github.com/segmentio/analytics-go/v3
 ```
 
 Then just import the library and initialize a new client your Segment source's **Write Key**, like so:


### PR DESCRIPTION
It looks like the go module is now at `go get github.com/segmentio/analytics-go/v3`

Following the docs a user gets this warning:

```
% go get gopkg.in/segmentio/analytics-go.v3

go: downloading gopkg.in/segmentio/analytics-go.v3 v3.2.1
go: gopkg.in/segmentio/analytics-go.v3@v3.2.1: parsing go.mod:
	module declares its path as: github.com/segmentio/analytics-go/v3
	        but was required as: gopkg.in/segmentio/analytics-go.v3
```

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
