### PR TITLE
Update send-data.md Updated page with List Destination info

### DIFF
--- a/src/engage/journeys/send-data.md
+++ b/src/engage/journeys/send-data.md
@@ -26,7 +26,7 @@ Follow these steps to send a test event:
 
 1. From the **Send to destinations** window, select **+ Add destination**.
 2. Choose the Destination that you want to connect.
-3. In the Destination pane, select **Event tester**. (This is only available for [Event Destinations][https://segment.com/docs/engage/using-engage-data/#engage-destination-types-event-vs-list].)
+3. In the Destination pane, select **Event tester**. This is only available for [Event Destinations](/docs/engage/using-engage-data/#engage-destination-types-event-vs-list).
 4. From the **Event Type** drop-down, select the event you want to test. Segment generates a test user ID.
 5. Select **Send Event**, then view the test event results in the **Event lifecycle** section.
 

--- a/src/engage/journeys/send-data.md
+++ b/src/engage/journeys/send-data.md
@@ -26,8 +26,8 @@ Follow these steps to send a test event:
 
 1. From the **Send to destinations** window, select **+ Add destination**.
 2. Choose the Destination that you want to connect.
-3. In the Destination pane, select **Event tester**. (This is only available for [Event Destinations]([url](https://segment.com/docs/engage/using-engage-data/#engage-destination-types-event-vs-list)).)
-4. From the **Event Type** dropdown, select the event you want to test. Segment generates a test user ID.
+3. In the Destination pane, select **Event tester**. (This is only available for [Event Destinations][https://segment.com/docs/engage/using-engage-data/#engage-destination-types-event-vs-list].)
+4. From the **Event Type** drop-down, select the event you want to test. Segment generates a test user ID.
 5. Select **Send Event**, then view the test event results in the **Event lifecycle** section.
 
 If your Destination successfully handled the event, Segment displays a `200 OK` HTTP status code along with the full response. If an error occurred, Segment displays any available details in the Event lifecyle section.

--- a/src/engage/journeys/send-data.md
+++ b/src/engage/journeys/send-data.md
@@ -26,7 +26,7 @@ Follow these steps to send a test event:
 
 1. From the **Send to destinations** window, select **+ Add destination**.
 2. Choose the Destination that you want to connect.
-3. In the Destination pane, select **Event tester**.
+3. In the Destination pane, select **Event tester**. (This is only available for [Event Destinations]([url](https://segment.com/docs/engage/using-engage-data/#engage-destination-types-event-vs-list)).)
 4. From the **Event Type** dropdown, select the event you want to test. Segment generates a test user ID.
 5. Select **Send Event**, then view the test event results in the **Event lifecycle** section.
 
@@ -69,6 +69,6 @@ When the user enters the step:
 
 ### List destination
 
-The destination receives a list of users who qualify for the associated journey step. Unlike lists associated with Engage Audiences, users who are added to a journey list cannot be subsequently removed. See [best practices](/docs/engage/journeys/faq-best-practices#suppress-targeting-with-journey-lists) for techniques to suppress targeting with journey lists.
+The destination receives a list of users who qualify for the associated journey step. Unlike lists associated with Engage Audiences, users who are added to a journey list cannot be subsequently removed. See [best practices](/docs/engage/journeys/faq-best-practices#suppress-targeting-with-journey-lists) for techniques to suppress targeting with journey lists. List destinations do not have access to the Event Tester.
 
 For more information, see [Using Engage Data](/docs/engage/using-engage-data/).

--- a/src/engage/journeys/send-data.md
+++ b/src/engage/journeys/send-data.md
@@ -69,6 +69,6 @@ When the user enters the step:
 
 ### List destination
 
-The destination receives a list of users who qualify for the associated journey step. Unlike lists associated with Engage Audiences, users who are added to a journey list cannot be subsequently removed. See [best practices](/docs/engage/journeys/faq-best-practices#suppress-targeting-with-journey-lists) for techniques to suppress targeting with journey lists. List destinations do not have access to the Event Tester.
+The destination receives a list of users who qualify for the associated journey step. Unlike lists associated with Engage Audiences, users who are added to a journey list cannot be subsequently removed. See [best practices](/docs/engage/journeys/faq-best-practices#suppress-targeting-with-journey-lists) for techniques to suppress targeting with journey lists. List destinations do not have access to the Event tester.
 
 For more information, see [Using Engage Data](/docs/engage/using-engage-data/).


### PR DESCRIPTION
### Proposed changes

A customer recently wrote in about why the Event Tester was not available when viewing journeys. This was related to it being connected to a List Destination, which does not have access to the Event Tester. Having this information across multiple docs, or at least referencing the other doc would improve customer understanding of these topics.

### Merge timing
- ASAP once approved?

### Related issues (optional)

Zendesk Ticket : https://segment.zendesk.com/agent/tickets/510108
