### PR TITLE
Add note on Facebook Custom Audiences destination

### DIFF
--- a/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
+++ b/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
@@ -7,6 +7,9 @@ id: 5a4d24dcc5836400017188f6
 ---
 ## Overview
 
+> info ""
+> Using this destination requires a Business tier account and includes [Engage](/docs/engage/).
+
 The Facebook Custom Audiences Destination is one of the most popular Engage Destinations. It has a variety of use cases related to suppression, acquisition (using lookalikes), retargeting, and more.
 
 This Destination can send audiences (lists of users) created in Engage to Facebook Custom Audiences as a **User-List**. Once you set this up, Segment sends an initial list of users to Facebook, and then keeps it up-to-date as new users enter or exit that audience.

--- a/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
+++ b/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
@@ -7,9 +7,6 @@ id: 5a4d24dcc5836400017188f6
 ---
 ## Overview
 
-> info ""
-> Using this destination requires a Business tier account and includes [Engage](/docs/engage/).
-
 The Facebook Custom Audiences Destination is one of the most popular Engage Destinations. It has a variety of use cases related to suppression, acquisition (using lookalikes), retargeting, and more.
 
 This Destination can send audiences (lists of users) created in Engage to Facebook Custom Audiences as a **User-List**. Once you set this up, Segment sends an initial list of users to Facebook, and then keeps it up-to-date as new users enter or exit that audience.
@@ -18,7 +15,7 @@ This allows you to run advertising campaigns in Facebook without having to manua
 
 
 ## Other Facebook Destinations Supported by Segment
-This page is about the **Facebook Custom Audiences** destination developed specifically for use with **EngagePersonas**. For documentation on other Facebook destinations, see the pages linked below.
+This page is about the **Facebook Custom Audiences** destination developed specifically for use with [Engage](/docs/engage/). This destination is not supported by other sources. For documentation on other Facebook destinations, see the pages linked below.
 
 | **Facebook Destination**                                                                                    | Supported by Engage |
 | ----------------------------------------------------------------------------------------------------------- | ------------------- |

--- a/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
+++ b/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
@@ -15,7 +15,7 @@ This allows you to run advertising campaigns in Facebook without having to manua
 
 
 ## Other Facebook Destinations Supported by Segment
-This page is about the **Facebook Custom Audiences** destination developed specifically for use with [Engage](/docs/engage/). This destination is not supported by other sources. For documentation on other Facebook destinations, see the pages linked below.
+This page is about the **Facebook Custom Audiences** destination developed specifically for use with [Engage](/docs/engage/). No other sources support this destination. For documentation on other Facebook destinations, see the pages linked below.
 
 | **Facebook Destination**                                                                                    | Supported by Engage |
 | ----------------------------------------------------------------------------------------------------------- | ------------------- |


### PR DESCRIPTION
### Proposed changes
A team plan customer has reached out regarding sending iOS events to Facebook Custom Audiences destination. So I’d like to add an info on our public doc for clarification:

> Using this destination requires a Business tier account and includes [Engage](https://github.com/segmentio/segment-docs/blob/develop/docs/engage).

### Merge timing
ASAP once approved