### PR TITLE
Adding warning to Warehouse Selective Sync section

### DIFF
--- a/src/connections/storage/warehouses/warehouse-syncs.md
+++ b/src/connections/storage/warehouses/warehouse-syncs.md
@@ -70,7 +70,7 @@ When you disable a source, collection or property, Segment no longer syncs data 
 > For each warehouse only the first 5,000 collections per source and 5,000 properties per collection are visible in the Selective Sync user interface. [Learn more about the limits](#selective-sync-user-interface-limits).
 
 > warning ""
-> All tables use `receieved_at` for the sort key, disabling this column will cause your syncs to fail.
+> Disabling the `recieved_at` column will cause your syncs to fail, as all tables use `receieved_at` as the sort key.
  
 ### When to use Selective Sync
 

--- a/src/connections/storage/warehouses/warehouse-syncs.md
+++ b/src/connections/storage/warehouses/warehouse-syncs.md
@@ -69,6 +69,9 @@ When you disable a source, collection or property, Segment no longer syncs data 
 > warning ""
 > For each warehouse only the first 5,000 collections per source and 5,000 properties per collection are visible in the Selective Sync user interface. [Learn more about the limits](#selective-sync-user-interface-limits).
 
+> warning ""
+> All tables use `receieved_at` for the sort key, disabling this column will cause your syncs to fail.
+ 
 ### When to use Selective Sync
 
 By default, all sources and their collections and properties are sent, and no data is prevented from reaching warehouses.


### PR DESCRIPTION
### Proposed changes

Customers have reached out regarding failed warehouse syncs and after taking the proper troubleshooting steps we determine that the error is caused by the customer disabling the received_at property in one or many of their collections in their Warehouse Selective sync settings. 

I think adding a warning that states that we use received_at as the sort key for all tables and that disabling this column will cause syncs to fail would be beneficial as it would avoid any failures / disruption in data flow. 

### Merge timing

- ASAP once approved
