### PR TITLE
Add note on hidden_entry columns

### DIFF
--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -163,7 +163,7 @@ And two entries in the `identifies` table:
 All these events were performed by the same person. If you use these tables to assemble your data models, though, always join them against `id_graph` to resolve each event’s `canonical_segment_id`.
 
 > info ""
-> In the data for profiles involved in Journey steps, columns appended with `hidden_entry` or `hidden_entry_joined_at` may appear. These denote internal Segment processes for user integration into Journeys, and do not require user attention or action.
+> You might see columns appended with `hidden_entry` or `hidden_entry_joined_at` in profile data of users in Journeys. Segment uses these for internal purposes, and they do not require any attention or action.
 
 ### Profiles Sync schema
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -162,6 +162,9 @@ And two entries in the `identifies` table:
 
 All these events were performed by the same person. If you use these tables to assemble your data models, though, always join them against `id_graph` to resolve each event’s `canonical_segment_id`.
 
+> info ""
+> In the data for profiles involved in Journey steps, columns appended with `hidden_entry` or `hidden_entry_joined_at` may appear. These denote internal Segment processes for user integration into Journeys, and do not require user attention or action.
+
 ### Profiles Sync schema
 
 Profiles Sync uses the following schema: `<profiles_space_name>.<tableName>`.


### PR DESCRIPTION
### Proposed changes

Customers have expressed confusion on columns appended with hidden_entry/hidden_entry_joined_at returned in the identifies table. Added a note that mentions these reflect internal processes and do not require attention or action.

Relevant Slack thread: https://twilio.slack.com/archives/C01L65AUTF1/p1669931030604689 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
