### PR TITLE
Update roles.md

### DIFF
--- a/src/segment-app/iam/roles.md
+++ b/src/segment-app/iam/roles.md
@@ -97,3 +97,7 @@ To **create or edit** transformations you must have either `Source Admin` for al
 ## Roles for Privacy Portal
 
 To **view, create or edit** PII related configurations in Privacy Portal, you need to have the `Workspace Owner` role.
+
+## Roles for Data Retention settings
+
+To **view or edit** Data Retention period in End-user privacy settings, you need to have the `Workspace Owner` role.

--- a/src/segment-app/iam/roles.md
+++ b/src/segment-app/iam/roles.md
@@ -96,4 +96,4 @@ To **create or edit** transformations you must have either `Source Admin` for al
 
 ## Roles for Privacy Portal
 
-The Privacy Portal is only accessible by `Workspace owners`. To **view, create or edit** any section of Privacy Portal, you will need to have the `Workspace Owner` role.
+The Privacy Portal is only accessible by `Workspace owners`. To **view, create or edit** any section of the Privacy Portal, you need to have the `Workspace Owner` role.

--- a/src/segment-app/iam/roles.md
+++ b/src/segment-app/iam/roles.md
@@ -96,8 +96,4 @@ To **create or edit** transformations you must have either `Source Admin` for al
 
 ## Roles for Privacy Portal
 
-To **view, create or edit** PII related configurations in Privacy Portal, you need to have the `Workspace Owner` role.
-
-## Roles for Data Retention settings
-
-To **view or edit** Data Retention period in End-user privacy settings, you need to have the `Workspace Owner` role.
+The Privacy Portal is only accessible by `Workspace owners`. To **view, create or edit** any section of Privacy Portal, you will need to have the `Workspace Owner` role.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

The Roles doc does not highlight the roles and permissions needed to access the Data Retention settings in End-user privacy. After testing it out, it seems that the End-user privacy access enables our customers to view the deletion and suppression lists but not data retention periods. A customer had this confusion and it would be beneficial to have this noted in the public docs. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
