### PR TITLE
Add public api token workspace permission detail

### DIFF
--- a/src/api/public-api/index.md
+++ b/src/api/public-api/index.md
@@ -56,4 +56,4 @@ This feature is automatically enabled for all workspaces on Team or Business tie
 If you see a CORS error, this means you're attempting to make a request to the Public API on the front-end. The Public API is used for server-side only. To get rid of the error, move all Public API requests to a server.
 
 #### What User Role / Workspace permissions are required to generate Public API tokens?
-Only [users that have "Workspace Owner"](https://segment.com/docs/segment-app/iam/roles/#global-roles) can create Public API Tokens.
+Only [users that have a `Workspace Owner` role](https://segment.com/docs/segment-app/iam/roles/#global-roles) can create Public API Tokens.

--- a/src/api/public-api/index.md
+++ b/src/api/public-api/index.md
@@ -55,3 +55,5 @@ This feature is automatically enabled for all workspaces on Team or Business tie
 #### What should I do when I see a CORS error? 
 If you see a CORS error, this means you're attempting to make a request to the Public API on the front-end. The Public API is used for server-side only. To get rid of the error, move all Public API requests to a server.
 
+#### What User Role / Workspace permissions are required to generate Public API tokens?
+Only [users that have "Workspace Owner"](https://segment.com/docs/segment-app/iam/roles/#global-roles) can create Public API Tokens.


### PR DESCRIPTION
### Proposed changes

**Before this PR:**
Segment Documentation does not state the required role / user permissions required to create a Public API Token

**After this PR:**
Segment Documentation now explicitly states the required role / user permissions required to create a Public API Token

**Reason that prompted this change:**
JPMC Question / [Finding Answer in Slack](https://twilio.slack.com/archives/C018FB6PZ0C/p1656694188032489?thread_ts=1656692127.704029&cid=C018FB6PZ0C)

### Merge timing
- ASAP once approved?