### PR TITLE
Update format for Get Profile Traits endpoint example

### DIFF
--- a/src/unify/profile-api.md
+++ b/src/unify/profile-api.md
@@ -273,7 +273,7 @@ https://profiles.segment.com/v1/spaces/<space_id>/
 Retrieve a single profile's traits within a collection using an `external_id`. For example, two different sources can set a different `first_name` for a user. The traits endpoint will resolve properties from multiple sources into a canonical source using the last updated precedence order.
 
 ```
-GET /v1/spaces/<space_id>/collections/users/profiles/<external_id>/traits
+GET /v1/spaces/<space_id>/collections/users/profiles/<id_type:external_id>/traits
 ```
 
 ##### Query parameters


### PR DESCRIPTION
### Proposed changes

In the Profile API section on [getting a Profile’s traits](https://segment.com/docs/unify/profile-api/#get-a-profiles-traits), the first demonstration of this endpoint is:

`GET /v1/spaces/<space_id>/collections/users/profiles/<external_id>/traits`

However, scrolling down to the examples shows:

`GET /v1/spaces/lg8283283/collections/users/profiles/user_id:u1234/traits`

The format in the user_id example is `users/profiles/<id_type:ext_id>`, which is the correct format, whereas the first demo of the URL is just `users/profiles/<external_id>` - if only the external_id is set in the request URL without the id_type, a 404 Not Found error is returned.

Scrolling further down to the first example for [getting a profile’s External IDs](https://segment.com/docs/unify/profile-api/#get-a-profiles-external-ids) also demonstrates the correct format:

`GET /v1/spaces/<space_id>/collections/users/profiles/<id_type:ext_id>/external_ids`

To better demonstrate the correct format, updated the first example for getting a Profile’s traits to be:

`GET /v1/spaces/<space_id>/collections/users/profiles/<id_type:external_id>/traits`

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
