### PR TITLE
SQL trait name clarification

### DIFF
--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -257,6 +257,6 @@ Segment added the compute schedule feature on Feb 8, 2021, so traits created pri
 
 Check that you've configured the identifier that uniquely identifies users in a SQL query (`user_id`, `anonymous_id`, `email`, or `group_id` for account traits) in Identity Resolution settings as an identifier. This ensures the trait is added to the user's profile with the correct identifier. If you don't configure the identifier in Identity Resolution settings, the trait's value is not added to the user profile.
 
-### Why doesn't the identifier updated by SQL trait shows the correct value found in the column?
+### Why doesn't the identifier updated by a SQL trait show the correct value found in the column?
 
 Ensure that the name given to the SQL trait is not the same name as the identifier or column name from the query. To use SQL trait to update the identifier, the identifier will need to be a column in the query of your SQL trait. The column name in the query of SQL trait should be the one that Identity Resolution use to generate the identifier. 

--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -256,3 +256,7 @@ Segment added the compute schedule feature on Feb 8, 2021, so traits created pri
 ### Why doesn't the value of a SQL trait show in a user profile after a successful sync?
 
 Check that you've configured the identifier that uniquely identifies users in a SQL query (`user_id`, `anonymous_id`, `email`, or `group_id` for account traits) in Identity Resolution settings as an identifier. This ensures the trait is added to the user's profile with the correct identifier. If you don't configure the identifier in Identity Resolution settings, the trait's value is not added to the user profile.
+
+### Why doesn't the identifier updated by SQL trait shows the correct value found in the column?
+
+Ensure that the name given to the SQL trait is not the same name as the identifier or column name from the query. To use SQL trait to update the identifier, the identifier will need to be a column in the query of your SQL trait. The column name in the query of SQL trait should be the one that Identity Resolution use to generate the identifier. 

--- a/src/engage/audiences/sql-traits.md
+++ b/src/engage/audiences/sql-traits.md
@@ -259,4 +259,4 @@ Check that you've configured the identifier that uniquely identifies users in a 
 
 ### Why doesn't the identifier updated by a SQL trait show the correct value found in the column?
 
-Ensure that the name given to the SQL trait is not the same name as the identifier or column name from the query. To use SQL trait to update the identifier, the identifier will need to be a column in the query of your SQL trait. The column name in the query of SQL trait should be the one that Identity Resolution use to generate the identifier. 
+Ensure that the name given to the SQL trait is not the same name as the identifier or column name from the query. To use SQL traits to update an identifier, the identifier will need to be a column in the query of your SQL trait. The column name in the query of the SQL trait should be the one that Identity Resolution uses to generate the identifier. 


### PR DESCRIPTION
### Proposed changes
Added the following question and answer to indicate that the name of SQL trait should not be the same name as the identifier.

"Why doesn't the identifier updated by SQL trait shows the correct value found in the column?

Ensure that the name given to the SQL trait is not the same name as the identifier or column name from the query. To use SQL trait to update the identifier, the identifier will need to be a column in the query of your SQL trait. The column name in the query of SQL trait should be the one that Identity Resolution use to generate the identifier."

Issue occurred in ticket https://segment.zendesk.com/agent/tickets/509275. Customer use an SQL trait with a name that is the same as the identifier, and resulted in Identifier with incorrect value.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
https://segment.zendesk.com/agent/tickets/509275
