### PR TITLE
Warning about audience edit for anon users

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -168,6 +168,8 @@ Engage then processes your realtime Audience or Trait edits. While the edit task
 > warning ""
 > It is not possible to edit an audience to convert it from real-time to batch, or vice-versa. If the computation type needs to be changed, you will need to recreate the audience with the appropriate conditions.
 
+> warning ""
+> It is not possible to edit an audience to include anonymous users. If anonymous profiles need to be included, you will need to recreate the audience with the appropriate conditions.
 
 ## Access your Audiences using the Profiles API
 

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -169,7 +169,7 @@ Engage then processes your realtime Audience or Trait edits. While the edit task
 > It is not possible to edit an audience to convert it from real-time to batch, or vice-versa. If the computation type needs to be changed, you will need to recreate the audience with the appropriate conditions.
 
 > warning ""
-> It is not possible to edit an audience to include anonymous users. If anonymous profiles need to be included, you will need to recreate the audience with the appropriate conditions.
+> You can't edit an audience to include anonymous users. If you need to include anonymous profiles, recreate the audience with the appropriate conditions
 
 ## Access your Audiences using the Profiles API
 


### PR DESCRIPTION
Based on https://segment.atlassian.net/browse/JON-780?atlOrigin=eyJpIjoiNjgyNmYzOGJmMzJhNDIzYTg3MTE2NGNkZjJhYmRhODIiLCJwIjoiaiJ9, eng has determined that edits to change the anon user flag are not supported by the backend, so the operation will be locked in the UI. Adding a warning note to reflect this.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
