### PR TITLE
Update Pinterest Conversions API Docs

### DIFF
--- a/src/connections/destinations/catalog/actions-pinterest-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-pinterest-conversions-api/index.md
@@ -47,7 +47,7 @@ To connect the Pinterest Conversions API Destination:
 {% include components/actions-fields.html settings="true"%}
 
 > warning ""
-> By default, all mappings are sent as `web` conversions. If you want to send events as mobile or offline conversions, update the Action Source in each mapping to be `app_android`, `app_ios`, `offline`.
+> By default, all mappings send as `web` conversions. If you want to send events as mobile or offline conversions, update the Action Source in each mapping to be `app_android`, `app_ios`, `offline`.
 
 ## FAQ & Troubleshooting
 

--- a/src/connections/destinations/catalog/actions-pinterest-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-pinterest-conversions-api/index.md
@@ -4,7 +4,6 @@ id: 63e42e512566ad7c7ca6ba9b
 hide-personas-partial: true
 hide-boilerplate: false
 hide-dossier: true
-private: true
 ---
 
 The Pinterest Conversions API destination is a server-to-server integration with [The Pinterest API for Conversions](https://help.pinterest.com/en/business/article/the-pinterest-api-for-conversions){:target="_blank"} that allows advertisers to send conversions directly to Pinterest without requiring a Pinterest Tag. These conversions map to Pinterest campaigns for conversion reporting to improve conversion visibility. When you pass events to Pinterest, advertisers can use Pinterest's insights to evaluate an ad's effectiveness to improve content, targeting, and placement of future ads.
@@ -46,6 +45,9 @@ To connect the Pinterest Conversions API Destination:
 
 
 {% include components/actions-fields.html settings="true"%}
+
+> warning ""
+> By default, all mappings are sent as `web` conversions. If you want to send events as mobile or offline conversions, update the Action Source in each mapping to be `app_android`, `app_ios`, `offline`.
 
 ## FAQ & Troubleshooting
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

This PR makes the docs public, as we are launching for public beta. This PR allows adds a warning section to clarify default Action Sources used with Presets. 

### Merge timing
Should be merged on May 30th (Public Beta for Pinterest Conversions API). 

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
