### PR TITLE
Update Actions Guidance

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -89,7 +89,7 @@ From the edit screen you can change the action's name and mapping, and toggle it
 
 ![Screenshot of the Mappings table with several enabled mappings](images/actions-list.png)
 
-Once an Action is created, it's disabled by default, to ensure that it's only used once fully configured. To begin sending data through an Action, enable it on the Actions page by flipping the toggle so that it appears blue.
+Once an Action is created, it's disabled by default, to ensure that it's only used after being fully configured. To begin sending data through an Action, enable it on the Actions page by selecting the toggle so that it appears blue.
 
 ## Disable a destination action
 If you find that you need to stop an action from running, but don't want to delete it completely, you can click the action to select it, then click the toggle next to the action's name to disable it. This takes effect within minutes, and disables the action until you reenable it.

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -89,6 +89,8 @@ From the edit screen you can change the action's name and mapping, and toggle it
 
 ![Screenshot of the Mappings table with several enabled mappings](images/actions-list.png)
 
+Once an Action is created, it's disabled by default, to ensure that it's only used once fully configured. To begin sending data through an Action, enable it on the Actions page by flipping the toggle so that it appears blue.
+
 ## Disable a destination action
 If you find that you need to stop an action from running, but don't want to delete it completely, you can click the action to select it, then click the toggle next to the action's name to disable it. This takes effect within minutes, and disables the action until you reenable it.
 

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -89,7 +89,7 @@ From the edit screen you can change the action's name and mapping, and toggle it
 
 ![Screenshot of the Mappings table with several enabled mappings](images/actions-list.png)
 
-Once an Action is created, it's disabled by default, to ensure that it's only used after being fully configured. To begin sending data through an Action, enable it on the Actions page by selecting the toggle so that it appears blue.
+When an Action is created, it's disabled by default, to ensure that it's only used after being fully configured. To begin sending data through an Action, enable it on the Actions page by selecting the toggle so that it appears blue.
 
 ## Disable a destination action
 If you find that you need to stop an action from running, but don't want to delete it completely, you can click the action to select it, then click the toggle next to the action's name to disable it. This takes effect within minutes, and disables the action until you reenable it.


### PR DESCRIPTION
Actions are disabled by default and need to be enabled to begin sending data

### Proposed changes

A common confusion for customers is after creating their Actions they're not enabled which means they won't be able to send data through that Action, but they're expecting it to be enabled by default upon creation. Actions are disabled by default and need to be enabled to begin sending data.

Once an Action is created, it’s disabled by default, to ensure that it’s only used once fully configured. To begin sending data through an Action, enable it on the Actions page by flipping the toggle so that it appears blue.

### Merge timing
- ASAP once approved?

### Related issues (optional)

Zendesk ticket : 
- https://segment.zendesk.com/agent/tickets/507638
