### PR TITLE
Add warning for partner audience type

### DIFF
--- a/src/connections/destinations/catalog/actions-tiktok-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-tiktok-audiences/index.md
@@ -21,6 +21,9 @@ By using Segment's TikTok Audiences destination, you can increase traffic and dr
 
 You must create an audience segment in your TikTok Advertising account. You can send Engage audiences to an existing audience segment, or create a new audience. Please note the `audience_id` as this is required to send Engage audiences to TikTok. 
 
+> warning ""
+> At the moment, you can only send audience data from Segment to a "Partner audience" type of custom audience in TikTok Ads Manager. TikTok's UI doesn't currently allow the selection of this custom audience type, but this destination's **Create Audience** mapping can create "Partner audience" custom audiences in TikTok. 
+
 #### Create a TikTok Audience
 
 To create an audience in Segment: 

--- a/src/connections/destinations/catalog/actions-tiktok-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-tiktok-audiences/index.md
@@ -22,7 +22,7 @@ By using Segment's TikTok Audiences destination, you can increase traffic and dr
 You must create an audience segment in your TikTok Advertising account. You can send Engage audiences to an existing audience segment, or create a new audience. Please note the `audience_id` as this is required to send Engage audiences to TikTok. 
 
 > warning ""
-> At the moment, you can only send audience data from Segment to a "Partner audience" type of custom audience in TikTok Ads Manager. TikTok's UI doesn't currently allow the selection of this custom audience type, but this destination's **Create Audience** mapping can create "Partner audience" custom audiences in TikTok. 
+> You can only send audience data from Segment to a "Partner audience" custom audience in TikTok Ads Manager. While TikTok's UI doesn't allow you to select this custom audience type, you can use this destination's **Create Audience** mapping to create "Partner audience" custom audiences in TikTok. 
 
 #### Create a TikTok Audience
 


### PR DESCRIPTION
### Proposed changes

Several customers have written in to support confused on how to create the necessary "partner audience" type custom audience in TikTok. Add a warning that states this cannot be selected within TikTok's UI, and that this destination's **Create Audience** mapping can create audiences of the required type in TikTok.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
