### PR TITLE
Adding info about new http client

### DIFF
--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -556,7 +556,7 @@ const appAnalytics = new Analytics({ writeKey: 'APP_WRITE_KEY' });
 ```
 ## AnalyticsHTTPClient
 
-We attempt to use the global `fetch` implementation if available in order to support several diverse environments.  Some special cases (e.g. http proxy) may require a different implementation for http communication.  A customized wrapper can be provided in the Analytics configuration to support this.  Here are a few approaches:
+Segment attempts to use the global `fetch` implementation if available in order to support several diverse environments.  Some special cases (for example, http proxy) may require a different implementation for http communication.  You can provide a customized wrapper in the Analytics configuration to support this.  Here are a few approaches:
 
 Use a custom fetch-like implementation with proxy (simple, recommended)
 ```

--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -559,8 +559,9 @@ const appAnalytics = new Analytics({ writeKey: 'APP_WRITE_KEY' });
 Segment attempts to use the global `fetch` implementation if available in order to support several diverse environments.  Some special cases (for example, http proxy) may require a different implementation for http communication.  You can provide a customized wrapper in the Analytics configuration to support this.  Here are a few approaches:
 
 Use a custom fetch-like implementation with proxy (simple, recommended)
-```
+```javascript
 import { HTTPFetchFn } from '../lib/http-client'
+import axios from 'axios'
 
 const httpClient: HTTPFetchFn = async (url, options) => {
   return axios({
@@ -578,7 +579,7 @@ const httpClient: HTTPFetchFn = async (url, options) => {
   })
 }
 
-new Analytics({
+const analytics = new Analytics({
   writeKey: '<YOUR_WRITE_KEY>',
   httpClient,
 })

--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -284,7 +284,7 @@ Setting | Details
 `flushInterval` _number_ | The number of milliseconds to wait before flushing the queue automatically. The default is: `10000`
 `httpRequestTimeout` | The maximum number of milliseconds to wait for an http request. The default is: `10000`
 `disable` | Disable the analytics library for testing. The default is: `false`
-`httpClient` | Optional custom AnalyticsHTTPClient implementation to support alternate libraries or proxies.  Defaults to global fetch or node-fetch for older versions of node.
+`httpClient` *Optional* | A custom AnalyticsHTTPClient implementation to support alternate libraries or proxies.  Defaults to global fetch or node-fetch for older versions of node.
 
 ## Graceful shutdown
 Avoid losing events after shutting down your console. Call `.closeAndFlush()` to stop collecting new events and flush all existing events. If a callback on an event call is included, this also waits for all callbacks to be called, and any of their subsequent promises to be resolved.


### PR DESCRIPTION
### Proposed changes

We're working on adding a new interface to customize the http client used in analytics-next node.

### Merge timing
~Once https://github.com/segmentio/analytics-next/pull/880 is merged~
Immediately

### Related issues (optional)
LIBWEB-1395