### PR TITLE
Add details for blocked fields

### DIFF
--- a/src/privacy/portal.md
+++ b/src/privacy/portal.md
@@ -186,7 +186,8 @@ This is where you can create your very own matchers to tell Segment what to scan
 for in your workspace. You can use this feature to detect properties that are
 unique to your company or region, or that aren't already handled by the default
 matchers above. You can have up to 100 custom matchers per workspace. Custom
-Matchers detect data in your Web, Mobile, Server, and Cloud Event Sources, and
+Matchers detect data in your Web, Mobile, Server, and Cloud Event Sources for 
+fields under `contexts`, `traits` and `properties` top level keys, and
 the data they detect appears in the Inbox.
 
 For example, if you have a restricted data point at your company called "SIN"

--- a/src/privacy/portal.md
+++ b/src/privacy/portal.md
@@ -187,7 +187,7 @@ for in your workspace. You can use this feature to detect properties that are
 unique to your company or region, or that aren't already handled by the default
 matchers above. You can have up to 100 custom matchers per workspace. Custom
 Matchers detect data in your Web, Mobile, Server, and Cloud Event Sources for 
-fields under `contexts`, `traits` and `properties` top level keys, and
+fields under `contexts`, `traits` and `properties` objects, and
 the data they detect appears in the Inbox.
 
 For example, if you have a restricted data point at your company called "SIN"


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

It’s currently not mentioned on Public doc that our Privacy won’t block fields outside “context”, “traits” and “properties” objects.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

