### PR TITLE
Update profile-api-limits.md with additional limitations

### DIFF
--- a/src/unify/profile-api-limits.md
+++ b/src/unify/profile-api-limits.md
@@ -5,6 +5,14 @@ redirect_from:
   - '/profiles/product-limits'
 ---
 
+###Unify Ingestion Limitations
+
+Unify will silently drop events if:
+- The groupId has more than 500 characters.
+- Events have more than 300 properties/traits.
+- messageId is longer than 100 characters.
+- The groupId is empty in a group call or context.groupId is empty in a track call.
+
 ## Profile API
 
 | Name                    | limit                   | Details                                                                                                                                                             |

--- a/src/unify/profile-api-limits.md
+++ b/src/unify/profile-api-limits.md
@@ -5,13 +5,6 @@ redirect_from:
   - '/profiles/product-limits'
 ---
 
-###Unify Ingestion Limitations
-
-Unify will silently drop events if:
-- The groupId has more than 500 characters.
-- Events have more than 300 properties/traits.
-- messageId is longer than 100 characters.
-- The groupId is empty in a group call or context.groupId is empty in a track call.
 
 ## Profile API
 
@@ -28,3 +21,11 @@ Unify will silently drop events if:
 | Identity Merges   | 100 merges    | Engage supports up to 100 merges per profile in its identity graph. Merges occur when a common `external_id` joins two existing profiles. For example, if a user initiates a mobile session but then signs in through a web application, a common identifier like `user_id` will join the two user profiles. No additional merges will be added once the profile reaches this limit. Event resolution for the profile, however, will continue. |
 | Identity Mappings | 1000 mappings | Engage supports up to 1000 mappings per profile in its identity graph. Mappings are external identifier values like a `user_id`, email, mobile advertising `id`, or any custom identifier. No additional mappings will be added once the profile reaches this limit. Event resolution for the profile, however, will continue.                                                                                                                 |
 | Identify calls    | 300 traits    | Engage rejects Identify events with 300 or more traits. If your use case requires more than 300 traits, you can split the traits into multiple Identify calls.                                                                                                                                                                                                                                                                                 |
+
+### Unify ingestion limitations
+
+Unify will silently drop events if:
+- The groupId has more than 500 characters.
+- Events have more than 300 properties/traits.
+- messageId is longer than 100 characters.
+- The groupId is empty in a group call or context.groupId is empty in a track call.


### PR DESCRIPTION
### Proposed changes

Some additional limitations were added, such as an event being dropped if the groupId has more than 500 characters or if the event has more than 300 properties or traits.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
