### PR TITLE
Note about array of objects in the builder.md

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -35,7 +35,7 @@ You can also build Audiences based on custom traits. These traits can be collect
 You can also use computed traits in an Audience definition. For example, you can create a `total_revenue` computed trait and use it to generate an audience of `big_spender` customers that exceed a certain threshold.
 
 > info ""
-> Engage does support nested traits, however, accessing objects nested in arrays is not currently supported by the Audience builder. When arrays of objects are sent, they will be flattened into strings. For building audiences based on array traits, all the same conditions that would work on strings will work on the array. Within the builder, you can only use string operations like 'contains' and 'does not contain' to look for individual characters or a set of characters in the flattened array.
+> Engage supports nested traits, but the Audience builder doesn’t support accessing objects nested in arrays. When you send arrays of objects, they are flattened into strings. As a result, the same conditions that work on strings will work on the array. Within the builder, you can only use string operations like `contains` and `does not contain` to look for individual characters or a set of characters in the flattened array.
 
 ### Funnel Audiences
 

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -34,6 +34,8 @@ You can also build Audiences based on custom traits. These traits can be collect
 
 You can also use computed traits in an Audience definition. For example, you can create a `total_revenue` computed trait and use it to generate an audience of `big_spender` customers that exceed a certain threshold.
 
+> info ""
+> Engage does support nested traits, however, accessing objects nested in arrays is not currently supported by the Audience builder. When arrays of objects are sent, they will be flattened into strings. For building audiences based on array traits, all the same conditions that would work on strings will work on the array. Within the builder, you can only use string operations like 'contains' and 'does not contain' to look for individual characters or a set of characters in the flattened array.
 
 ### Funnel Audiences
 


### PR DESCRIPTION
Engage does support nested traits, however, accessing objects nested in arrays is not currently supported by the Audience builder.

To go a bit more into how arrays work with Engage, when arrays are sent, they get flattened into strings and stored in our backend. For building audiences based on array traits, all the same conditions that would work on strings will work on the array (since the array is now being treated as a string).

Said in other words, when you try to access a trait within an object in an array in the Audience builder, you won't be able to access any of the nested objects. Instead, you can only use string operations like 'contains' and 'does not contain' to look for individual characters or a set of characters in the string.


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
