### PR TITLE
Update Server link to GitHub repo - Totango

### DIFF
--- a/src/connections/destinations/catalog/totango/index.md
+++ b/src/connections/destinations/catalog/totango/index.md
@@ -2,7 +2,7 @@
 title: Totango Destination
 id: 54521fdb25e721e32a72eefa
 ---
-Our Totango destination code is all open-source on GitHub if you want to check it out: [JavaScript](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/totango)
+Segment's Totango destination code is all open-source on GitHub: [JavaScript](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/totango){:target="_blank"}.
 
 ## Getting Started
 

--- a/src/connections/destinations/catalog/totango/index.md
+++ b/src/connections/destinations/catalog/totango/index.md
@@ -2,7 +2,7 @@
 title: Totango Destination
 id: 54521fdb25e721e32a72eefa
 ---
-Our Totango destination code is all open-source on GitHub if you want to check it out: [JavaScript](https://github.com/segment-integrations/analytics.js-integration-totango), [Server](https://github.com/segmentio/integrations/tree/master/integrations/totango).
+Our Totango destination code is all open-source on GitHub if you want to check it out: [JavaScript](https://github.com/segment-integrations/analytics.js-integration-totango)
 
 ## Getting Started
 

--- a/src/connections/destinations/catalog/totango/index.md
+++ b/src/connections/destinations/catalog/totango/index.md
@@ -2,7 +2,7 @@
 title: Totango Destination
 id: 54521fdb25e721e32a72eefa
 ---
-Our Totango destination code is all open-source on GitHub if you want to check it out: [JavaScript](https://github.com/segment-integrations/analytics.js-integration-totango), [Server](https://github.com/segmentio/integration-totango).
+Our Totango destination code is all open-source on GitHub if you want to check it out: [JavaScript](https://github.com/segment-integrations/analytics.js-integration-totango), [Server](https://github.com/segmentio/integrations/tree/master/integrations/totango).
 
 ## Getting Started
 

--- a/src/connections/destinations/catalog/totango/index.md
+++ b/src/connections/destinations/catalog/totango/index.md
@@ -2,7 +2,7 @@
 title: Totango Destination
 id: 54521fdb25e721e32a72eefa
 ---
-Our Totango destination code is all open-source on GitHub if you want to check it out: [JavaScript](https://github.com/segment-integrations/analytics.js-integration-totango)
+Our Totango destination code is all open-source on GitHub if you want to check it out: [JavaScript](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/totango)
 
 ## Getting Started
 


### PR DESCRIPTION
### Proposed changes

The link to the GitHub repo for server does not work. It gives a 404 error. I went ahead and updated this to the correct link. 

### Merge timing
Once approved
