### PR TITLE
Instructions to download mappings via Public API

### DIFF
--- a/src/connections/destinations/catalog/adobe-analytics/settings.md
+++ b/src/connections/destinations/catalog/adobe-analytics/settings.md
@@ -629,3 +629,7 @@ This option is only available when you use a cloud mode (also called server-side
     }
  });
 ```
+### Download Your Mappings With Segment’s Public API
+
+You can download your Adobe Destination’s mappings by sending a GET request to Segment’s [Public API]([url](https://segment.com/docs/api/public-api/)) endpoint for [Get Destination]([url](https://docs.segmentapis.com/tag/Destinations#operation/getDestination)). The response from the Public API will include the field names for both the Segment fields and Adobe fields.
+The Endpoint : `https://api.segmentapis.com/destinations/{destinationId}/`

--- a/src/connections/destinations/catalog/adobe-analytics/settings.md
+++ b/src/connections/destinations/catalog/adobe-analytics/settings.md
@@ -629,7 +629,7 @@ This option is only available when you use a cloud mode (also called server-side
     }
  });
 ```
-### Download Your Mappings With Segment’s Public API
+### Download mappings with the Segment Public API
 
-You can download your Adobe Destination’s mappings by sending a GET request to Segment’s [Public API]([url](https://segment.com/docs/api/public-api/)) endpoint for [Get Destination]([url](https://docs.segmentapis.com/tag/Destinations#operation/getDestination)). The response from the Public API will include the field names for both the Segment fields and Adobe fields.
-The Endpoint : `https://api.segmentapis.com/destinations/{destinationId}/`
+Download your Adobe Destination mappings by sending a GET request to Segment’s [Public API](/docs/api/public-api/) endpoint for [Get Destination](https://docs.segmentapis.com/tag/Destinations#operation/getDestination). The response from the Public API includes the field names for both the Segment fields and Adobe fields.
+The endpoint: `https://api.segmentapis.com/destinations/{destinationId}/`


### PR DESCRIPTION
Customers may not be aware that this option is available, which might make it easier to compare their mappings between multiple instances of Adobe destinations within Segment. Zendesk ticket : https://segment.zendesk.com/agent/tickets/505734


### Proposed changes

> ### Download Your Mappings With Segment’s Public API
> 
> You can download your Adobe Destination’s mappings by sending a GET request to Segment’s [Public API]([url](https://segment.com/docs/api/public-api/)) endpoint for [Get Destination]([url](https://docs.segmentapis.com/tag/Destinations#operation/getDestination)). The response from the Public API will include the field names for both the Segment fields and Adobe fields.
> The Endpoint : `https://api.segmentapis.com/destinations/{destinationId}/`

Customers may not be aware that this option is available, which might make it easier to compare their mappings between multiple instances of Adobe destinations within Segment. This was the case for the customer in the ticket below.
Zendesk ticket : https://segment.zendesk.com/agent/tickets/505734

### Merge timing

- any time once approved

### Related issues (optional)
