### PR TITLE
Add Google doc link to Account ID section

### DIFF
--- a/src/connections/destinations/catalog/personas-display-video-360/index.md
+++ b/src/connections/destinations/catalog/personas-display-video-360/index.md
@@ -212,7 +212,7 @@ When you select the destination, you're prompted to complete the destination set
 | Setting                        | Description                                                                                                                                                               |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | User Role Granted              | The permission you requested from Google. Either `Advertiser`, `Partner`, or `Publisher`. **Note:** Select `Publisher` only if you plan to connect to Google Ad Manager.  |
-| Account ID                     | The ID of your DV360 or Ad Manager account.                                                                                                                               |
+| Account ID                     | The ID of your DV360 or Ad Manager account. The Account ID can be found [here](https://support.google.com/displayvideo/answer/3423704?hl=en#zippy=)                                                                                                                       |
 
 On Step 3: Review & Create, **deselect** the Historical Backfill option to ensure that audience sizes between Engage and DV360 align more closely.
 

--- a/src/connections/destinations/catalog/personas-display-video-360/index.md
+++ b/src/connections/destinations/catalog/personas-display-video-360/index.md
@@ -212,7 +212,7 @@ When you select the destination, you're prompted to complete the destination set
 | Setting                        | Description                                                                                                                                                               |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | User Role Granted              | The permission you requested from Google. Either `Advertiser`, `Partner`, or `Publisher`. **Note:** Select `Publisher` only if you plan to connect to Google Ad Manager.  |
-| Account ID                     | The ID of your DV360 or Ad Manager account. The Account ID can be found [here](https://support.google.com/displayvideo/answer/3423704?hl=en#zippy=)                                                                                                                       |
+| Account ID                     | The ID of your DV360 or Ad Manager account. For help finding your Account ID, see [Display & Video 360 Help](https://support.google.com/displayvideo/answer/3423704?hl=en#zippy=){:target="_blank"}.                                                                                                                     |
 
 On Step 3: Review & Create, **deselect** the Historical Backfill option to ensure that audience sizes between Engage and DV360 align more closely.
 


### PR DESCRIPTION


### Proposed changes

I added a link for google docs showing where to find the Account ID because several customers are having trouble finding it. 

### Merge timing

- ASAP once approved?


### Related issues (optional)

https://segment.zendesk.com/agent/tickets/518893

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
