### PR TITLE
Add note on mapping limitation

### DIFF
--- a/src/connections/destinations/catalog/eloqua/index.md
+++ b/src/connections/destinations/catalog/eloqua/index.md
@@ -124,7 +124,7 @@ in Eloqua and a property called `AccountType` in your Segment event, the
 mapping will get handled.
 
 > info "Track event mapping limitations"
-> Each track event can only be mapped to a single custom object; mapping a single track event to multiple custom objects is not supported.
+> Each `track` event can only be mapped to a single custom object. Segment doesn't support mapping a single `track` event to multiple custom objects.
 
 For `track` event properties you intend to send to Eloqua as Custom Object
 fields, make sure the value of the data type sent to Segment matches the

--- a/src/connections/destinations/catalog/eloqua/index.md
+++ b/src/connections/destinations/catalog/eloqua/index.md
@@ -123,6 +123,9 @@ formatting-insensitive match so that if you have a field called `Account Type`
 in Eloqua and a property called `AccountType` in your Segment event, the
 mapping will get handled.
 
+> info "Track event mapping limitations"
+> Each track event can only be mapped to a single custom object; mapping a single track event to multiple custom objects is not supported.
+
 For `track` event properties you intend to send to Eloqua as Custom Object
 fields, make sure the value of the data type sent to Segment matches the
 data type specified in your Eloqua dashboard. If a Custom Object field data


### PR DESCRIPTION
### Proposed changes

Track events can only be mapped to a single custom object - even if you try updating the settings to do so, the UI will only save the last mapping for a given event. 

Added note to docs that highlight this and clarify that mapping a single track event to multiple custom objects is not supported.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
