### PR TITLE
Ran sass migrator to replace slashes

### DIFF
--- a/src/_sass/objects/_flex.scss
+++ b/src/_sass/objects/_flex.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .flex {
   $this: &;
 
@@ -29,8 +31,8 @@
 
     @for $i from 1 through $flex-columns {
       &--#{$i} {
-        flex-basis: percentage($i / $flex-columns);
-        max-width: percentage($i / $flex-columns);
+        flex-basis: percentage(math.div($i, $flex-columns));
+        max-width: percentage(math.div($i, $flex-columns));
       }
     }
 
@@ -42,8 +44,8 @@
       @include breakpoint($breakpoint up) {
         @for $i from 1 through $flex-columns {
           &--#{$i}\@#{$breakpoint} {
-            flex-basis: percentage($i / $flex-columns);
-            max-width: percentage($i / $flex-columns);
+            flex-basis: percentage(math.div($i, $flex-columns));
+            max-width: percentage(math.div($i, $flex-columns));
           }
         }
       }

--- a/src/_sass/objects/_gutter.scss
+++ b/src/_sass/objects/_gutter.scss
@@ -3,23 +3,23 @@
 
   $size: map-get($gutter-sizes, $gutter-size);
 
-  margin-right: -#{$size / 2};
-  margin-left: -#{$size / 2};
+  margin-right: -#{$size * 0.5};
+  margin-left: -#{$size * 0.5};
 
   & > * {
-    padding-right: $size / 2;
-    padding-left: $size / 2;
+    padding-right: $size * 0.5;
+    padding-left: $size * 0.5;
   }
 
   @each $name, $size in $gutter-sizes {
     @if $name != $gutter-size {
       &--#{$name} {
-        margin-right: -#{$size / 2};
-        margin-left: -#{$size / 2};
+        margin-right: -#{$size * 0.5};
+        margin-left: -#{$size * 0.5};
 
         & > * {
-          padding-right: $size / 2;
-          padding-left: $size / 2;
+          padding-right: $size * 0.5;
+          padding-left: $size * 0.5;
         }
       }
     }
@@ -29,12 +29,12 @@
     @include breakpoint($breakpoint up) {
       @each $name, $size in $gutter-sizes {
         &--#{$name}\@#{$breakpoint} {
-          margin-right: -#{$size / 2};
-          margin-left: -#{$size / 2};
+          margin-right: -#{$size * 0.5};
+          margin-left: -#{$size * 0.5};
 
           & > * {
-            padding-right: $size / 2;
-            padding-left: $size / 2;
+            padding-right: $size * 0.5;
+            padding-left: $size * 0.5;
           }
         }
       }

--- a/src/_sass/objects/_waffle.scss
+++ b/src/_sass/objects/_waffle.scss
@@ -3,19 +3,19 @@
 
   $size: map-get($waffle-sizes, $waffle-size);
 
-  margin: -#{$size / 2};
+  margin: -#{$size * 0.5};
 
   & > * {
-    padding: $size / 2;
+    padding: $size * 0.5;
   }
 
   @each $name, $size in $waffle-sizes {
     @if $name != $waffle-size {
       &--#{$name} {
-        margin: -#{$size / 2};
+        margin: -#{$size * 0.5};
 
         & > * {
-          padding: $size / 2;
+          padding: $size * 0.5;
         }
       }
     }
@@ -25,10 +25,10 @@
     @include breakpoint($breakpoint up) {
       @each $name, $size in $waffle-sizes {
         &--#{$name}\@#{$breakpoint} {
-          margin: -#{$size / 2};
+          margin: -#{$size * 0.5};
 
           & > * {
-            padding: $size / 2;
+            padding: $size * 0.5;
           }
         }
       }


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Several files in our _scss directory used `/` characters for math functions. Sass is deprecating this functionality and provided a migrator to translate division (/2) to 
multiplication (*.5) where possible, and `math.div` where not possible.


<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
