### PR TITLE
Update cookie-validity-update.md A.js Cookie methods

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/cookie-validity-update.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/cookie-validity-update.md
@@ -127,3 +127,15 @@ You can still manually track identity by calling `analytics.identify()` with the
 Analytics.js tries to detect when a page is about to be closed and saves pending events to `localStorage`. When the user navigates to another page within the same domain, Analytics.js attempts to send any events it finds in localStorage.
 
 When `disableClientPersistence` is set to `true`, Analytics.js won't store any pending events into `localStorage`.
+
+## Client Side Cookie Methods (Get, Set, Clear)
+
+To access or assign a value to a cookie, outside of the standard Segment methods (track/identify/page/group), you can use the following methods. To access the cookie's value pass an empty `()` at the end of the method. To assign the value, include the string value inside those parenthesis `('123-abc')`. To clear (remove) the value for a specific field, pass in an empty value of its type, for string `('')`, for object `({})`.
+
+| Field | Cookie Name | Analytics.js Method | Local Storage Method | Set Example | Clear Example |
+| ----- | ----------- | ------------------- | -------------------- | --------------- | ------------- |
+| `userId` | `ajs_user_id` | `analytics.user().id();` | `window.localStorage.ajs_user_id` | `analytics.user().id('123-abc');` | `analytics.user().id('');` |
+| `anonymousId` | `ajs_anonymous_id` | `analytics.user().anonymousId();` | `window.localStorage.ajs_anonymous_id` | `analytics.user().anonymousId('333-abc-456-dfg');` | `analytics.user().anonymousId('');` |
+| `user traits` | `ajs_user_traits` | `analytics.user().traits();` | `window.localStorage.ajs_user_traits` | `analytics.user().traits({firstName:'Jane'});` | `analytics.user().traits({});` |
+| `groupId` | `ajs_group_id` | `analytics.group().id();` | `window.localStorage.ajs_group_id` | `analytics.group().id('777-qwe-098');` | `analytics.group().id('');` |
+| `group traits` | `ajs_group_properties` | `analytics.group().traits()` | `window.localStorage.ajs_group_properties` | `analytics.group().traits({name:'Segment'})` | `analytics.group().traits({})` |

--- a/src/connections/sources/catalog/libraries/website/javascript/cookie-validity-update.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/cookie-validity-update.md
@@ -128,9 +128,9 @@ Analytics.js tries to detect when a page is about to be closed and saves pending
 
 When `disableClientPersistence` is set to `true`, Analytics.js won't store any pending events into `localStorage`.
 
-## Client Side Cookie Methods (Get, Set, Clear)
+## Client side cookie methods (get, set, clear)
 
-To access or assign a value to a cookie, outside of the standard Segment methods (track/identify/page/group), you can use the following methods. To access the cookie's value pass an empty `()` at the end of the method. To assign the value, include the string value inside those parenthesis `('123-abc')`. To clear (remove) the value for a specific field, pass in an empty value of its type, for string `('')`, for object `({})`.
+To access or assign a value to a cookie outside of the standard Segment methods (track/identify/page/group), you can use the following methods. To access the cookie's value, pass an empty `()` at the end of the method. To assign the value, include the string value inside those parenthesis, for example, `('123-abc')`. To clear or remove the value for a specific field, pass in an empty value of its type. For example, for string `('')`, or for object `({})`.
 
 | Field | Cookie Name | Analytics.js Method | Local Storage Method | Set Example | Clear Example |
 | ----- | ----------- | ------------------- | -------------------- | --------------- | ------------- |


### PR DESCRIPTION
### Proposed changes

Customers and Segmenters are often unaware of the native Analytics.js cookie methods that allow you to access client-side cookies and get their values returned. This is very useful when you need to access a certain cookie to pass from client-side to server-side.

Added the methods at the bottom of the [Client-side persistence in Analytics.js](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/cookie-validity-update/) doc. Priscila (PTL) proposed in the slack thread that it should go on this page.

### Merge timing
- ASAP once approved?

### Related issues (optional)

Slack Thread : https://twilio.slack.com/archives/C9Z93GW76/p1675992398931969
Zendesk Ticket : https://segment.zendesk.com/agent/tickets/509663