### PR TITLE
Add section to Frequently Asked Questions - Profiles Sync

### DIFF
--- a/src/unify/profiles-sync/sample-queries.md
+++ b/src/unify/profiles-sync/sample-queries.md
@@ -197,5 +197,5 @@ By contrast, Segment Unify and incrementally-built Profiles Sync materialization
 
 #### What hash function is used for the external_id_hash field by Profile Sync?
 
-The value of the `external_id_hash` is a hash of the `external_id_type` and `external_id_value`, using SHA-1. This field corresponds the `primary_key` for the table. `hash ( external_id_type and external_id_value)`
+The `external_id_hash` is a hash of the `external_id_type` and `external_id_value` using SHA-1. This field corresponds to the `primary_key` for the table: `hash (external_id_type and external_id_value)`
 For example, in Big Query this is the logic, `TO_HEX(SHA1(concat(external_id_type, external_id_value))) as seg_hash`.

--- a/src/unify/profiles-sync/sample-queries.md
+++ b/src/unify/profiles-sync/sample-queries.md
@@ -198,4 +198,4 @@ By contrast, Segment Unify and incrementally-built Profiles Sync materialization
 #### What hash function is used for the external_id_hash field by Profile Sync?
 
 The `external_id_hash` is a hash of the `external_id_type` and `external_id_value` using SHA-1. This field corresponds to the `primary_key` for the table: `hash (external_id_type and external_id_value)`
-For example, in Big Query this is the logic, `TO_HEX(SHA1(concat(external_id_type, external_id_value))) as seg_hash`.
+For example, in BigQuery the logic is: `TO_HEX(SHA1(concat(external_id_type, external_id_value))) as seg_hash`.

--- a/src/unify/profiles-sync/sample-queries.md
+++ b/src/unify/profiles-sync/sample-queries.md
@@ -197,5 +197,5 @@ By contrast, Segment Unify and incrementally-built Profiles Sync materialization
 
 #### What hash function is used for the external_id_hash field by Profiles Sync?
 
-The `external_id_hash` is a hash of the `external_id_type` and `external_id_value` using SHA-1. This field corresponds to the `primary_key` for the table: `hash (external_id_type and external_id_value)`
+The `external_id_hash` is a hash of the `external_id_type` and `external_id_value` using SHA-1. This field corresponds to the `primary_key` for the table: `hash (external_id_type and external_id_value)`.
 For example, in BigQuery the logic is: `TO_HEX(SHA1(concat(external_id_type, external_id_value))) as seg_hash`.

--- a/src/unify/profiles-sync/sample-queries.md
+++ b/src/unify/profiles-sync/sample-queries.md
@@ -195,7 +195,7 @@ The following edge cases might drive slight (<0.01%) variation:
 
 By contrast, Segment Unify and incrementally-built Profiles Sync materializations won’t combine already-computed traits across two merged profiles at the moment of merge. Instead, one profile’s traits will be chosen across the board.
 
-#### What hash function is used for the external_id_hash field by Profile Sync?
+#### What hash function is used for the external_id_hash field by Profiles Sync?
 
 The `external_id_hash` is a hash of the `external_id_type` and `external_id_value` using SHA-1. This field corresponds to the `primary_key` for the table: `hash (external_id_type and external_id_value)`
 For example, in BigQuery the logic is: `TO_HEX(SHA1(concat(external_id_type, external_id_value))) as seg_hash`.

--- a/src/unify/profiles-sync/sample-queries.md
+++ b/src/unify/profiles-sync/sample-queries.md
@@ -194,3 +194,8 @@ The following edge cases might drive slight (<0.01%) variation:
 - If you rebuild or use non-incremental materialization for `profile_traits`, Profiles Sync will fully calculate traits against a user. As a result, Profiles Sync would ensure that all traits reflect the most recently observed value for fully-merged users.
 
 By contrast, Segment Unify and incrementally-built Profiles Sync materializations won’t combine already-computed traits across two merged profiles at the moment of merge. Instead, one profile’s traits will be chosen across the board.
+
+#### What hash function is used for the external_id_hash field by Profile Sync?
+
+The value of the `external_id_hash` is a hash of the `external_id_type` and `external_id_value`, using SHA-1. This field corresponds the `primary_key` for the table. `hash ( external_id_type and external_id_value)`
+For example, in Big Query this is the logic, `TO_HEX(SHA1(concat(external_id_type, external_id_value))) as seg_hash`.


### PR DESCRIPTION
What hash function is used for the external_id_hash field by Profile Sync? Zendesk Ticket : https://segment.zendesk.com/agent/tickets/503271

<!--Thanks for helping! Remove these comments as you go.-->

#### What hash function is used for the external_id_hash field by Profile Sync?

The value of the `external_id_hash` is a hash of the `external_id_type` and `external_id_value`, using SHA-1. This field corresponds the `primary_key` for the table. `hash ( external_id_type and external_id_value)`
For example, in Big Query this is the logic, `TO_HEX(SHA1(concat(external_id_type, external_id_value))) as seg_hash`.


Customer (MongoDB) reached out in March wondering what hashing algorithm is used by the Profiles Sync, no docs stated this anywhere though it's obvious that a hashing algorithm is used. Since this page is technical listing Profiles Sync Sample Queries, it's likely other customers would also want this information in order to un-hash (decrypt) their user data.

### Merge timing

- anytime once approved

### Related issues (optional)
n/a
