### PR TITLE
Update ab-testing.md Sending A / B Testing Data To Different Destinat…

### DIFF
--- a/src/connections/spec/ab-testing.md
+++ b/src/connections/spec/ab-testing.md
@@ -29,3 +29,30 @@ Property          | Type   | Description
 `experiment_name` | String | The experiment's human-readable name.
 `variation_id`    | String | The variations's ID.
 `variation_name`  | String | The variation's human-readable name.
+
+
+## Sending A / B Testing Data To Different Destinations
+
+**This implementation strategy requires a Business Tier plan, as it requires the use of Destination Filters.**
+
+Connect two destinations (A & B) to the same Segment Source. Destination A to receive events related to user events for group-A. Destination B to receive events related to user events for group-B. Configure the destinations as you normally would, and navigate to the Destinations Filter tab on each destination. Referencing the [Destination Filters]([url](https://segment.com/docs/connections/destinations/destination-filters/)) doc and [FQL]([url](https://segment.com/docs/api/public-api/fql/)) doc, create a Destination Filter for each destination to either Allow or Block the events you want sent to each destination. 
+
+For example, Destination A's filter could be built to Allow all events where `context.page.url` has a specific value, and Destination B could be built to Block all events where the `context.page.url` has a specific value. You could also configure them to only Allow/Block events by other fields that can be referenced within the event payloads. Please note that when using Destination Filters, an event must pass all filters in order to be sent to the destination.
+
+**This second implementation strategy does not require a Business Tier plan, but does require code changes to modify the events' `integrations` object.**
+
+Connect two destinations (A & B) to the same Segment Source. Destination A to receive events related to user events for group-A. Destination B to receive events related to user events for group-B. Next, modify the code where these events are being generated, before sending to Segment, by setting the `integrations` object to false for the unwanted destination. This would require additional logic on your team's end to decide if the event should send to Destination A or B. For example, Destination A's filter could be built to Allow all events where `context.page.url` has a specific value, and Destination B could be built to Block all events where the `context.page.url` has a specific value.
+
+To route data to Destination A, modify the integrations object like this `integrations : { "_Destination A_" : true, "_Destination B_" : false}`, where _Destination A_ and _Destination B_ is the name of the integration. Follow these same steps for events you want to send to Destination B and not to Destination A. To find the name of the integration to include in the integrations object, please refer to that destination's specific Segment documentation, found under Destination Info _(Refer to it as ___ in the Integrations object)_. To route data to Destination B, modify the integrations object like this `integrations : { "_Destination B_" : true, "_Destination A_" : false,}`. 
+
+*Note* If you're wanting both Destination A and Destination B to be the same integration, such as two Mixpanel destinations, then modifying the `integrations` wouldn't work, as the integrations object would set them both to true or false. See the third implementation strategy below for Destination Function.
+
+**This third implementation strategy does not require a Business Tier plan, but utilizes Segment's Custom Functions : Source Functions & Destination Functions.**
+
+You can use either a source function or a destination function, depending on whether you'd like to modify the `integrations` object or simply add logic to route the events that you want sent to the destination.
+
+[Source Function]([url](https://segment.com/docs/connections/functions/source-functions/)) : Create a Source Function in your [workspace]([url](https://app.segment.com/goto-my-workspace/functions/catalog/new)) and select Source for a Source Function. Build out the source function's code to handle the logic for modifying the integrations object as explained in the second implementation strategy above for Destination A and Destination B. Functions require you to build out event handlers for each event type (track/identify/page/screen/group/alias), so make sure all events you want sent to the source are configured appropriately.
+
+*Note* If you want both Destination A and Destination B to be the same integration, such as two Mixpanel destinations, then modifying the `integrations` wouldn't work, as the integrations object would set them both to true or false. See the destination function strategy below.
+
+[Destination Function]([url](https://segment.com/docs/connections/functions/destination-functions/)) : Create a Destination Function in your [workspace]([url](https://app.segment.com/goto-my-workspace/functions/catalog/new)) and select Destination for a Destination Function. Build out the destination function's code to handle the logic to check whether the event should be sent to Destination A or Destination B. Set two endpoints, one for each destination, and route all events pertaining to group-A to use Destination A's endpoint and route all events pertaining to group-B to use Destination B's endpoint. Functions require you to build out event handlers for each event type (track/identify/page/screen/group/alias), so make sure all events you want sent to each destination are configured appropriately.


### PR DESCRIPTION
Sending A / B Testing Data To Different Destinations

Sending A / B Testing Data To Different Destinations is a common task that can be done easily with Segment, and providing additional information on this process could provide customers the scope to do this independently and not relying on support or professional services.

### Proposed changes

Added a section on the workarounds support has provided to share with customers some implementation strategies (at all tier levels) to perform A/B testing with their Segment workspace.

### Merge timing
- ASAP once approved?

### Related issues (optional)

Zendesk ticket : 
- https://segment.zendesk.com/agent/tickets/508938
