### PR TITLE
hide integration docs

### DIFF
--- a/src/connections/destinations/catalog/customfit-ai/index.md
+++ b/src/connections/destinations/catalog/customfit-ai/index.md
@@ -3,7 +3,7 @@ title: CustomFit Destination
 rewrite: true
 id: 5cee939ff784ec0001f1cf91
 hidden: true
-private: true
+published: false
 ---
 [CustomFit.ai](https://customfit.ai/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners) is an intelligent `App Experience Engine` for B2C apps(Mobile/Web/IoT), with which one can effortlessly craft hyper-personalized app experiences & alternative user journeys to each of their user or segment of users with zero code. Every user is unique, so should be your app.
 

--- a/src/connections/destinations/catalog/customfit-ai/index.md
+++ b/src/connections/destinations/catalog/customfit-ai/index.md
@@ -2,6 +2,8 @@
 title: CustomFit Destination
 rewrite: true
 id: 5cee939ff784ec0001f1cf91
+hidden: true
+private: true
 ---
 [CustomFit.ai](https://customfit.ai/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners) is an intelligent `App Experience Engine` for B2C apps(Mobile/Web/IoT), with which one can effortlessly craft hyper-personalized app experiences & alternative user journeys to each of their user or segment of users with zero code. Every user is unique, so should be your app.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

I am hiding the docs because this integration has been deprecated, and is no longer available in our catalog. If it makes more sense to delete the docs entirely, that would be okay. 

### Merge timing
asap
