### PR TITLE
Add alternatives to SSH Tunneling FAQ

### DIFF
--- a/src/connections/storage/catalog/redshift/index.md
+++ b/src/connections/storage/catalog/redshift/index.md
@@ -151,10 +151,10 @@ Segment does not currently support SSH tunneling to Redshift. You can usually al
 
 Segment does not currently support Serverless Redshift. While you can set up the connection in the Segment app, Segment does not have the functionality to query Redshift's SYS tables.
 
-Despite the fact we need a public IP address to access your remote instance, Segment supports several layers of Redshift's security model:
+Despite the fact Segment needs a public IP address to access your remote instance, Segment supports several layers of Redshift's security model:
  
-Security group — This is the firewall that Segment asks customers to open a pinhole in for Segment's IP address. Security groups are a fundamental building block of AWS security;
+Security group — This is the firewall that Segment asks customers to open a pinhole in for Segment's IP address. Security groups are a fundamental building block of AWS security.
 
-SSL — This secures data in transit and also allows client apps like Segment to validate that the warehouse at the other end is actually a warehouse owned by AWS. This is especially important if your Redshift warehouse is not within the us-west-2 region;
+SSL — This secures data in transit and also allows client apps like Segment to validate that the warehouse at the other end is actually a warehouse owned by AWS. This is especially important if your Redshift warehouse is not within the us-west-2 region.
 
 Username /password — This is the basic method used to authenticate database users and apply varying levels of permissions like who can create tables, who can delete data, who can see which tables, etc.

--- a/src/connections/storage/catalog/redshift/index.md
+++ b/src/connections/storage/catalog/redshift/index.md
@@ -158,5 +158,3 @@ Username /password — This is the basic method used to authenticate database us
 ### Do you support Redshift Serverless?
 
 Segment does not currently support Serverless Redshift. While you can set up the connection in the Segment app, Segment does not have the functionality to query Redshift's SYS tables.
-
-

--- a/src/connections/storage/catalog/redshift/index.md
+++ b/src/connections/storage/catalog/redshift/index.md
@@ -150,3 +150,11 @@ Segment does not currently support SSH tunneling to Redshift. You can usually al
 ### Do you support Redshift Serverless?
 
 Segment does not currently support Serverless Redshift. While you can set up the connection in the Segment app, Segment does not have the functionality to query Redshift's SYS tables.
+
+Despite the fact we need a public IP address to access your remote instance, Segment supports several layers of Redshift's security model:
+ 
+Security group — This is the firewall that Segment asks customers to open a pinhole in for Segment's IP address. Security groups are a fundamental building block of AWS security;
+
+SSL — This secures data in transit and also allows client apps like Segment to validate that the warehouse at the other end is actually a warehouse owned by AWS. This is especially important if your Redshift warehouse is not within the us-west-2 region;
+
+Username /password — This is the basic method used to authenticate database users and apply varying levels of permissions like who can create tables, who can delete data, who can see which tables, etc.

--- a/src/connections/storage/catalog/redshift/index.md
+++ b/src/connections/storage/catalog/redshift/index.md
@@ -147,10 +147,6 @@ You can also unload data to a s3 bucket and then load the data into another Reds
 
 Segment does not currently support SSH tunneling to Redshift. You can usually allow Segment's ETL to write to Redshift without leaving the cluster available to other connections by using IP level restrictions.
 
-### Do you support Redshift Serverless?
-
-Segment does not currently support Serverless Redshift. While you can set up the connection in the Segment app, Segment does not have the functionality to query Redshift's SYS tables.
-
 Despite the fact Segment needs a public IP address to access your remote instance, Segment supports several layers of Redshift's security model:
  
 Security group — This is the firewall that Segment asks customers to open a pinhole in for Segment's IP address. Security groups are a fundamental building block of AWS security.
@@ -158,3 +154,9 @@ Security group — This is the firewall that Segment asks customers to open a pi
 SSL — This secures data in transit and also allows client apps like Segment to validate that the warehouse at the other end is actually a warehouse owned by AWS. This is especially important if your Redshift warehouse is not within the us-west-2 region.
 
 Username /password — This is the basic method used to authenticate database users and apply varying levels of permissions like who can create tables, who can delete data, who can see which tables, etc.
+
+### Do you support Redshift Serverless?
+
+Segment does not currently support Serverless Redshift. While you can set up the connection in the Segment app, Segment does not have the functionality to query Redshift's SYS tables.
+
+

--- a/src/connections/storage/catalog/redshift/index.md
+++ b/src/connections/storage/catalog/redshift/index.md
@@ -147,13 +147,11 @@ You can also unload data to a s3 bucket and then load the data into another Reds
 
 Segment does not currently support SSH tunneling to Redshift. You can usually allow Segment's ETL to write to Redshift without leaving the cluster available to other connections by using IP level restrictions.
 
-Despite the fact Segment needs a public IP address to access your remote instance, Segment supports several layers of Redshift's security model:
- 
-Security group — This is the firewall that Segment asks customers to open a pinhole in for Segment's IP address. Security groups are a fundamental building block of AWS security.
+Segment supports several layers of Redshift's security model:
 
-SSL — This secures data in transit and also allows client apps like Segment to validate that the warehouse at the other end is actually a warehouse owned by AWS. This is especially important if your Redshift warehouse is not within the us-west-2 region.
-
-Username /password — This is the basic method used to authenticate database users and apply varying levels of permissions like who can create tables, who can delete data, who can see which tables, etc.
+ - **Security groups**: Security groups control the incoming and outgoing traffic to a resource. You can think of this like a pinhole in a firewall that only allows traffic from Segment's IP address. Security groups are a fundamental building block of AWS security.
+- **SSL**:  This secures data in transit and allows Segment to validate that the warehouse at the other end is actually a warehouse owned by AWS. This is especially important if your Redshift warehouse is not located in the `us-west-2` region.
+- **Username and password**: This is the basic method used to authenticate database users and apply varying levels of permissions - for example, who can create tables, who can delete data, who can see which tables.
 
 ### Do you support Redshift Serverless?
 


### PR DESCRIPTION
We have gotten tickets in the past in where customers as if we support SSH tunneling to Redshift (we do not). We have alternatives listed in our Zendesk Macros/Internal docs and I believe it is appropriate to share these workarounds in the public docs as well so there is less back and forth. 

### Merge timing
ASAP once approved


