### PR TITLE
Update Plugin Architecture link AJS

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/index.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/index.md
@@ -751,7 +751,7 @@ window.analytics.ready(() => {
     })
 ```
 
-You can view Segment's [existing plugins](https://github.com/segmentio/analytics-next/tree/master/src/plugins){:target="_blank"} to see more examples.
+You can view Segment's [existing plugins](https://github.com/segmentio/analytics-next/tree/master/packages/browser/src/plugins){:target="_blank"} to see more examples.
 
 ### Register a plugin
 Registering plugins enable you to modify your analytics implementation to best fit your needs. You can register a plugin using this:


### PR DESCRIPTION
### Proposed changes
Currently, the link provides a 404 error. My proposed change is to update the existing.

At the bottom of Plugin Architecture, there is a line that say:
You can view Segment’s [existing plugins](https://github.com/segmentio/analytics-next/tree/master/src/plugins) to see more examples.

I want to update this to: 
You can view Segment’s [existing plugins](https://github.com/segmentio/analytics-next/tree/master/packages/browser/src/plugins) to see more examples.


### Merge timing
ASAP once approved

