### PR TITLE
Add section for user data field formatting

### DIFF
--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -149,6 +149,19 @@ Segment creates a SHA-256 hash of the following fields before sending to Faceboo
 
 If you use Facebook Pixel, the Pixel library also hashes the External ID. This means External IDs will match across Facebook Pixel and Facebook Conversions API if they use the External ID for [deduplication](https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events/#fbp-or-external-id){:target="_blank"}.
 
+### User Data Formatting
+
+Segment applies formatting to User Data Parameters as follows:
+
+| User Data Field                                                                     | Formatting applied to field value before hashing                                                                                                               |
+|-------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| External ID, Email, Gender,  Last Name, First Name,  City, State, Zip Code, Country | All whitespace is removed from string, set to lowercase.                                                                                                       |
+| Phone                                                                               | All non-numeric characters are removed from string.                                                                                                            |
+| Gender                                                                              | A string of 'male' will be transformed to 'm', and 'female' to 'f'.                                                                                            |
+| Date of Birth                                                                       | No formatting is applied.                                                                                                                                      |
+| State                                                                               | Compared against a Map object of states and their 2-character ANSI abbreviation code. Example: "Texas", "TX", or "tx" in this field will be formatted as "tx". |
+| Country                                                                             | Compared against a Map object of countries and their 2-letter ISO 3166-1 alpha-2 country codes.                                                                |
+
 ### User Data Parameters
 
 Segment automatically maps User Data fields to their corresponding parameters [as expected by the Conversions API](https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters/){:target="_blank"} before sending to Facebook:

--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -159,8 +159,8 @@ Segment applies formatting to User Data Parameters as follows:
 | Phone                                                                               | All non-numeric characters are removed from string.                                                                                                            |
 | Gender                                                                              | A string of 'male' will be transformed to 'm', and 'female' to 'f'.                                                                                            |
 | Date of Birth                                                                       | No formatting is applied.                                                                                                                                      |
-| State                                                                               | Compared against a Map object of states and their 2-character ANSI abbreviation code. Example: "Texas", "TX", or "tx" in this field will be formatted as "tx". |
-| Country                                                                             | Compared against a Map object of countries and their 2-letter ISO 3166-1 alpha-2 country codes.                                                                |
+| State                                                                               | Compared against a Map object of states and their two-character ANSI abbreviation code. Example: "Texas", "TX", or "tx" in this field will be formatted as "tx". |
+| Country                                                                             | Compared against a Map object of countries and their two-letter ISO 3166-1 alpha-2 country codes.                                                                |
 
 ### User Data Parameters
 

--- a/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-facebook-conversions-api/index.md
@@ -153,14 +153,17 @@ If you use Facebook Pixel, the Pixel library also hashes the External ID. This m
 
 Segment applies formatting to User Data Parameters as follows:
 
-| User Data Field                                                                     | Formatting applied to field value before hashing                                                                                                               |
-|-------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| External ID, Email, Gender,  Last Name, First Name,  City, State, Zip Code, Country | All whitespace is removed from string, set to lowercase.                                                                                                       |
-| Phone                                                                               | All non-numeric characters are removed from string.                                                                                                            |
-| Gender                                                                              | A string of 'male' will be transformed to 'm', and 'female' to 'f'.                                                                                            |
-| Date of Birth                                                                       | No formatting is applied.                                                                                                                                      |
-| State                                                                               | Compared against a Map object of states and their two-character ANSI abbreviation code. Example: "Texas", "TX", or "tx" in this field will be formatted as "tx". |
-| Country                                                                             | Compared against a Map object of countries and their two-letter ISO 3166-1 alpha-2 country codes.                                                                |
+| User Data Field       | Formatting applied to field value before hashing                                                                                                                                                                             |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| External ID           | All whitespace is removed from string, set to lowercase.                                                                                                                                                                     |
+| Email                 | All whitespace is removed from string, set to lowercase.                                                                                                                                                                     |
+| First Name, Last Name | All whitespace is removed from string, set to lowercase.                                                                                                                                                                     |
+| Gender                | All whitespace is removed from string, set to lowercase. "male" is set to "m", "female" is set to "f".                                                                                                                       |
+| Date of Birth         | No formatting is applied.                                                                                                                                                                                                    |
+| Phone                 | All whitespace is removed from string.                                                                                                                                                                                       |
+| Zip Code              | All whitespace is removed from string.                                                                                                                                                                                       |
+| State                 | All whitespace is removed from string and the result is compared against a map object of states and their two-character ANSI abbreviation code.  Example: "Texas", "TX", or "tx" in this field will be formatted as "tx".    |
+| Country               | All whitespace is removed from string and the result is compared against a map object of countries and their two-letter ISO 3166-1 alpha-2 country code.  Example: "Germany", "germany", or "de" will be formatted as "de".  |
 
 ### User Data Parameters
 


### PR DESCRIPTION
### Proposed changes

Facebook CAPI (Actions) docs do not currently provide insight into what formatting the integration performs to user data values prior to hashing them. Added this information as a section under FAQ.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
