### PR TITLE
Building an Audience - info on selection to Include Anonymous Users

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -18,7 +18,7 @@ You can build an Audience from existing events, traits, computed traits, or othe
 
 ![Creating an Engage Audience from the conditions list](/docs/engage/images/audience_condition_list.png)
 
-There's also the option to _Include Anonymous Users_, which are profiles that only have anonymousIds. When this option is not selected, users who have a userId, email address, android.idfa, or ios.idfa are considered known users and thus included in the audience by default. The option to select _Include Anonymous Users_ is only available upon the initial creation of the audience and cannot be changed by an edit post-creation.
+There's also the option to **Include Anonymous Users**, which are profiles that only have `anonymousIds`. When this option is not selected, users who have a `userId`, `email address`, `android.idfa`, or `ios.idfa` are considered known users and included in the audience by default. The option to select **Include Anonymous Users** is only available upon the initial creation of the audience and can't be changed post-creation.
 
 ### Events
 

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -18,7 +18,7 @@ You can build an Audience from existing events, traits, computed traits, or othe
 
 ![Creating an Engage Audience from the conditions list](/docs/engage/images/audience_condition_list.png)
 
-There's also the option to _Include Anonymous Users_, which when selected will also include users who do not currently have a userId associated with their profile. When this is not selected, users who have a userId, email address, android.idfa, or ios.idfa are considered known users and thus included in the audience by default. The option to select _Include Anonymous Users_ is only available upon the initial creation of the audience and cannot be changed by an edit post-creation.
+There's also the option to _Include Anonymous Users_, which are profiles that only have anonymousIds. When this option is not selected, users who have a userId, email address, android.idfa, or ios.idfa are considered known users and thus included in the audience by default. The option to select _Include Anonymous Users_ is only available upon the initial creation of the audience and cannot be changed by an edit post-creation.
 
 ### Events
 

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -18,6 +18,8 @@ You can build an Audience from existing events, traits, computed traits, or othe
 
 ![Creating an Engage Audience from the conditions list](/docs/engage/images/audience_condition_list.png)
 
+There's also the option to _Include Anonymous Users_, which when selected will also include users who do not currently have a userId associated with their profile. When this is not selected, users who have a userId, email address, android.idfa, or ios.idfa are considered known users and thus included in the audience by default. The option to select _Include Anonymous Users_ is only available upon the initial creation of the audience and cannot be changed by an edit post-creation.
+
 ### Events
 
 You can build an Audience from any events that are connected to Engage, including [Track](/docs/connections/spec/track), [Page](/docs/connections/spec/page), and [Screen](/docs/connections/spec/screen) calls. You can use the `property` button to refine the audience on specific event properties, as well. Select `and not who` to indicate users that have not performed an event. For example, you might want to look at all users that have viewed a product above a certain price point but not completed the order.


### PR DESCRIPTION
Adding this section will ensure that customers see that option and know the implications for selecting it or leaving it unselected. Tickets : https://segment.zendesk.com/agent/tickets/503318, https://segment.zendesk.com/agent/tickets/419010

> There’s also the option to _Include Anonymous Users_, which when selected will also include users who do not currently have a userId associated with their profile. When this is not selected, users who have a userId, email address, android.idfa, or ios.idfa are considered known users and thus included in the audience by default. The option to select _Include Anonymous Users_ is only available upon the initial creation of the audience and cannot be changed by an edit post-creation.

Customers may not be aware that this is not something they can modify at a later date. It’s also unstated anywhere within our docs for what a “known” and an “anonymous” user is, which is important to understand why users are included in an audience though they may not have a userId but do have an email, android.idfa, or ios.idfa.

### Merge timing

- ASAP once approved

### Related issues (optional)

