### PR TITLE
Fixed broken link on iOS Quickstart page

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/index.md
@@ -107,7 +107,7 @@ import Segment
 
 To keep the Analytics-iOS SDK lightweight, the Analytics pod only installs the Segment destination. This means that all your data is sent through Segment's servers to any tools you enable using the default Cloud-mode.
 
-Some destinations [require or offer Device-mode connections](/docs/connections/destinations/#connection-modes). For those destinations, you must take some additional steps as [to package the device-mode SDKs](/../#packaging-device-mode-destination-sdks).
+Some destinations [require or offer Device-mode connections](/docs/connections/destinations/#connection-modes). For those destinations, you must take some additional steps as [to package the device-mode SDKs](/docs/connections/sources/catalog/libraries/mobile/ios/#packaging-device-mode-destination-sdks).
 
 Now that the Segment Analytics-iOS SDK is installed and set up, you're ready to…
 

--- a/src/connections/sources/catalog/libraries/mobile/ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/index.md
@@ -107,7 +107,7 @@ import Segment
 
 To keep the Analytics-iOS SDK lightweight, the Analytics pod only installs the Segment destination. This means that all your data is sent through Segment's servers to any tools you enable using the default Cloud-mode.
 
-Some destinations [require or offer Device-mode connections](/docs/connections/destinations/#connection-modes). For those destinations, you must take some additional steps as [to package the device-mode SDKs](/docs/connections/sources/catalog/libraries/mobile/ios/#packaging-device-mode-destination-sdks).
+Some destinations [require or offer Device-mode connections](/docs/connections/destinations/#connection-modes). For those destinations, you must take some additional steps as [to package the device-mode SDKs](/../#packaging-device-mode-destination-sdks).
 
 Now that the Segment Analytics-iOS SDK is installed and set up, you're ready to…
 

--- a/src/connections/sources/catalog/libraries/mobile/ios/quickstart.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/quickstart.md
@@ -81,7 +81,7 @@ Some destinations do not accept data coming from the Segment servers and require
 
 Many advanced marketing automation and analytics tools offer an SDK or allow you to choose to send data server to server -- depending on the features you need. Most optimization, deep linking, error tracking, and survey tools *must* be included on the device to use their core features.
 
-In those cases, follow the additional steps to [bundle the destination tools](/docs/connections/sources/catalog/libraries/mobile/ios/#packaging-device-mode-destination-sdks).
+In those cases, follow the additional steps to [bundle the destination tools](/docs/connections/sources/catalog/libraries/mobile/ios#packaging-device-mode-destination-sdks).
 
 Now that the SDK is installed and set up, you're ready to start making calls.
 


### PR DESCRIPTION
### Proposed changes
Removed backslash that was breaking a link on the iOS Quickstart page

### Merge timing
ASAP

### Related issues (optional)
Closes #4836 
