### PR TITLE
Adding ANSI Reserved Keyword error to Warehouse Errors Page

### DIFF
--- a/src/connections/storage/warehouses/warehouse-errors.md
+++ b/src/connections/storage/warehouses/warehouse-errors.md
@@ -54,3 +54,7 @@ This is a permissioning issue. To learn how to set up proper permissions, you ca
 ### EOF
 
 This error is generally a network error when Redshift closes the connection. If the problem persists on multiple runs, [contact us](https://segment.com/help/contact/).
+
+### ERROR: failed to create table: 002318 (42601): SQL compilation error: invalid column definition name "XXX" (ANSI reserved)
+
+This error indicates that a column that is attempting to sync has the same title as a reserved word in Snowflake. More information regarding Snowflake's reserved keywords can be found [here](https://docs.snowflake.com/en/sql-reference/reserved-keywords).

--- a/src/connections/storage/warehouses/warehouse-errors.md
+++ b/src/connections/storage/warehouses/warehouse-errors.md
@@ -57,4 +57,4 @@ This error is generally a network error when Redshift closes the connection. If 
 
 ### ERROR: failed to create table: 002318 (42601): SQL compilation error: invalid column definition name "XXX" (ANSI reserved)
 
-This error indicates that a column that is attempting to sync has the same title as a reserved word in Snowflake. More information regarding Snowflake's reserved keywords can be found [here](https://docs.snowflake.com/en/sql-reference/reserved-keywords).
+This error indicates that a column that is attempting to sync has the same title as a reserved keyword in Snowflake. More information regarding Snowflake's reserved keywords can be found [here](https://docs.snowflake.com/en/sql-reference/reserved-keywords).

--- a/src/connections/storage/warehouses/warehouse-errors.md
+++ b/src/connections/storage/warehouses/warehouse-errors.md
@@ -57,4 +57,4 @@ This error is generally a network error when Redshift closes the connection. If 
 
 ### ERROR: failed to create table: 002318 (42601): SQL compilation error: invalid column definition name "XXX" (ANSI reserved)
 
-This error indicates that a column that is attempting to sync has the same title as a reserved keyword in Snowflake. More information regarding Snowflake's reserved keywords can be found [here](https://docs.snowflake.com/en/sql-reference/reserved-keywords).
+This error indicates that a column that is attempting to sync has the same title as a reserved keyword in Snowflake. More information regarding Snowflake's reserved keywords can be found [in Snowflake's docs](https://docs.snowflake.com/en/sql-reference/reserved-keywords){:target="_blank”}.


### PR DESCRIPTION
Customers have reached out regarding Snowflake warehouse sync failures, after taking the proper troubleshooting steps this is the error we see in our logs: 

`Error=failed to create table: 002318 (42601): SQL compilation error: invalid column definition name 'CURRENT_DATE' (ANSI reserved)`

Which indicate that they one of the columns they are trying to sync has the same title as an ANSI reserved keyword by Snowflake. I don't believe there is any documentation in our public docs that address this so I think it would be a good idea to add this in the Warehouse Errors page and provide a link to a snowflake doc that lists all their keywords so they know not to use any of those reserved keywords in the future. 

### Merge timing
ASAP once approved
