### PR TITLE
Updated the data type under the Conditions section

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -166,7 +166,7 @@ The available operators depend on the property's data type:
 | Data Type         | Supported Operators                                                                          |
 | ----------------- | -------------------------------------------------------------------------------------------- |
 | string            | `is`, `is not`, `contains`,  `does not contain`, `starts with`, `ends with`                  |
-| string or numeric | `is less than`, `is less than or equal to`, `is greater than`, `is greater than or equal to` |
+| numeric           | `is less than`, `is less than or equal to`, `is greater than`, `is greater than or equal to` |
 | boolean           | `is true`, `is false`                                                                        |
 
 You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY to “subscribe” to multiple conditions. Use ALL when you need to filter for very specific conditions. You can only create one group condition per destination action. You cannot created nested conditions.


### PR DESCRIPTION
### Proposed changes

Modified the Data Type from "string or numeric" to only "numeric" since using any of those supported operators with a string value will prevent the event from sending to the destination.

This will indicate to our users to only use numeric values when selecting these supported operators.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
