### PR TITLE
Clarify maximum batch size for Salesforce

### DIFF
--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -154,7 +154,7 @@ When using the `create` operation, it's possible for duplicate records to be cre
 Please note this is only a concern when using the `create` operation. You can use the `upsert` operation instead to avoid duplicates if `upsert` meets your needs.
 
 ### How does Salesforce Bulk API work?
-When **Use Salesforce Bulk API** is enabled for your mapping, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm){:target="_blank"} rather than their streaming REST API. If enabled, Segment will collect events into batches of 1000 before sending to Salesforce. Bulk support can be used for the `upsert` or `update` operations only.
+When **Use Salesforce Bulk API** is enabled for your mapping, events are sent to [Salesforce’s Bulk API 2.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm){:target="_blank"} rather than their streaming REST API. If enabled, Segment will collect events into batches of up to 1000 before sending to Salesforce. Bulk support can be used for the `upsert` or `update` operations only.
 
 For bulk `update`, if a record in a batch is missing a Bulk Update Record ID, Segment will still send it to Salesforce. Salesforce will reject the individual record because it will be unable to find a record to update. Other records in the batch that are valid will still be processed. Please note that Segment's Event Delivery tab will show the entire batch as successful as Segment cannot currently break down Event Delivery stats into individual failed/passed events.
 


### PR DESCRIPTION
### Proposed changes

After a customer complained that Segment wasn't sending as many events as possible in one batch a discussion ensued that led to an understanding that, currently, batching to Salesforce _could_ reach 1000k per request but probably wouldn't due to various throttling mechanisms in Centrifuge. This update makes that a bit more clear.

### Merge timing
ASAP is fine