### PR TITLE
Add email size limit

### DIFF
--- a/src/engage/campaigns/broadcasts.md
+++ b/src/engage/campaigns/broadcasts.md
@@ -72,6 +72,12 @@ SMS broadcasts longer than 160 characters are split into segments and then joine
 
 For more on message segments, view [SMS character limits](https://www.twilio.com/docs/glossary/what-sms-character-limit){:target="_blank"}.
 
+### Email Templates Limits
+
+The total size of your email, including attachments, must be less than 30MB.
+
+For more on email limits, view [Email Limits](https://docs.sendgrid.com/api-reference/mail-send/limitations#:~:text=The%20total%20size%20of%20your,must%20no%20more%20than%201000.){:target="_blank"}.
+
 ### Scale and throughput
 
 The following table lists geographic availability, scale, and speed details for email broadcasts and [short code SMS](https://support.twilio.com/hc/en-us/articles/223182068-What-is-a-Messaging-Short-Code-){:target="_blank"} broadcasts:


### PR DESCRIPTION
Email template size limit is set by SendGrids limits, which are detailed in https://docs.sendgrid.com/api-reference/mail-send/limitations#:~:text=The%20total%20size%20of%20your,must%20no%20more%20than%201000.

This is in place after a fix deployed on 15/06. Thread: https://twilio.slack.com/archives/C01L65AUTF1/p1686784823831639?thread_ts=1678225834.689149&cid=C01L65AUTF1

### Proposed changes

Added limit as mentioned in SendGrids docs and link to that doc

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
