### PR TITLE
Remove cross_domain_id reference

### DIFF
--- a/src/unify/identity-resolution/externalids.md
+++ b/src/unify/identity-resolution/externalids.md
@@ -27,7 +27,6 @@ Segment automatically promotes the following traits and IDs in track and identif
 | android.idfa       | context.device.advertisingId when context.device.type = 'android' AND context.device.adTrackingEnabled = true |
 | android.push_token | context.device.token when context.device.type = 'android'                                                     |
 | anonymous_id       | anonymousId                                                                                                   |
-| cross_domain_id    | cross_domain_id when XID has been enabled for the workspace                                                   |
 | ga_client_id       | context.integrations['Google Analytics'].clientId when explicitly captured by users                           |
 | group_id           | groupId                                                                                                       |
 | ios.id             | context.device.id when context.device.type = 'ios'                                                            |


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->
- Removed `cross_domain_id` from the externalID docs as Segment no longer supports this.
### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->
- Once approved
### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
