### PR TITLE
GAclientId may cause user merge

### DIFF
--- a/src/unify/identity-resolution/externalids.md
+++ b/src/unify/identity-resolution/externalids.md
@@ -35,7 +35,7 @@ Segment automatically promotes the following traits and IDs in track and identif
 | ios.push_token     | context.device.token when context.device.type = 'ios'                                                         |
 
 > note ""
-> The Google clientID(ga_clientid) is a unique value created for each browser-device pair and will exist for 2 years if the cookie is not cleared. The analytics.reset() call will be triggered from Segment end when the user logs off. This call will clear the cookies and local Storage created by Segment. It doesn’t clear data from other integrated tools. So on the next login, the user will be assigned with unique anonymous_id but with the same ga_clientid(as the cookie is not cleared). Hence, the profiles with different anonymous_id but with same ga_clientid will get merged.
+> The Google clientID(ga_clientid) is a unique value created for each browser-device pair and will exist for 2 years if the cookie is not cleared. The analytics.reset() call should be triggered from Segment end when the user logs off. This call will clear the cookies and local Storage created by Segment. It doesn’t clear data from other integrated tools. So on the next login, the user will be assigned with a new unique anonymous_id, but the same ga_clientid will remain if this cookie is not cleared. Hence, the profiles with different anonymous_id but with same ga_clientid will get merged.
 
 ## Custom externalIDs
 

--- a/src/unify/identity-resolution/externalids.md
+++ b/src/unify/identity-resolution/externalids.md
@@ -34,6 +34,9 @@ Segment automatically promotes the following traits and IDs in track and identif
 | ios.idfa           | context.device.advertisingId when context.device.type = 'ios'     |
 | ios.push_token     | context.device.token when context.device.type = 'ios'                                                         |
 
+> note ""
+> The Google clientID(ga_clientid) is a unique value created for each browser-device pair and will exist for 2 years if the cookie is not cleared. The analytics.reset() call will be triggered from Segment end when the user logs off. This call will clear the cookies and local Storage created by Segment. It doesn’t clear data from other integrated tools. So on the next login, the user will be assigned with unique anonymous_id but with the same ga_clientid(as the cookie is not cleared). Hence, the profiles with different anonymous_id but with same ga_clientid will get merged.
+
 ## Custom externalIDs
 
 Unify resolves identity for any other externalIDs that you bind to users - such as a phone number or any custom identifier that you support.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

The Google clientID(ga_clientid) is a unique value created for each browser-device pair and will exist for 2 years if the cookie is not cleared. The analytics.reset() call will be triggered from Segment end when the user logs off. This call will clear the cookies and local Storage created by Segment. It doesn’t clear data from other integrated tools. So on the next login, the user will be assigned with unique anonymous_id but with the same ga_clientid(as the cookie is not cleared). Hence, the profiles with different anonymous_id but with same ga_clientid will get merged.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
