### PR TITLE
Remove section

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/amplitude-react-native.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/amplitude-react-native.md
@@ -73,14 +73,6 @@ The Amplitude destination requires that each event include either a Device ID or
 
 By default, Segment maps the Segment property `context.device.id` to the Amplitude property `Device ID`. If `context.device.id` isn't available, Segment maps the property `anonymousId` to the Amplitude `Device ID`. The Actions interface indicates this with the following contents of the Device ID field: `coalesce(` `context.device.id` `anonymousId` `)`.
 
-## Important differences from the classic Amplitude destination
-
-The classic Amplitude destination captures the following user fields in device-mode (when it runs on the user's device):
-
-- Device Type (for example, Mac, PC, mobile device)
-- Platform (for example iOS or Android)
-
-Amplitude (Actions) runs in cloud-mode, and does not capture these fields.
 {% capture log-event-details %}
 #### Track Revenue Per Product
 


### PR DESCRIPTION
### Proposed changes

Removed a section as I think it's a bit redundant. We mention further up the doc that this is only supported in cloud mode, and Device Type and platform properties are still mapped on the server side. 
