### PR TITLE
Fix plan note bug

### DIFF
--- a/src/_data/products.yml
+++ b/src/_data/products.yml
@@ -154,3 +154,12 @@ items:
     team: true
     business: true
     add-on: false
+
+- product_display_name: Audit Trail
+  slug: audit-trail
+  plan-note: "Audit Trail is available as an add-on for customers with the Business plan."
+  plans:
+    free: false
+    team: false
+    business: true
+    add-on: true

--- a/src/_data/products.yml
+++ b/src/_data/products.yml
@@ -92,6 +92,7 @@ items:
     add-on: false
 - product_display_name: Audit Trail
   slug: audit-trail
+  plan-note: "Audit Trail is available as an add-on for customers with the Business plan."
   plans:
     free: false
     team: false
@@ -155,11 +156,3 @@ items:
     business: true
     add-on: false
 
-- product_display_name: Audit Trail
-  slug: audit-trail
-  plan-note: "Audit Trail is available as an add-on for customers with the Business plan."
-  plans:
-    free: false
-    team: false
-    business: true
-    add-on: true

--- a/src/segment-app/iam/audit-trail.md
+++ b/src/segment-app/iam/audit-trail.md
@@ -1,7 +1,7 @@
 ---
 title: Audit Trail
+plan: audit-trail
 ---
-{% include content/plan-grid.md name="audit-trail" %}
 
 Segment offers an in-app 90 day Audit Trail for Business Tier accounts. If you are a Workspace Owner, you view user and system activity in your workspace settings, in the "Audit Trail" tab under "Admin".
 


### PR DESCRIPTION
### Proposed changes
Added plan note to frontmatter with `plan: audit-trail` instead of liquid formatting in body of the page, which wasn't rendering correctly.

### Merge timing
ASAP

### Related issues (optional)
Closes #5121 
