### PR TITLE
Update HubSpot Source to add custom property instructions

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/hubspot/index.md
+++ b/src/connections/sources/catalog/cloud-apps/hubspot/index.md
@@ -61,7 +61,10 @@ Due to HubSpot's [API Rate Limits](http://developers.hubspot.com/apps/api_guidel
 
 Below are tables outlining the properties included in the collections listed above. To see the full description of each property, refer to the HubSpot documentation linked in the collections above.
 
-If you have Custom Properties on Contacts or Companies collections that you would like to sync, submit a ticket detailing the custom properties [here](http://segment.com/help/contact) and we can enable it for you. **Note:** For Deals collection, Segment pulls whatever properties the HubSpot API returns, which means you can add the new fields on your own from HubSpot if you have the necessary permissions.
+If you have Custom Properties on Contacts or Companies collections that you would like to sync, submit a ticket detailing the custom properties [here](http://segment.com/help/contact) and we can enable it for you. 
+
+> info ""
+> For Deals collection, Segment retrieves properties that the HubSpot API returns, which means you can add the new fields on your own from HubSpot if you have the necessary permissions.
 
 ### Contacts
 

--- a/src/connections/sources/catalog/cloud-apps/hubspot/index.md
+++ b/src/connections/sources/catalog/cloud-apps/hubspot/index.md
@@ -61,7 +61,7 @@ Due to HubSpot's [API Rate Limits](http://developers.hubspot.com/apps/api_guidel
 
 Below are tables outlining the properties included in the collections listed above. To see the full description of each property, refer to the HubSpot documentation linked in the collections above.
 
-If you have Custom Properties on Contacts or Companies collections that you would like to sync, submit a ticket detailing the custom properties [here](http://segment.com/help/contact) and we can enable it for you. 
+If you have Custom Properties on Contacts or Companies collections that you would like to sync, submit a ticket detailing the custom properties [here](http://segment.com/help/contact){:target="_blank"}.
 
 > info ""
 > For Deals collection, Segment retrieves properties that the HubSpot API returns, which means you can add the new fields on your own from HubSpot if you have the necessary permissions.

--- a/src/connections/sources/catalog/cloud-apps/hubspot/index.md
+++ b/src/connections/sources/catalog/cloud-apps/hubspot/index.md
@@ -61,7 +61,7 @@ Due to HubSpot's [API Rate Limits](http://developers.hubspot.com/apps/api_guidel
 
 Below are tables outlining the properties included in the collections listed above. To see the full description of each property, refer to the HubSpot documentation linked in the collections above.
 
-If you have Custom Properties on Contacts or Companies collections that you would like to sync, submit a ticket detailing the custom properties [here](http://segment.com/help/contact) and we can enable it for you. **Note:** For Deals collection, Segment pulls whatever properties the HubSpot API returns, which means you can add the new fileds on your own from HubSpot.
+If you have Custom Properties on Contacts or Companies collections that you would like to sync, submit a ticket detailing the custom properties [here](http://segment.com/help/contact) and we can enable it for you. **Note:** For Deals collection, Segment pulls whatever properties the HubSpot API returns, which means you can add the new fields on your own from HubSpot if you have the necessary permissions.
 
 ### Contacts
 

--- a/src/connections/sources/catalog/cloud-apps/hubspot/index.md
+++ b/src/connections/sources/catalog/cloud-apps/hubspot/index.md
@@ -61,7 +61,7 @@ Due to HubSpot's [API Rate Limits](http://developers.hubspot.com/apps/api_guidel
 
 Below are tables outlining the properties included in the collections listed above. To see the full description of each property, refer to the HubSpot documentation linked in the collections above.
 
-If you have Custom Properties on any of these collections that you would like to sync, submit a ticket detailing the custom properties [here](http://segment.com/help/contact) and we can enable it for you.
+If you have Custom Properties on Contacts or Companies collections that you would like to sync, submit a ticket detailing the custom properties [here](http://segment.com/help/contact) and we can enable it for you. **Note:** For Deals collection, Segment pulls whatever properties the HubSpot API returns, which means you can add the new fileds on your own from HubSpot.
 
 ### Contacts
 


### PR DESCRIPTION
### Proposed changes

Customers often create tickets to include custom properties of Deals collection as the doc states that Support can help with adding custom fields to any collection. In reality, CSEng can only run commands to add custom properties to companies or contacts collections. For deals, Segment will pull whatever properties the API returns, as long as the permissions are correct. This would help our customers to get this info without having to create a ticket each time. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
