### PR TITLE
Fixing link formatting on analytics-swift-firebase-plugin page

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/firebase-swift.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/firebase-swift.md
@@ -12,9 +12,11 @@ Firebase’s destination plugin code is open source and available on GitHub. You
 > the Firebase library itself will be installed as an additional dependency.
 
 ### through Xcode
-In the Xcode `File` menu, click `Add Packages`.  You'll see a dialog where you can search for Swift packages.  In the search field, enter the URL to this repository.
+In the Xcode `File` menu, click `Add Packages`.  You'll see a dialog where you can search for Swift packages.  In the search field, enter the URL to this repository:
 
-https://github.com/segment-integrations/analytics-swift-firebase{:target="_blank"}
+```
+https://github.com/segment-integrations/analytics-swift-firebase
+```
 
 You'll then have the option to pin to a version, or specific branch, as well as which project in your workspace to add it to.  Once you've made your selections, click the `Add Package` button.  
 


### PR DESCRIPTION
### Proposed changes
Fixed funky link

Before: 
![Screenshot 2023-07-28 at 7 55 46 PM 3](https://github.com/segmentio/segment-docs/assets/92472883/e992068e-73f3-4df8-8c5f-6acc033a8a75)

After: 
![Screenshot 2023-07-28 at 7 57 24 PM 3](https://github.com/segmentio/segment-docs/assets/92472883/1a0388a2-8791-4eb9-b487-f3c6b219a84b)

### Merge timing
ASAP

### Related issues (optional)

