### PR TITLE
Update install instructions to new braze sdk

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/braze-react-native.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/braze-react-native.md
@@ -21,17 +21,17 @@ You need to install the `@segment/analytics-react-native-plugin-braze` and the `
 
 Using NPM:
 ```bash
-npm install --save @segment/analytics-react-native-plugin-braze react-native-appboy-sdk
+npm install --save @segment/analytics-react-native-plugin-braze @braze/react-native-sdk
 ```
 
 Using Yarn:
 ```bash
-yarn add @segment/analytics-react-native-plugin-braze react-native-appboy-sdk
+yarn add @segment/analytics-react-native-plugin-braze @braze/react-native-sdk
 ```
 
 Run `pod install` after the installation to autolink the Braze SDK.
 
-See [Braze React SDK](https://github.com/Appboy/appboy-react-sdk) for more details of this dependency.
+See [Braze React SDK](https://github.com/braze-inc/braze-react-native-sdk) for more details of this dependency.
 
 ## Using the Plugin in your App
 


### PR DESCRIPTION
### Proposed changes

The install instructions in the docs had customers installing the `react-native-appboy-sdk` rather than the new `braze/react-native-sdk` per our plugin [instructions here](https://github.com/segmentio/analytics-react-native/tree/master/packages/plugins/plugin-braze)

### Merge timing

- ASAP once approved

### Related issues (optional)

n/a
