### PR TITLE
Update docs for when GA4 will replace UA

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -16,7 +16,7 @@ versions:
 When you have Segment installed, you can use your existing tracking implementation to fulfill your data collection needs with Google Analytics 4. Segment will send your data server-side to [Google's Measurement Protocol API](https://developers.google.com/analytics/devguides/collection/protocol/ga4){:target='_blank'}.
 
 > warning ""
-> Google Analytics 4 doesn't officially support a pure server-to-server integration. However, Segment monitors the capabilities of the Measurement Protocol API and updates the cloud integration accordingly to achieve a reasonable level of reporting for mutual customers. For full functionality, please see the [Google Analytics 4 Web destination](/docs/connections/destinations/catalog/actions-google-analytics-4-web/).
+> Google Analytics 4 doesn't officially support a pure server-to-server integration. However, Segment monitors the capabilities of the Measurement Protocol API and updates the cloud integration accordingly to achieve a reasonable level of reporting for mutual customers. For full functionality, please see the [Google Analytics 4 Web destination](/docs/connections/destinations/catalog/actions-google-analytics-4-web/){:target='_blank'}.
 
 ## Benefits of Google Analytics 4 Cloud
 
@@ -25,7 +25,7 @@ The Google Analytics 4 Cloud destination provides the following benefits:
 - **Fewer settings**. Data mapping for actions-based destinations happens during configuration, which eliminates the need for most settings.
 - **Clearer mapping of data**. Actions-based destinations enable you to define the mapping between the data Segment receives from your source and the data Segment sends to Google Analytics 4.
 - **Prebuilt mappings**. Mappings for recommended Google Analytics 4 events, like `Purchase`, are prebuilt with the prescribed parameters and available for customization.
-- **Support for multi-product arrays**. Products nested within arrays, like the `products` array in the [Order Completed](/docs/connections/spec/ecommerce/v2/#order-completed) event, can be sent to Google Analytics 4.
+- **Support for multi-product arrays**. Products nested within arrays, like the `products` array in the [Order Completed](/docs/connections/spec/ecommerce/v2/#order-completed){:target='_blank'} event, can be sent to Google Analytics 4.
 
 ## Getting started
 
@@ -55,17 +55,17 @@ Google Analytics 4 has different out-of-the-box reports. Google Analytics 4’s 
 
 ### Migrating from Universal Analytics to Google Analytics 4
 > warning ""
-> Google announced that all standard Universal Analytics properties will stop processing new hits on July 1, 2023. 360 Universal Analytics properties will stop processing new hits on October 1, 2023.
+> Google announced that all standard Universal Analytics properties will stop processing new data on July 1, 2023. 360 Universal Analytics properties with a current order will receive a one-time processing extension ending on July 1, 2024. Learn more about when [Google Analytics 4 will replace Universal Analytics](https://support.google.com/analytics/answer/11583528?sjid=13479291677968058253-NA){:target='_blank'}. 
 
 Segment’s Google Analytics 4 Cloud integration is a server-side integration with the GA4 Measurement Protocol API. This is similar to Segment’s Google Universal Analytics cloud-mode integration in that all data is sent directly to Google’s servers. Please note that this means client-side functionality, such as [Enhanced Measurement](https://support.google.com/analytics/answer/9216061){:target='_blank'}, may not be available through Segment. In addition, as Google continues to develop the GA4 Measurement Protocol API ahead of general availability of the API, there may be limitations that impact what can be seen in the Google Analytics 4 reports.
 
 #### Recommended events
-Google Analytics 4 requires the use of [recommended events and properties](https://support.google.com/analytics/answer/9267735){:target='_blank'} to power certain built-in reports. Segment’s Google Analytics 4 Cloud destination provides prebuilt mappings to automatically map your [Segment spec](/docs/connections/spec/ecommerce/v2) events to the corresponding Google Analytics 4 events and properties. If your Segment events don't follow the Segment spec exactly, you can modify the mappings. For example, Segment maps "Order Completed" events to the Google Analytics 4 “Purchase” event by default. If your company uses “Products Purchase” to indicate a purchase, this can be mapped in the Purchase action’s Event Trigger instead.
+Google Analytics 4 requires the use of [recommended events and properties](https://support.google.com/analytics/answer/9267735){:target='_blank'} to power certain built-in reports. Segment’s Google Analytics 4 Cloud destination provides prebuilt mappings to automatically map your [Segment spec](/docs/connections/spec/ecommerce/v2){:target='_blank'} events to the corresponding Google Analytics 4 events and properties. If your Segment events don't follow the Segment spec exactly, you can modify the mappings. For example, Segment maps "Order Completed" events to the Google Analytics 4 “Purchase” event by default. If your company uses “Products Purchase” to indicate a purchase, this can be mapped in the Purchase action’s Event Trigger instead.
 
-Segment recommends using the prebuilt mappings when possible, however the Segment spec doesn't have an equivalent event for every Google Analytics 4 recommended event. If there are other recommended events you would like to send, please use the [Custom Event action](/docs/connections/destinations/catalog/actions-google-analytics-4/#custom-event). For example, to send a `spend_virtual_currency` event, create a mapping for Custom Event, set up your Event Trigger criteria, and input a literal string of "spend_virtual_currency" as the Event Name. You can use the Event Parameters object to add fields that are in the `spend_virtual_currency` event such as `value` and `virtual_currency_name`.
+Segment recommends using the prebuilt mappings when possible, however the Segment spec doesn't have an equivalent event for every Google Analytics 4 recommended event. If there are other recommended events you would like to send, please use the [Custom Event action](/docs/connections/destinations/catalog/actions-google-analytics-4/#custom-event){:target='_blank'}. For example, to send a `spend_virtual_currency` event, create a mapping for Custom Event, set up your Event Trigger criteria, and input a literal string of "spend_virtual_currency" as the Event Name. You can use the Event Parameters object to add fields that are in the `spend_virtual_currency` event such as `value` and `virtual_currency_name`.
 
 #### Custom events
-In addition to recommended events, you can also send custom events using the [Custom Event action](/docs/connections/destinations/catalog/actions-google-analytics-4/#custom-event). Custom events are events that you name. Custom events don't appear in most standard reports; you need to set up custom reports for meaningful analysis. To create custom events in the Google Analytics 4 web interface, see Google’s [Modify and create events through the user interface](https://support.google.com/analytics/answer/10085872){:target='_blank'}.
+In addition to recommended events, you can also send custom events using the [Custom Event action](/docs/connections/destinations/catalog/actions-google-analytics-4/#custom-event){:target='_blank'}. Custom events are events that you name. Custom events don't appear in most standard reports; you need to set up custom reports for meaningful analysis. To create custom events in the Google Analytics 4 web interface, see Google’s [Modify and create events through the user interface](https://support.google.com/analytics/answer/10085872){:target='_blank'}.
 
 > info "Event naming limitations"
 > Google Analytics 4 requires that all event names contain only alpha-numeric characters and underscores, must start with an alphabetic character, and support a maximum of 40 characters. Segment replaces spaces in Event Names with an underscore, so that these events are accepted by GA4. For example, Segment renames an event named `Home Profile` to `Home_Profile`. In some cases, GA4 may reject an event outright, due to unsupported characters. For example, an event named `Home | Profile` will be silently rejected due to the pipe character.
@@ -138,7 +138,7 @@ Ensure that at least one mapping has been configured and enabled in the destinat
 
 ### Attribution reporting
 
-Google doesn't currently support passing certain reserved fields to the Google Analytics 4 Measurement Protocol API. This includes attribution data, like UTM parameters. If you rely on attribution reporting, you can either send this data as [custom dimensions](/docs/connections/destinations/catalog/actions-google-analytics-4/#custom-dimensions-and-metrics) or implement a parallel client-side integration to collect this data with gtag.js (web) or Firebase (mobile).
+Google doesn't currently support passing certain reserved fields to the Google Analytics 4 Measurement Protocol API. This includes attribution data, like UTM parameters. If you rely on attribution reporting, you can either send this data as [custom dimensions](/docs/connections/destinations/catalog/actions-google-analytics-4/#custom-dimensions-and-metrics){:target='_blank'} or implement a parallel client-side integration to collect this data with gtag.js (web) or Firebase (mobile).
 
 ### Debug mode
 
@@ -163,5 +163,5 @@ Google has some requirements/[limitations](https://developers.google.com/analyti
 
 ### Data takes a long time to appear in Google's reports
 
-Google may take [24-48 hours](https://support.google.com/analytics/answer/9333790)  to process data sent to Google Analytics. As a result, the Google Analytics user interface may not reflect the most current data. The Google Analytics [Realtime report](https://support.google.com/analytics/answer/9271392){:target="_blank"} displays activity on your site as it happens.
+Google may take [24-48 hours](https://support.google.com/analytics/answer/9333790){:target='_blank'}  to process data sent to Google Analytics. As a result, the Google Analytics user interface may not reflect the most current data. The Google Analytics [Realtime report](https://support.google.com/analytics/answer/9271392){:target="_blank"} displays activity on your site as it happens.
 


### PR DESCRIPTION
### Proposed changes
- Update date from October 1, 2023 to July 1, 2024
- Add link to Google's docs for when Universal Analytics will be replaced by Google Analytics 4
- add {:target='_blank’} to links on page so that a new browser window automatically opens up when user clicks on the link

### Merge timing
- ASAP once approved

