### PR TITLE
Update custom-proxy.md SDK initialization

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
@@ -116,8 +116,7 @@ const analytics = AnalyticsBrowser.load(
 
 ## Custom Proxy CloudFront
 
-These instructions refer to Amazon CloudFront, but apply more generally to other providers as well. Once you've updated the SDK initialization in your application, you can proceed with the following steps to set up your CDN Proxy. 
-(Changing the configuration in the Segment UI before the SDK initialization has been made can result in unexpected changes in app behavior)
+These instructions refer to Amazon CloudFront, but apply more generally to other providers as well. Before changing the Segment UI (Segment tracking API) or the Segment snippet (Segment CDN) to use your new proxy, please ensure that you have completed the custom domain proxy setup on your side to avoid any unexpected behavior.
 
 ### CDN Proxy
 To set up your CDN Proxy:

--- a/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
@@ -116,7 +116,8 @@ const analytics = AnalyticsBrowser.load(
 
 ## Custom Proxy CloudFront
 
-These instructions refer to Amazon CloudFront, but apply more generally to other providers as well.
+These instructions refer to Amazon CloudFront, but apply more generally to other providers as well. Once you've updated the SDK initialization in your application, you can proceed with the following steps to set up your CDN Proxy. 
+(Changing the configuration in the Segment UI before the SDK initialization has been made can result in unexpected changes in app behavior)
 
 ### CDN Proxy
 To set up your CDN Proxy:

--- a/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
@@ -116,7 +116,7 @@ const analytics = AnalyticsBrowser.load(
 
 ## Custom Proxy CloudFront
 
-These instructions refer to Amazon CloudFront, but apply more generally to other providers as well. Before changing the Segment UI (Segment tracking API) or the Segment snippet (Segment CDN) to use your new proxy, please ensure that you have completed the custom domain proxy setup on your side to avoid any unexpected behavior.
+These instructions refer to Amazon CloudFront, but apply more generally to other providers as well. Before changing the Segment Tracking API or the Segment snippet (Segment CDN) to use your new proxy, complete the custom domain proxy setup on your side to avoid any unexpected behavior.
 
 ### CDN Proxy
 To set up your CDN Proxy:


### PR DESCRIPTION
A customer pointed out that, before starting with the CDN Proxy setup, they needed to update the SDK initialization within your application first.

Ticket: https://segment.zendesk.com/agent/tickets/510041 

### Proposed changes

"These instructions refer to Amazon CloudFront, but apply more generally to other providers as well. Once you've updated the SDK initialization in your application, you can proceed with the following steps to set up your CDN Proxy. 
(Changing the configuration in the Segment UI before the SDK initialization has been made can result in unexpected changes in app behaviour)"

Before starting with the CDN Proxy setup, customers need to update the SDK initialization within your application first.  Changing the configuration in the Segment UI before the SDK initialization has been made can result in unexpected changes in app behaviour.

### Merge timing

- ASAP once approved


### Related issues (optional)
N/A
