### PR TITLE
Add info about "Archived Events" to Schema Configuration page

### DIFF
--- a/src/protocols/enforce/schema-configuration.md
+++ b/src/protocols/enforce/schema-configuration.md
@@ -17,6 +17,9 @@ To enable blocking, go to the **Settings** tab for your source and click on **Sc
 > success ""
 > You can [export your Source Schema](/docs/connections/destination-data-control/#export-your-source-schema) as a CSV file to quickly audit events from your Tracking Plan.
 
+> warning "Archived Events"
+> **Important:** If you archive events while your source is connected to a tracking plan, then disconnect your tracking plan from that source, any archived events will stay archived, but they will be allowed at that point. To view all archived events, go to your **Source Schema** page, click **Filter** next to the search bar, and select **Archived**. To unarchive events that have been archived, click **Unarchive** in the far right-hand column of the event. 
+
 ## Track Calls - Unplanned Events
 When you set this dropdown to Block Event, Segment drops any events that are not defined in your Tracking Plan. Only allowlisted `track` calls in your Tracking Plan flow through Segment to your Destinations.
 


### PR DESCRIPTION
### Proposed changes

Add the following to the Schema Configuration page: 
> warning "Archived Events"
> **Important:** If you archive events while your source is connected to a tracking plan, then disconnect your tracking plan from that source, any archived events will stay archived, but they will be allowed at that point. To view all archived events, go to your **Source Schema** page, click **Filter** next to the search bar, and select **Archived**. To unarchive events that have been archived, click **Unarchive** in the far right-hand column of the event. 

Why? 
- I wasn't able to find much information about how archived events are handled in our docs

### Merge timing
- ASAP once approved

