### PR TITLE
Warning about Behavior Events (Legacy)

### DIFF
--- a/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
@@ -20,7 +20,7 @@ When you use the HubSpot Cloud Mode (Actions) destination, Segment sends your da
 > The **Upsert Company** action is not compatible with the Segment Event Tester. As a result, Segment recommends using other tools to test and troubleshoot the creation and updates of companies in HubSpot.
 
 > warning ""
-> **Behavioral Events (Legacy)** are only supported with [Hubspot Classic Destination]([https://duckduckgo.com](https://segment.com/docs/connections/destinations/catalog/hubspot/)).
+> **Behavioral Events (Legacy)** are only supported with [Hubspot Classic Destination](https://segment.com/docs/connections/destinations/catalog/hubspot/).
 
 
 ## Benefits of HubSpot Cloud Mode (Actions) vs HubSpot Classic

--- a/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
@@ -20,7 +20,7 @@ When you use the HubSpot Cloud Mode (Actions) destination, Segment sends your da
 > The **Upsert Company** action is not compatible with the Segment Event Tester. As a result, Segment recommends using other tools to test and troubleshoot the creation and updates of companies in HubSpot.
 
 > warning ""
-> **Behavioral Events (Legacy)** are only supported with [Hubspot Classic Destination](https://segment.com/docs/connections/destinations/catalog/hubspot/).
+> **Behavioral Events (Legacy)** are only supported with [Hubspot Classic Destination](/docs/connections/destinations/catalog/hubspot/).
 
 
 ## Benefits of HubSpot Cloud Mode (Actions) vs HubSpot Classic

--- a/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
@@ -19,6 +19,9 @@ When you use the HubSpot Cloud Mode (Actions) destination, Segment sends your da
 > warning ""
 > The **Upsert Company** action is not compatible with the Segment Event Tester. As a result, Segment recommends using other tools to test and troubleshoot the creation and updates of companies in HubSpot.
 
+> warning ""
+> **Behavioral Events (Legacy)** are only supported with [Hubspot Classic Destination]([https://duckduckgo.com](https://segment.com/docs/connections/destinations/catalog/hubspot/)).
+
 
 ## Benefits of HubSpot Cloud Mode (Actions) vs HubSpot Classic
 HubSpot Cloud Mode (Actions) provides the following benefits over the classic HubSpot destination:


### PR DESCRIPTION
Hubspot Cloud Actions Destination supports Custom Behavioral Events and not Behavioral Events (Legacy).  This warning box directs users to the Hubspot Classic Destination for Behavioral Events (Legacy).

### Proposed changes

I added a warning Box that informs users that Behavioral Events (Legacy) is only done through Hubspot Classic Destination.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
