### PR TITLE
Update faqs.md

### DIFF
--- a/src/engage/faqs.md
+++ b/src/engage/faqs.md
@@ -122,3 +122,6 @@ Yes, Engage supports the ability to send an audience or computed trait to two or
 An audience/computed trait Run or a Sync may fail on its first attempt, but Engage will retry up to 5 times before considering it a hard failure and display on that audience/compute trait's Overview page. As long as the runs/syncs within the specific Audience's Overview page say they are successful, then these can be safely ignored.  The Audit Trail logic, however, is configured in the way that it simply notifies about every task failure, even if it then later succeeds.
 
 If your team would like to avoid receiving the notifications for transient failures, please **[reach out to support](https://segment.com/help/contact/)**, who upon request can disable transient failure notifications.
+
+### Can I delete certain events of users from Engage? 
+No. Alternatively, you could achieve this by deleting the entire user profile from Segment. 


### PR DESCRIPTION
### Proposed changes

Customer has inquired if it is possible to erase only tracks and identify calls of certain users from Segment’s Engage. This is currently not feasible and the only way around it is to delete the full profile of a user based on their userId from Segment’s systems, including Engage/Unify. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
