### PR TITLE
Update email and sms subscription field.md

### DIFF
--- a/src/engage/user-subscriptions/subscription-sql.md
+++ b/src/engage/user-subscriptions/subscription-sql.md
@@ -36,8 +36,8 @@ To configure Subscriptions with SQL Traits, you can write your own query or clic
 > Click **Reset Template** to reset your SQL query.
 
 Queries must return at least one pair of the columns below with a value of `subscribed`, `unsubscribed`, or `did_not_subscribe`:
-- `email` and `_segment_internal_email_subscription_`
-- `phone` and `_segment_internal_sms_subscription_`
+- `email` and `__segment_internal_email_subscription__`
+- `phone` and `__segment_internal_sms_subscription__`
 
 For more subscription SQL best practices, view the [query requirements](#query-requirements) below.
 


### PR DESCRIPTION
These fields need double underscores instead of just 1. Changing values to __segment_internal_email_subscription__ & __segment_internal_sms_subscription__

This is needed to match what is mentioned in the UI:

Subscription states
When your identity resolution configuration includes an email or phone identifier, you may assign a subscription status using the __segment_internal_email_subscription__ and __segment_internal_whatsapp_subscription__ and __segment_internal_sms_subscription__ columns.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
