### PR TITLE
Update schema.md

### DIFF
--- a/src/connections/storage/warehouses/schema.md
+++ b/src/connections/storage/warehouses/schema.md
@@ -457,6 +457,8 @@ All four timestamps pass through to your Warehouse for every ETL'd event. In mos
 
 `received_at` does not ensure chronology of events.  For queries based on event chronology, `timestamp` should be used.
 
+For Business Tier customers, it is recommended to have `received_at` enabled in the Selective Sync settings to ensure the syncs and backfills complete successfully. 
+
 > info ""
 > ISO-8601 date strings with timezones included are required when using timestamps with [Engage](/docs/engage/). Sending custom traits without a timezone included in the timestamp will result in the value not being saved. 
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Support receives backfill requests to the customers' warehouses after a change in their Selective Sync settings. In several cases, the received_at property remains disabled and this being the sort key is likely to have an impact on the routine syncs as well as the completion of backfills. Therefore, it could be better to have this note in our Public Docs so that our customers can take proper actions to ensure everything works as expected. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
