### PR TITLE
DOTORG-872: Update Blackbaud Raiser's Edge NXT Docs

### DIFF
--- a/src/connections/destinations/catalog/blackbaud-raisers-edge-nxt/index.md
+++ b/src/connections/destinations/catalog/blackbaud-raisers-edge-nxt/index.md
@@ -23,11 +23,4 @@ page, copy your **Primary access key**, and paste the value into the **Blackbaud
 Event Types and/or Event Names will trigger each mapping.
 8. Enable the destination and configured mappings.
 
-## Note on Authentication
-
-If you wish to connect multiple sources to the Blackbaud Raiser's Edge NXT destination, you must
-authenticate using a different Blackbaud Developer account for each source. If you authenticate using the
-same Blackbaud Developer account with more than one source, only the most recent source will send data to
-Raiser's Edge NXT.
-
 {% include components/actions-fields.html %}


### PR DESCRIPTION
### Proposed changes

This PR updates the docs for the Blackbaud Raiser's Edge NXT destination to remove the "Note on Authentication" section. In https://github.com/segmentio/action-destinations/pull/1340 we updated the destination to allow for multiple instances to be used with the same developer account and OAuth token, so the previous warning is no longer needed.

### Merge timing

ASAP once approved