### PR TITLE
Adding Engage silent drop limitations

### DIFF
--- a/src/engage/product-limits.md
+++ b/src/engage/product-limits.md
@@ -11,6 +11,15 @@ To provide consistent performance and reliability at scale, Segment enforces def
 To learn more about custom limits and upgrades, contact your dedicated Customer Success Manager or [friends@segment.com](mailto:friends@segment.com).
 
 
+## Engage Ingestion Limits
+
+Engage silently drops inbound events if:
+- The groupId has more than 500 characters.
+- Events have more than 500 characters.
+- The messageId is longer than 100 characters.
+- The groupId is empty in a group call or context.groupId is empty in a track call.
+
+
 ## Default Limits
 
 | Name                                        | limit                                                       | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |


### PR DESCRIPTION
Adding some limitations that Engage has on ingesting events before the event is silently dropped.  The limitations focus mainly on charcter length for different fields such as messgeId.


### Proposed changes

There are a few limitations on incoming events before the event is ingested by Engage.  For example, an event will be silently dropped by Engage if the messageId is more than 100 characters.  This information is available internally, but would benefit customers to know publically, since customers could further troubleshoot issues independent of support tickets. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
