### PR TITLE
Include dot notation limitation

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -174,7 +174,7 @@ You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY
 > info "Unsupported Special Characters"
 > Mappings do not support the use of double quotes " or a tilde ~ in the trigger fields.
 
->info "Limitations"
+> info "Limitations"
 > Mapping fields don't support dot notation. For example, properties.amount.cost or properties_amount.cost aren't supported.
 
 > info "Destination Filters"

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -174,6 +174,9 @@ You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY
 > info "Unsupported Special Characters"
 > Mappings do not support the use of double quotes " or a tilde ~ in the trigger fields.
 
+>info "Limitations"
+>Mapping fields do not support dot notation. i.e. properties.amount.cost or properties_amount.cost.
+
 > info "Destination Filters"
 > Destination filters are compatible with Destination Actions. Consider a Destination Filter when:
 > - You need to remove properties from the data sent to the destination

--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -175,7 +175,7 @@ You can combine criteria in a single group using **ALL** or **ANY**.  Use an ANY
 > Mappings do not support the use of double quotes " or a tilde ~ in the trigger fields.
 
 >info "Limitations"
->Mapping fields do not support dot notation. i.e. properties.amount.cost or properties_amount.cost.
+> Mapping fields don't support dot notation. For example, properties.amount.cost or properties_amount.cost aren't supported.
 
 > info "Destination Filters"
 > Destination filters are compatible with Destination Actions. Consider a Destination Filter when:


### PR DESCRIPTION
Actions Mappings don't support dot notation in mapping fields


### Proposed changes

Several customers are sending in payloads with dot notation and then trying to map them but are unsuccessful because dot notation isn't supported. 

### Merge timing
- ASAP once approved

### Related issues (optional)

https://segment.zendesk.com/agent/tickets/516943 
https://twilio.slack.com/archives/CC97A542H/p1681243270312659 
