### PR TITLE
Add upgrade link to the React Native Side Menu

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -168,7 +168,9 @@ sections:
   - path: /connections/sources/catalog/libraries/mobile/react-native
     title: Overview
   - path: /connections/sources/catalog/libraries/mobile/react-native/implementation
-    title: Implementation / Upgrade
+    title: Implementation
+  - path: /connections/sources/catalog/libraries/mobile/react-native/migration
+    title: Upgrade
   - path: /connections/sources/catalog/libraries/mobile/react-native/destination-plugins
     title: Destination Plugins
   - path: /connections/sources/catalog/libraries/mobile/react-native/cloud-mode-destinations


### PR DESCRIPTION
### Proposed changes
This page is not listed in our RN menu: https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/migration/
Adding it to show in the menu sidebar.
