### PR TITLE
Add note on removing handler

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -61,7 +61,7 @@ Segment invokes a separate part of the function (called a "handler") for each ev
 The default source code template includes handlers for all event types. You don't need to implement all of them - just use the ones you need, and skip the ones you don't.
 
 > info ""
-> Removing the handler for a specific event type will result in the events of that type being blocked from arriving at their destination.
+> Removing the handler for a specific event type results in blocking the events of that type from arriving at their destination. 
 
 Insert functions can define handlers for each message type in the [Segment spec](/docs/connections/spec/):
 

--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -60,6 +60,9 @@ Segment invokes a separate part of the function (called a "handler") for each ev
 
 The default source code template includes handlers for all event types. You don't need to implement all of them - just use the ones you need, and skip the ones you don't.
 
+> info ""
+> Removing the handler for a specific event type will result in the events of that type being blocked from arriving at their destination.
+
 Insert functions can define handlers for each message type in the [Segment spec](/docs/connections/spec/):
 
 - `onIdentify`


### PR DESCRIPTION
### Proposed changes

It's not clearly stated that removing the handler for a specific event type will result in the events of that type being blocked from arriving at their destination.

Added as a note to help clarify this for customers.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
