### PR TITLE
add slug overrides to fix the integrations from being hidden

### DIFF
--- a/src/_data/catalog/slugs.yml
+++ b/src/_data/catalog/slugs.yml
@@ -7,6 +7,10 @@ sources:
   - original: "shopify-by-littledata"
     override: "shopify-littledata"
 destinations:
+  - original: "vwo-cloud-mode-actions"
+    override: "actions-vwo-cloud"
+  - original: "vwo-web-mode-actions"
+    override: "actions-vwo-web"
   - original: "talon-one"
     override: "talonone"
   - original: "google-adwords-remarketing-lists-customer-match"


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Currently the VWO actions dest show as hidden in the `destinations.yml` file, preventing the docs from showing on their respective category pages. These slug overrides address that.

### Merge timing
asap

