### PR TITLE
Added information that the Engage generated source should not be disabled

### DIFF
--- a/src/unify/debugger.md
+++ b/src/unify/debugger.md
@@ -7,18 +7,18 @@ redirect_from:
 
 The Profile Source Debugger enables you to inspect and monitor events that Segment sends downstream
 
-Because Segment generates a unique Source for every Destination connected to a Space, the Debugger gives you insight into how Segment sends events before they reach their Destination. This automatically generated source cannot be deleted and should not be disabled even when the destination is removed, in order for Segment to function as designed. The source will be reused by Segment as needed.
+Because Segment generates a unique source for every destination connected to a Space, the Debugger gives you insight into how Segment sends events before they reach their destination. Even when a destination is removed, you can't delete and shouldn't disable this source for Segment to function as designed. The source will be reused by Segment as needed.
 
-The Debugger provides you with the payload information you need to troubleshoot potential formatting issues and ensure Segment sends events as your Destinations expect.
+The Debugger provides you with the payload information you need to troubleshoot potential formatting issues and ensure Segment sends events as your destinations expect.
 
 ## Working with the Debugger
- 
-Navigate to the Debugger tab on the Unify settings page of the space you want to debug. Select the Source you want to inspect in the Debugger.
+
+Navigate to the Debugger tab on the Unify settings page of the space you want to debug. Select the source you want to inspect in the Debugger.
 
 The Debugger presents a stream of incoming events. The event inspector displays three tabs for each event:
 
-* **Pretty view** shows the actual API call Segment sends to your Destination.
-* **Raw view** shows the full JSON object Segment sends to your Destination from the calls you sent, including timestamps, properties, traits, and ids.
+* **Pretty view** shows the actual API call Segment sends to your destination.
+* **Raw view** shows the full JSON object Segment sends to your destination from the calls you sent, including timestamps, properties, traits, and ids.
 * **Violations** displays any violations triggered by the event.
 
 Similar to the Connections Debugger, you can search through events using information contained within the event's payload.

--- a/src/unify/debugger.md
+++ b/src/unify/debugger.md
@@ -7,7 +7,7 @@ redirect_from:
 
 The Profile Source Debugger enables you to inspect and monitor events that Segment sends downstream
 
-Because Segment generates a unique Source for every Destination connected to a Space, the Debugger gives you insight into how Segment sends events before they reach their Destination. This automatically generated source cannot be deleted even when the destination is removed, in order for Segment to function as designed. The source will be reused by Segment as needed.
+Because Segment generates a unique Source for every Destination connected to a Space, the Debugger gives you insight into how Segment sends events before they reach their Destination. This automatically generated source cannot be deleted and should not be disabled even when the destination is removed, in order for Segment to function as designed. The source will be reused by Segment as needed.
 
 The Debugger provides you with the payload information you need to troubleshoot potential formatting issues and ensure Segment sends events as your Destinations expect.
 


### PR DESCRIPTION
### Proposed changes
Added information that the source should not be disabled also. As there were tickets where customers disabled these sources and result in audiences/traits not synching to destinations.

Original sentence:
This automatically generated source cannot be deleted even when the destination is removed, in order for Segment to function as designed. The source will be reused by Segment as needed.

Added "and should not be disabled" and modified to: 
This automatically generated source cannot be deleted and should not be disabled even when the destination is removed, in order for Segment to function as designed. The source will be reused by Segment as needed.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)
<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
https://segment.zendesk.com/agent/tickets/506372

