### PR TITLE
update known invalid settings issue  for adwords-remarketing-lists

### DIFF
--- a/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
+++ b/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
@@ -123,6 +123,10 @@ You can set an email on the user profile by including `email` as a trait, as a p
 
 If a user has more than one email address or IDFA on their account as `external_ids`, Engage sends the most recent id on the user profile to Adwords for matching. The match rate will be low if Google can't identify users based on the data that you provide.
 
+### Invalid Settings error in Event Delivery
+
+Make sure that this destination was created in [Engage](/docs/engage/) as it requires additional event data not available in standard destinations.
+
 ## FAQs
 
 #### What Google Ads campaigns does Engage support?


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Customers have been creating the `adwords-remarketing-list` destination outside of Engage which leads it to have a 100% error rate. Until we can restrict the creation of the destination to the proper workflows, we're doing a small documentation update.

### Merge timing
ASAP

### Related issues (optional)
https://segment.atlassian.net/browse/STRATCONN-2760
