### PR TITLE
Add info about $value mapping for Klaviyo's Track events

### DIFF
--- a/src/connections/destinations/catalog/klaviyo/index.md
+++ b/src/connections/destinations/catalog/klaviyo/index.md
@@ -142,6 +142,8 @@ analytics.track({
 
 When you call `track` on `analytics.js`, Segment calls Klaviyo's `track` with the same parameters.
 
+If you include `properties.revenue` in Track event, Segment maps it to Klaviyo's event `$value`.
+
 > info ""
 > When you're tracking client-side, some Klaviyo events require you send an Identify call  before a Track call. 
 

--- a/src/connections/destinations/catalog/klaviyo/index.md
+++ b/src/connections/destinations/catalog/klaviyo/index.md
@@ -142,7 +142,7 @@ analytics.track({
 
 When you call `track` on `analytics.js`, Segment calls Klaviyo's `track` with the same parameters.
 
-If you include `properties.revenue` in Track event, Segment maps it to Klaviyo's event `$value`.
+If you include `properties.revenue` in a track event, Segment maps it to Klaviyo's `$value` event.
 
 > info ""
 > When you're tracking client-side, some Klaviyo events require you send an Identify call  before a Track call. 


### PR DESCRIPTION
### Proposed changes
Checking our source code for Klaviyo device-mode destination: https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/klaviyo/lib/index.js#L109-L117  

We map the `revenue` property from Segment's Track event to Klaviyo's `$value` field. 

So, when customers include a revenue property in Track events, they will see unexpected fields in Klaviyo:
![image](https://user-images.githubusercontent.com/37472597/234807521-fe751736-1782-42be-bb59-d5f8e0482cdb.png)


### Merge timing
ASAP once approved
