### PR TITLE
Add information that editing is locked until resume process completes

### DIFF
--- a/src/engage/journeys/build-journey.md
+++ b/src/engage/journeys/build-journey.md
@@ -90,7 +90,7 @@ Follow these steps to resume entry to a paused Journey:
 1. Select the **Journeys** tab within your Engage space.
 2. Select the **More Options** icon next to the Journey you want to resume.
 3. From the dropdown menu, select **Resume Entry**.
-4. A modal window appears. Select **Resume Entry** again to confirm.
+4. A modal window appears. Select **Resume Entry** again to confirm. After the confirmation, editing is locked until the Journey Resume process completes.
 
 ### Cloning a Journey
 

--- a/src/engage/journeys/build-journey.md
+++ b/src/engage/journeys/build-journey.md
@@ -90,7 +90,7 @@ Follow these steps to resume entry to a paused Journey:
 1. Select the **Journeys** tab within your Engage space.
 2. Select the **More Options** icon next to the Journey you want to resume.
 3. From the dropdown menu, select **Resume Entry**.
-4. A modal window appears. Select **Resume Entry** again to confirm. After the confirmation, editing is locked until the Journey Resume process completes.
+4. A modal window appears. Select **Resume Entry** again to confirm. After the confirmation, editing locks until the Journey Resume process completes.
 
 ### Cloning a Journey
 


### PR DESCRIPTION
### Proposed changes
Customer is not aware that editing is locked when resumes is triggered. Provide the information in the public document so that customer is aware of the behavior when they see that editing is locked.

Added information that when journey resume is triggered, editing is locked until the resume process completes.

Original sentence:
"4. A modal window appears. Select **Resume Entry** again to confirm."

Modified to:
"4. A modal window appears. Select **Resume Entry** again to confirm. After the confirmation, editing is locked until the Journey Resume process completes."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
https://segment.zendesk.com/agent/tickets/506624
https://twilio.slack.com/archives/C01L65AUTF1/p1682564382741599