### PR TITLE
fix broken link in docs

### DIFF
--- a/src/_data/catalog/slugs.yml
+++ b/src/_data/catalog/slugs.yml
@@ -117,3 +117,5 @@ destinations:
     override: "encharge-cloud-actions"
   - original: "pardot-actions"
     override: "actions-pardot"
+  - original: "airship-actions"
+    override: "actions-airship"

--- a/src/connections/destinations/catalog/airship-actions/index.md
+++ b/src/connections/destinations/catalog/airship-actions/index.md
@@ -1,9 +1,0 @@
----
-title: Airship (Actions) Destination
-hidden: false
-id: 6475c5c14f7db4914bcd512f
-published: false
-beta: true
-private: false
-
----


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

currently there is [a broken link](https://segment.com/docs/connections/destinations/catalog/#marketing-automation) for the airship actions dest in prod: 
![Screen Shot 2023-07-14 at 11 30 55 AM](https://github.com/segmentio/segment-docs/assets/64277654/ae9aec19-c51a-4bb9-8ac4-d29ab5546a21)

I've added a slug override in order to reflect the actual integration slug on our backend. Local environment: 
![Screen Shot 2023-07-14 at 11 29 22 AM](https://github.com/segmentio/segment-docs/assets/64277654/283db7ab-d582-446f-8754-7bf3de0a5b78)





### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
