### PR TITLE
STRATCONN-2662 - Removed outdated migration info from Salesforce (Actions)

### DIFF
--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -81,7 +81,6 @@ If you have more than one Salesforce instance connected to Segment, repeat these
 
 Keep the following in mind as you begin to use Salesforce (Actions):
 - Salesforce (Actions) supports batching. The workspace owner can edit the enabled-batching field manually for any of the mappings. This setting is disabled by default.
-- Salesforce (Actions) doesn’t support Delete CRUD operations on Custom Object. Custom Objects with CRUD the operation set to `delete` are not migrated.
 - Sending Identify events to Salesforce (Classic) results in a create or update operation for Leads, and maps properties from `event.traits` Salesforce (Actions) does not support this behavior. By default, the automatic migration maps only a subset of the most used Lead properties as mentioned below. The workspace owner must map any additional Salesforce properties or Custom properties manually.
 
 Review the tables below to see how settings from Salesforce (Classic) were migrated to Salesforce (Actions).


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

Automated Migration of Salesforce didn't support migration of the `Delete` CRUD Operation which was called out in the documentation. Later we decided to support the Delete CRUD operation. This PR removes the callout text that "we don't support Delete CRUD operation".



### Merge timing
Can be merged ASAP once approved.

### Related documents
https://docs.google.com/document/d/1zYUT2jTOuogzhF4NkBPK9Qvgu8GHTc6NRe99QuuTByk/edit

