### PR TITLE
Add warning for traits with "not computing" status

### DIFF
--- a/src/engage/audiences/computed-traits.md
+++ b/src/engage/audiences/computed-traits.md
@@ -163,7 +163,10 @@ For account-level computed traits, you have the option to send either a [group](
 
 ## View compute status
 
-After you create a computed trait, use the Overview page to view the current [compute status](/docs/engage/audiences#compute-statuses), number of users with the trait, connected destinations, and more. For real-time traits, click **Refresh Trait** to update the current number of users with the trait.  
+After you create a computed trait, use the Overview page to view the current [compute status](/docs/engage/audiences#compute-statuses), number of users with the trait, connected destinations, and more. For real-time traits, click **Refresh Trait** to update the current number of users with the trait. 
+
+> warning ""
+> If a destination hasn't been connected to a computed trait, the trait's status will show as "Not Computing" until a destination is connected, or if the flag for "Compute without enabled destinations" is enabled in the computed trait's settings.
 
 ## Editing Realtime Traits
 


### PR DESCRIPTION
### Proposed changes

Computed traits docs do not currently mention why a trait may show "not computing" as the status - added a warning that highlights why this status surfaces and how to resolve it.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
