### PR TITLE
The Intercom source syncs all historic data

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/intercom/index.md
+++ b/src/connections/sources/catalog/cloud-apps/intercom/index.md
@@ -37,7 +37,7 @@ Segment begins to sync your Intercom data into Segment, and writes it to your wa
 
 The Intercom source has a sync component, which means Segment make requests to [their API](https://developers.intercom.io/docs/) on your behalf on a 3 hour interval to pull all historical data into Segment. In the initial sync, Segment grabs all the Intercom objects (and their corresponding properties) according to the collections table below. The objects will be written into a designated schema corresponding to the source instance's schema name you designated upon creation. For example, if you went with `intercom_prod`, the `users` collection will be accessible at `intercom_prod.users` in SQL.
 
-The sync component uses an upsert API, so the data loaded to your warehouse during syncs will reflect the latest state of the corresponding resource in Intercom.  For example, if the `users.last_seen_ip` will be the latest value upon each sync.
+The sync component uses an upsert API, so the data in your warehouse loaded using sync will reflect the latest state of the corresponding resource in Intercom.  For example, if the `users.last_seen_ip` will be the latest value upon each sync.
 
 The source syncs and warehouse syncs are independent processes. Source runs pull your data into the Segment Hub, and warehouse runs flush that data to your warehouse. Sources will sync with Segment every 3 hours. Depending on your Warehouses plan, Segment pushes the Source data to your warehouse on the interval associated with your billing plan.
 

--- a/src/connections/sources/catalog/cloud-apps/intercom/index.md
+++ b/src/connections/sources/catalog/cloud-apps/intercom/index.md
@@ -35,9 +35,9 @@ Segment begins to sync your Intercom data into Segment, and writes it to your wa
 
 ### Sync
 
-The Intercom source has a sync component, which means Segment make requests to [their API](https://developers.intercom.io/docs/) on your behalf on a 3 hour interval to pull the latest data into Segment. In the initial sync, Segment grabs all the Intercom objects (and their corresponding properties) according to the collections table below. The objects will be written into a designated schema corresponding to the source instance's schema name you designated upon creation. For example, if you went with `intercom_prod`, the `users` collection will be accessible at `intercom_prod.users` in SQL.
+The Intercom source has a sync component, which means Segment make requests to [their API](https://developers.intercom.io/docs/) on your behalf on a 3 hour interval to pull all historical data into Segment. In the initial sync, Segment grabs all the Intercom objects (and their corresponding properties) according to the collections table below. The objects will be written into a designated schema corresponding to the source instance's schema name you designated upon creation. For example, if you went with `intercom_prod`, the `users` collection will be accessible at `intercom_prod.users` in SQL.
 
-The sync component uses an upsert API, so the data in your warehouse loaded using sync will reflect the latest state of the corresponding resource in Intercom.  For example, if the `users.last_seen_ip` will be the latest value upon each sync.
+The sync component uses an upsert API, so the data loaded to your warehouse during syncs will reflect the latest state of the corresponding resource in Intercom.  For example, if the `users.last_seen_ip` will be the latest value upon each sync.
 
 The source syncs and warehouse syncs are independent processes. Source runs pull your data into the Segment Hub, and warehouse runs flush that data to your warehouse. Sources will sync with Segment every 3 hours. Depending on your Warehouses plan, Segment pushes the Source data to your warehouse on the interval associated with your billing plan.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Intercom source syncs completely, meaning all historical data is pulled with each source sync. The public doc mentioned that this source pulls the latest data every 3 hours. This could confuse the customers. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
