### PR TITLE
csharp redirect

### DIFF
--- a/src/connections/sources/catalog/libraries/server/csharp/index.md
+++ b/src/connections/sources/catalog/libraries/server/csharp/index.md
@@ -3,7 +3,8 @@ title: Analytics for CSharp (C#)
 strat: csharp
 id: 
 redirect_from:
-   - '/connections/sources/catalog/libraries/mobile/unity'          
+   - '/connections/sources/catalog/libraries/mobile/unity'
+   - '/connections/sources/catalog/libraries/mobile/csharp/'          
 ---
 
 With Analytics-CSharp, you can add Segment analytics to your C# based app which includes Unity, Xamarin, .NET. Analytics-CSharp helps you measure your users, product, and business. It unlocks insights into your app's funnel, core business metrics, and whether you have product-market fit. The Analytics-CSharp library is open-source [on GitHub](https://github.com/segmentio/analytics-csharp){:target="_blank"}. 


### PR DESCRIPTION
added a redirect link for the C# tile until we figure out why the tile is showing on the docs site and get that hidden
