### PR TITLE
Add troubleshooting tips for CleverTap

### DIFF
--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -176,3 +176,10 @@ CleverTap has created a sample iOS application that integrates CleverTap using S
 If you chose not to bundle the CleverTap Mobile SDK, then you will have to implement your own Push Message processors (and you won't have access to CleverTap's In-App feature).
 
 If you decide to implement your own Push Message processors, then you can pass push tokens to CleverTap using the server-side destination. You can do this by sending it inside context.device.token.
+
+
+## Troubleshooting
+
+### Verbose Logging
+
+When using Web Device-mode, you can enable verbose logging of all communication with CleverTap servers by setting the `theWZRK_D` variable in `sessionStorage`. In the developer console of your browser, enter `sessionStorage['WZRK_D'] = '';`, you will see error messages and warnings logged. 

--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -182,4 +182,4 @@ If you decide to implement your own Push Message processors, then you can pass p
 
 ### Verbose Logging
 
-When using Web Device-mode, you can enable verbose logging of all communication with CleverTap servers by setting the `theWZRK_D` variable in `sessionStorage`. In the developer console of your browser, enter `sessionStorage['WZRK_D'] = '';`, you will see error messages and warnings logged. 
+When using Web Device-mode, you can enable verbose logging of all communication with CleverTap servers by setting the `theWZRK_D` variable in `sessionStorage`. In the developer console of your browser, enter `sessionStorage['WZRK_D'] = '';`, you will see error messages and warnings logged. Please check [CleverTap docs](https://developer.clevertap.com/docs/web-quickstart-guide#debugging) for more details.

--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -182,4 +182,4 @@ If you decide to implement your own Push Message processors, then you can pass p
 
 ### Verbose Logging
 
-When using Web Device-mode, you can enable verbose logging of all communication with CleverTap servers by setting the `theWZRK_D` variable in `sessionStorage`. In the developer console of your browser, enter `sessionStorage['WZRK_D'] = '';`, you will see error messages and warnings logged. Please check [CleverTap docs](https://developer.clevertap.com/docs/web-quickstart-guide#debugging) for more details.
+When using Web Device-mode, you can enable verbose logging of all communication with CleverTap servers by setting the `theWZRK_D` variable in `sessionStorage`. In the developer console of your browser, enter `sessionStorage['WZRK_D'] = '';`, you'll see error messages and warnings logged. See the [CleverTap Web Quickstart Guide](https://developer.clevertap.com/docs/web-quickstart-guide#debugging){:target="_blank"} for more details.


### PR DESCRIPTION
### Proposed changes
There are some debugging tips from CleverTap’s [documentation](https://developer.clevertap.com/docs/web-quickstart-guide#debugging):

> This section is applicable to all browsers such as Chrome, Firefox, and Safari. Error messages and warnings are logged to the JS console of the browser.
> 
> For verbose logging, enable verbose logging of all communication with CleverTap servers by setting the theWZRK_D variable in sessionStorage. Enter sessionStorage['WZRK_D'] = ''; in the developer console of your browser.

### Merge timing
ASAP once approved