### PR TITLE
Add config table field for host option

### DIFF
--- a/src/connections/sources/catalog/libraries/server/php/index.md
+++ b/src/connections/sources/catalog/libraries/server/php/index.md
@@ -395,6 +395,10 @@ Segment::init("YOUR_WRITE_KEY", array(
     <td>`error_handler` _Function, optional_</td>
     <td>A handler which will be called on errors to aid in debugging, `function ($code, $message) {}`</td>
   </tr>
+  <tr>
+    <td>`host` _String, optional_</td>
+    <td>To explicitly set which regional host to use. Defaults to `api.segment.io`.</td>
+  </tr>  
 </table>
 
 ### Lib-Curl Consumer


### PR DESCRIPTION
### Proposed changes

Top of the docs mention setting [regional configuration](https://segment.com/docs/connections/sources/catalog/libraries/server/php/#regional-configuration) with the `host` field, but the [Configuration section](https://segment.com/docs/connections/sources/catalog/libraries/server/php/#regional-configuration) table does not show an example of this - added a field that elaborates on this parameter, along with the default value ([relevant code snippet](https://github.com/segmentio/analytics-php/blob/master/lib/Consumer/Socket.php#L27))

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
