### PR TITLE
Add FAQ for Other properties

### DIFF
--- a/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-hubspot-cloud/index.md
@@ -62,6 +62,10 @@ HubSpot has several limits for custom behavioral events, including a limit on th
 > note ""
 > A HubSpot Enterprise Marketing Hub account is required to send Custom Behavioral Events.
 
+### Why can't I set an entire object for the Other properties field?
+
+This destination does not allow selecting an entire object for the Other properties field. HubSpot rejects API calls if a property name does not match with HubSpot's internal name. To prevent the possibility of rejection when working with a large object of key/value pairs, explicit mapping of each key/value pair is required. This helps to ensure that every key matches the pre-created property names in HubSpot.
+
 ### Does the HubSpot Cloud Mode (Actions) destination support EU data residency?
 Yes. HubSpot will automatically redirect API requests directly to an EU data center if your HubSpot instance is on an EU data center. See more in HubSpot's [Routing API Traffic](https://product.hubspot.com/blog/routing-api-traffic){:target="_blank"} article.
 


### PR DESCRIPTION
### Proposed changes

Per this slack thread: https://twilio.slack.com/archives/CC97A542H/p1669907095535879?thread_ts=1669882189.824319&cid=CC97A542H

HubSpot (Actions) does not allow mapping an entire object to Other properties field because it helps to avoid passing a huge object of key/value pairs that will get rejected.

Adding this information to FAQs per customer request

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
