### PR TITLE
Add missing "Spec: Alias" to sidenav

### DIFF
--- a/src/_data/sidenav/main.yml
+++ b/src/_data/sidenav/main.yml
@@ -112,6 +112,8 @@ sections:
       title: 'Spec: Group'
     - path: /connections/spec/identify
       title: 'Spec: Identify'
+    - path: /connections/spec/alias
+      title: 'Spec: Alias'
     - path: /connections/spec/common
       title: 'Spec: Common Fields'
     - path: /connections/spec/mobile

--- a/src/_data/sidenav/main.yml
+++ b/src/_data/sidenav/main.yml
@@ -173,9 +173,9 @@ sections:
       title: Reverse ETL Overview
     - path: /connections/reverse-etl/reverse-etl-catalog
       title: Reverse ETL Catalog
-    - section_title: Reverse ETL Source Setup Guides  
+    - section_title: Reverse ETL Source Setup Guides
       slug: connections/reverse-etl/reverse-etl-source-setup-guides
-      section: 
+      section:
       - path: /connections/reverse-etl/reverse-etl-source-setup-guides/bigquery-setup
         title: BigQuery Reverse ETL Setup
       - path: /connections/reverse-etl/reverse-etl-source-setup-guides/redshift-setup


### PR DESCRIPTION
### Proposed changes

Adds missing `Spec: Alias` to navbar/sidenav and removes trailing whitespace from the file.
<!--Tell us what you did and why-->

### Merge timing

No dependency on anything and no timeframe, so ASAP once it's approved.
