### PR TITLE
remove Event Delivery references

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -237,12 +237,6 @@ Note the following limitations for batching with insert functions:
 
 {% endcomment %}
 
-## Destination insert functions logs and errors
-
-A function can throw errors, or Segment might encounter errors while invoking your function. You can view these errors in the [Event Delivery](/docs/connections/event-delivery/) tab for your Destination as in the example below.
-
-![A screenshot of the event delivery tab, showing 519 failed events broken into categories explaining why they failed](images/event-delivery.png)
-
 ### Destination insert functions error types
 
 - **Bad Request** - Any error thrown by the function code that is not covered by the other errors.


### PR DESCRIPTION
### Proposed changes

Insert Function error information is not surfaced in the Event Delivery view contrary to what was originally published in our docs. A Functions engineer confirmed this: https://twilio.slack.com/archives/CH44TB529/p1689777484339219. Some customers have already expressed confusion about this so I'm removing the reference to Event Delivery until that functionality exists.

### Merge timing
ASAP is fine