### PR TITLE
specify-source-type-for-audit-trail-forwarding

### DIFF
--- a/src/segment-app/iam/audit-trail.md
+++ b/src/segment-app/iam/audit-trail.md
@@ -97,8 +97,9 @@ You can forward events in your workspace to any of the sources you have configur
 
 To forward Audit Trail events:
 
-1. Navigate to **Settings > Workspace Settings > Audit Forwarding**.
-2. Select the source to which you'll forward workspace events.
-3. Toggle the setting to **On** and click **Save Changes**.
+1. Navigate to **Settings > Workspace Settings > Audit Forwarding**
+2. Add a new source (e.g. [HTTP API](docs/connections/sources/catalog/libraries/server/http-api/)) to receive workspace events (optional)
+3. Select the source you created or select an existing [event streams source](/docs/connections/sources/#event-streams-sources)
+4. Toggle the setting to **On** and click **Save Changes**
 
 When you forward audit events to a source, Segment passes those events through its entire processing pipeline. This ensures that tracking plans, filters, and other features work with the audit events, and also ensures you can send those events to multiple downstream destinations.


### PR DESCRIPTION
### Proposed changes

When customer configure audit trail forwarding, they could also select Engage sources, rETL sources and Cloud (event) sources which don’t make much sense. Therefore, this PR is to add some clarity about what sources are expected to be used.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->
