### PR TITLE
Add info about columns for external_id_mapping_updates table

### DIFF
--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -111,7 +111,26 @@ If you’ll use Profiles Sync to build models, refer to the `id_graph` model, wh
 
 ### The external_id_mapping_updates table
 
-This table maps Segment-generated identifiers, like `segment_id`, to external identifiers that your users provide.
+This table maps Segment-generated identifiers, like `segment_id`, to external identifiers that your users provide. It has the following columns:
+
+| field                         | description                                                                                         |
+| ----------------------------- | --------------------------------------------------------------------------------------------------- |
+| `EXTERNAL_ID_HASH`            | The hash of the identifier sent in the incoming event.                                              |
+| `EXTERNAL_ID_TYPE`            | The type of  the external identifier sent in the incoming event such as `user_id` or `anonymous_id`. External identifiers become the identities attached to a user profile. |
+| `EXTERNAL_ID_VALUE`           | The value of the identifier sent in the incoming event.                                             |
+| `ID`                          | A unique identifier for the table row.                                                              |
+| `RECEIVED_AT`                 | The timestamp when the Segment API receives the payload from client or server.                      |
+| `SEGMENT_ID`                  | The Profile ID that Segment appends to an event or an identifier at the time it was first observed. |
+| `SEQ`                         | A sequential value derived from the timestamp.                                                      |
+| `TIMESTAMP`                   | The UTC-converted timestamp set by the Segment library.                                             |
+| `TRIGGERING_EVENT_ID`         | The specific ID of the incoming event.                                                              |
+| `TRIGGERING_EVENT_NAME`       | The specific name of the incoming event.                                                            |
+| `TRIGGERING_EVENT_SOURCE_ID`  | The specific source ID of the incoming event.                                                       |
+| `TRIGGERING_EVENT_SOURCE_NAME`| The name of the source that triggered the event.                                                    |
+| `TRIGGERING_EVENT_SOURCE_SLUG`| The slug of the source that triggered the event.                                                    |
+| `TRIGGERING_EVENT_TYPE`       | The type of the tracking method used for triggering the incoming event.                             |
+| `UUID_TS`                     | A unique identifier of the timestamp.                                                               |
+
 
 The anonymous site visits sample used earlier would generate the following events:
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -116,10 +116,10 @@ This table maps Segment-generated identifiers, like `segment_id`, to external id
 | field                         | description                                                                                         |
 | ----------------------------- | --------------------------------------------------------------------------------------------------- |
 | `EXTERNAL_ID_HASH`            | The hash of the identifier sent in the incoming event.                                              |
-| `EXTERNAL_ID_TYPE`            | The type of  the external identifier sent in the incoming event such as `user_id` or `anonymous_id`. External identifiers become the identities attached to a user profile. |
+| `EXTERNAL_ID_TYPE`            | The type of external identifier sent in the incoming event, such as `user_id` or `anonymous_id`. External identifiers become the identities attached to a user profile. |
 | `EXTERNAL_ID_VALUE`           | The value of the identifier sent in the incoming event.                                             |
 | `ID`                          | A unique identifier for the table row.                                                              |
-| `RECEIVED_AT`                 | The timestamp when the Segment API receives the payload from client or server.                      |
+| `RECEIVED_AT`                 | The timestamp when the Segment API receives the payload from the client or server.                      |
 | `SEGMENT_ID`                  | The Profile ID that Segment appends to an event or an identifier at the time it was first observed. |
 | `SEQ`                         | A sequential value derived from the timestamp.                                                      |
 | `TIMESTAMP`                   | The UTC-converted timestamp set by the Segment library.                                             |
@@ -128,7 +128,7 @@ This table maps Segment-generated identifiers, like `segment_id`, to external id
 | `TRIGGERING_EVENT_SOURCE_ID`  | The specific source ID of the incoming event.                                                       |
 | `TRIGGERING_EVENT_SOURCE_NAME`| The name of the source that triggered the event.                                                    |
 | `TRIGGERING_EVENT_SOURCE_SLUG`| The slug of the source that triggered the event.                                                    |
-| `TRIGGERING_EVENT_TYPE`       | The type of the tracking method used for triggering the incoming event.                             |
+| `TRIGGERING_EVENT_TYPE`       | The type of tracking method used for triggering the incoming event.                             |
 | `UUID_TS`                     | A unique identifier of the timestamp.                                                               |
 
 


### PR DESCRIPTION
### Proposed changes

[Our public docs](https://segment.com/docs/unify/profiles-sync/tables/#the-external_id_mapping_updates-table) are missing some columns for the external_id_mapping_updates table. And here are all the columns in the external_id_mapping_updates table:
```
EXTERNAL_ID_TYPE
RECEIVED_AT
SEGMENT_ID
TRIGGERING_EVENT_ID
TIMESTAMP
TRIGGERING_EVENT_NAME
TRIGGERING_EVENT_SOURCE_ID
TRIGGERING_EVENT_TYPE
EXTERNAL_ID_HASH
EXTERNAL_ID_VALUE
ID
SEQ
UUID_TS
TRIGGERING_EVENT_SOURCE_SLUG
TRIGGERING_EVENT_SOURCE_NAME
```

### Merge timing
ASAP once approved