### PR TITLE
TikTok Audience and Advertiser ID clarification.

### DIFF
--- a/src/connections/destinations/catalog/actions-tiktok-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-tiktok-audiences/index.md
@@ -36,7 +36,7 @@ By using Segment's TikTok Audiences destination, you can increase traffic and dr
 
 8. Under Select mappings, select the TikTok "Advertiser ID" of the audience segment you want to add users to. Input the `audience_id` of that audience segment under "Audience ID." **Note: A separate mapping must be created for each audience segment you plan to send Engage audiences to.**
 > info ""
-> You can get the "Audience ID" from "Assets->Audiences" page of TikTok once you have created the audience with the name of Segment's audience key. And the "Advertiser ID" can be visible over the TikTok URL as "aadvid".
+> Once you've created the audience using the name of Segment's audience key, you can get the Audience ID from TikTok's Assets>Audiences page. You'll also find the Advertised ID, noted by `aadvid`, over the TikTok URL.
 
 9. Repeat Steps 7 and 8 to also set up a **Remove Users** mapping.
      

--- a/src/connections/destinations/catalog/actions-tiktok-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-tiktok-audiences/index.md
@@ -35,6 +35,8 @@ By using Segment's TikTok Audiences destination, you can increase traffic and dr
 7. Navigate to the **Mappings** tab, click **New Mapping**, and select **Add Users**.
 
 8. Under Select mappings, select the TikTok "Advertiser ID" of the audience segment you want to add users to. Input the `audience_id` of that audience segment under "Audience ID." **Note: A separate mapping must be created for each audience segment you plan to send Engage audiences to.**
+> info ""
+> You can get the "Audience ID" from "Assets->Audiences" page of TikTok once you have created the audience with the name of Segment's audience key. And the "Advertiser ID" can be visible over the TikTok URL as "aadvid".
 
 9. Repeat Steps 7 and 8 to also set up a **Remove Users** mapping.
      


### PR DESCRIPTION
### Proposed changes

> info ""
> You can get the "Audience ID" from "Assets->Audiences" page of TikTok once you have created the audience with the name of Segment's audience key. And the "Advertiser ID" can be visible over the TikTok URL as "aadvid".

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
