### PR TITLE
Provided links for edge functions and destination filters - Kotlin

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/index.md
@@ -43,7 +43,7 @@ Analytics Kotlin adds several improvements to the overall experience of using th
 ### Device Mode Transformations & Filtering
 For the first time ever, developers can filter and transform their users’ events even before the events leave the mobile device. What’s more, these Filters & transformations can be applied dynamically (either via the Segment Dashboard, or via Javascript uploaded to the workspace) and do not require any app updates!
 
-Learn more about [Destination Filters]() on Mobile, and [Edge Functions]() on Mobile. 
+Learn more about [Destination Filters](https://github.com/segmentio/DestinationFilters-kotlin) on Mobile, and [Edge Functions](https://github.com/segmentio/EdgeFn-kotlin) on Mobile. 
 
 
 ## Getting started


### PR DESCRIPTION
### Proposed changes

Links to destination filters and edge functions don't go anywhere currently. Proposed changes are to update these links to take you to the GitHub repository where these are referenced. 

### Merge timing
ASAP

