### PR TITLE
Update index.md Disabling a destination

### DIFF
--- a/src/connections/destinations/index.md
+++ b/src/connections/destinations/index.md
@@ -120,6 +120,7 @@ To add a Destination:
 8. Configure the settings and enable your destination on the destination settings page.
 
 [Learn more](/docs/connections/destinations/add-destination/) about what adding a destination entails.
+> Note : **Disabling a destination** If you disable a destination or your destination hasn't yet been enabled, a disabled destination will prevent any data from reaching the destination. For Business-tier customers, [a replay]([url](https://segment.com/docs/guides/what-is-replay/)) can be requested to resend that data from the time the destination was disabled to the time it was re-enabled. Replays can send data to currently disabled destinations. _Please note that some destinations are not compatible with replays after a certain number of days, and is worth checking with Segment’s support team [friends@segment.com](friends@segment.com) for whether that destination allows historical timestamps._
 
 ## Data deliverability
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Customers are not always aware that a destination must be enabled in order to receive data.

Disabling a destination

> Note : **Disabling a destination** If you disable a destination or your destination hasn't yet been enabled, a disabled destination will prevent any data from reaching the destination. For Business-tier customers, [a replay]([url](https://segment.com/docs/guides/what-is-replay/)) can be requested to resend that data from the time the destination was disabled to the time it was re-enabled. Replays can send data to currently disabled destinations. _Please note that some destinations are not compatible with replays after a certain number of days, and is worth checking with Segment’s support team [friends@segment.com](friends@segment.com) for whether that destination allows historical timestamps._


### Merge timing
- ASAP once approved

### Related issues (optional)

Zendesk [ticket](https://segment.zendesk.com/agent/tickets/518677)
