### PR TITLE
Add troubleshooting guide for Redshift rETL

### DIFF
--- a/src/connections/reverse-etl/reverse-etl-source-setup-guides/redshift-setup.md
+++ b/src/connections/reverse-etl/reverse-etl-source-setup-guides/redshift-setup.md
@@ -25,3 +25,10 @@ To set up Redshift with Reverse ETL:
 Give the `segment` user read permissions for any resources (databases, schemas, tables) the query needs to access. 
 
 Give the `segment` user write permissions for the Segment managed schema (`__segment_reverse_etl`), which keeps track of changes to the query results.  
+
+### Troubleshooting
+#### Extraction failures: relation does not exist
+If you are able to run the query in the Query Builder, but the sync fails with `relation does not exist` error, please make sure the schema name is included before the database table name, and check that the schema name is correct:
+```ts
+SELECT id FROM <schema_name>.<table_name>
+```

--- a/src/connections/reverse-etl/reverse-etl-source-setup-guides/redshift-setup.md
+++ b/src/connections/reverse-etl/reverse-etl-source-setup-guides/redshift-setup.md
@@ -28,7 +28,7 @@ Give the `segment` user write permissions for the Segment managed schema (`__seg
 
 ### Troubleshooting
 #### Extraction failures: relation does not exist
-If you are able to run the query in the Query Builder, but the sync fails with `relation does not exist` error, please make sure the schema name is included before the database table name, and check that the schema name is correct:
+If you are able to run the query in the Query Builder, but the sync fails with the `relation does not exist` error, please make sure the schema name is included before the database table name, and check that the schema name is correct:
 ```ts
 SELECT id FROM <schema_name>.<table_name>
 ```


### PR DESCRIPTION
### Proposed changes
The customer has encountered an error when initiating the first sync from their Redshift rETL source:  
```
relation "tb_customers" does not exist
```
 

However, they were able to retrieve the records when testing in query builder. Here is the query they were using:
```
SELECT id id_do_cliente, email, document, name, telephone, date(created_at) cadastro_em 
FROM tb_customers
```
 
In the end, the issue was resolved by adding the schema name in front of the database table name:
```
SELECT id id_do_cliente, email, document, name, telephone, date(created_at) cadastro_em 
FROM <schema_name>.tb_customers
```
 
Supporting docs - [Starting with Amazon Redshift Cluster for SQL Database Developer](https://www.kodyaz.com/aws/amazon-redshift-cluster-for-sql-database-developers.aspx)  

> If you don't use the schema name and execute the SELECT statement directly on "tables" table, you will get the execution exception:
> 
> [Amazon](500310) Invalid operation: relation "tables" does not exist;
> 
> If you get such an error, be sure you are using the schema name in front of the database table name and check the schema name is correct.


### Merge timing
ASAP once approved