### PR TITLE
Fix Typo in Pinterest Conversions API Docs

### DIFF
--- a/src/connections/destinations/catalog/actions-pinterest-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-pinterest-conversions-api/index.md
@@ -93,7 +93,7 @@ LDP relies on 3 fields and is enabled only when all 3 combinations are met, if o
 
 ### PII Hashing
 
-Segment creates a SHA-256 hash of the following fields before sending to Facebook:
+Segment creates a SHA-256 hash of the following fields before sending to Pinterest:
 - External ID
 - Mobile Ad Identifier
 - Email


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

There was a typo in the Pinterest Conversions API Docs

### Merge timing
<!-- When should this get merged/published?
As soon as possible

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
