### PR TITLE
fix bug - wrong tool name

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/onetrust/index.md
+++ b/src/connections/sources/catalog/cloud-apps/onetrust/index.md
@@ -37,7 +37,7 @@ The following table lists events that OneTrust sends to Segment. These events sh
 
 ## Event Properties
 
-The following table lists event properties included with all events Segment receives from Braze.
+The following table lists event properties included with all events Segment receives from OneTrust.
 
 |  Property Name | Type | Description |
 |  ------ | ------ | ------ |


### PR DESCRIPTION
### Proposed changes
Fixed an incorrect tool name in the OneTrust source docs.

### Merge timing
ASAP

### Related issues (optional)
Closes #4880 
