### PR TITLE
Update index.md Zendesk clarification on sending name

### DIFF
--- a/src/connections/destinations/catalog/zendesk/index.md
+++ b/src/connections/destinations/catalog/zendesk/index.md
@@ -28,7 +28,7 @@ analytics.identify("97980cfea0067", {
 });
 ```
 
-When you call `identify`, Segment inserts or updates a user record in Zendesk and uses the user email in `traits.email` to match user records in Zendesk. If there are multiple users matching the email, then no updates are submitted. Note that you must provide a trait for either `name` or `first_name` and `last_name` in order for the `identify` call to send to Zendesk. If you provide a `name`, Segment parses this into the `first_name` and `last_name` fields.
+When you call `identify`, Segment inserts or updates a user record in Zendesk and uses the user email in `traits.email` to match user records in Zendesk. If there are multiple users matching the email, then no updates are submitted. Note that you must provide a trait for either `name` or `first_name` and `last_name` in order for the `identify` call to send to Zendesk. If you provide a `name`, Segment parses this into the `first_name` and `last_name` fields. If you provide `name`, but are missing the `last_name` field, this will still send successfully to Zendesk.
 
 Here's an example:
 


### PR DESCRIPTION
### Proposed changes

A customer recently asked how to send events to Zendesk when they only have a first_name field available. When testing, I confirmed that if you send name, with only the first_name value, it'll still send successfully to Zendesk. 

Identify : https://segment.com/docs/connections/destinations/catalog/zendesk/#:~:text=When%20you%20call,fields.
When you call identify, Segment inserts or updates a user record in Zendesk and uses the user email in traits.email to match user records in Zendesk. If there are multiple users matching the email, then no updates are submitted. Note that you must provide a trait for either name or first_name and last_name in order for the identify call to send to Zendesk. If you provide a name, Segment parses this into the first_name and last_name fields.

ADDED : 
If you provide `name`, but are missing the `last_name` field, this will still send successfully to Zendesk.

### Merge timing
- ASAP once approved

### Related issues (optional)

Zendesk ticket : 
https://segment.zendesk.com/agent/tickets/509000