### PR TITLE
add info about GA4 not accepting dash character

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -155,7 +155,8 @@ The Segment Google Analytics 4 Cloud destination supports sending mobile app eve
 Google reserves certain event names, parameters, and user properties. Google silently drops any events that include [these reserved names](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#reserved_names){:target="_blank"}. Google doesn't accept events in the following conditions:
 - event or user property names have spaces in them
 - fields with `null` values
-- fields or events with reserved names 
+- fields or events with reserved names
+- events with the dash character (`-`) in the name
  
 ### Verifying Event Meet GA4's Measurement Protocol API
 **Why are the events returning an error _Param [PARAM] has unsupported value._?**


### PR DESCRIPTION
### Proposed changes

After some testing for a customer, I discovered that Google Analytics 4 silently drops events that have a `-` in the name. This update makes customers aware of that.

### Merge timing
ASAP is fine