### PR TITLE
Added plan-grid note to frontmatter

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -1,8 +1,7 @@
 ---
 title: Destination Actions
+plan: dest-actions
 ---
-
-{% include content/plan-grid.md name="dest-actions" %}
 
 The Destination Actions framework improves on classic destinations by enabling you to see and control how Segment sends the event data it receives from your sources, to actions-based destinations. Each Action in a destination lists the event data it requires, and the event data that is optional.
 

--- a/src/connections/storage/data-lakes/comparison.md
+++ b/src/connections/storage/data-lakes/comparison.md
@@ -1,8 +1,7 @@
 ---
 title: Comparing Data Lakes and Warehouses
+plan: data-lakes
 ---
-{% include content/plan-grid.md name="data-lakes" %}
-
 
 As Segment builds new data storage products, each product evolves from prior products to best support the needs of customers. Segment Data Lakes is an evolution of the Warehouses product that meets the changing needs of customers.
 

--- a/src/connections/storage/data-lakes/data-lakes-manual-setup.md
+++ b/src/connections/storage/data-lakes/data-lakes-manual-setup.md
@@ -1,9 +1,8 @@
 ---
 hidden: true
 title: Configure the Data Lakes AWS Environment
+plan: data-lakes
 ---
-{% include content/plan-grid.md name="data-lakes" %}
-
 
 The instructions below will guide you through the process required to configure the environment required to begin loading data into your Segment Data Lake. For a more automated process, see [Set Up Segment Data Lakes](/docs/connections/storage/catalog/data-lakes).
 

--- a/src/connections/storage/data-lakes/index.md
+++ b/src/connections/storage/data-lakes/index.md
@@ -1,9 +1,8 @@
 ---
 title: Segment Data Lakes Overview
 redirect_from: '/connections/destinations/catalog/data-lakes/'
+plan: data-lakes
 ---
-
-{% include content/plan-grid.md name="data-lakes" %}
 
 > warning "Segment Data Lakes (Azure) deletion policies"
 > Data deletion is not supported by Segment Data Lakes (Azure), as customers retain data in systems that they manage.

--- a/src/connections/storage/data-lakes/lake-formation.md
+++ b/src/connections/storage/data-lakes/lake-formation.md
@@ -1,8 +1,7 @@
 ---
 title: Lake Formation
+plan: data-lakes
 ---
-
-{% include content/plan-grid.md name="data-lakes" %}
 
 Lake Formation is a fully managed service built on top of the AWS Glue Data Catalog that provides one central set of tools to build and manage a Data Lake. These tools help import, catalog, transform, and deduplicate data, as well as provide strategies to optimize data storage and security. To learn more about Lake Formation features, see [Amazon Web Services documentation](https://aws.amazon.com/lake-formation/features/){:target="_blank"}.
 

--- a/src/connections/storage/data-lakes/sync-history.md
+++ b/src/connections/storage/data-lakes/sync-history.md
@@ -1,7 +1,7 @@
 ---
 title: Data Lakes Sync History and Health
+plan: data-lakes
 ---
-{% include content/plan-grid.md name="data-lakes" %}
 
 The Segment Data Lakes sync history and health tabs generate real-time information about data syncs so you can monitor the health and performance of your data lakes. These tools provide monitoring and debugging capabilities within the Data Lakes UI, so you can identify and proactively address data sync or data pipeline failures.
 

--- a/src/connections/storage/data-lakes/sync-reports.md
+++ b/src/connections/storage/data-lakes/sync-reports.md
@@ -1,8 +1,7 @@
 ---
 title: Data Lakes Sync Reports and Errors
+plan: data-lakes
 ---
-{% include content/plan-grid.md name="data-lakes" %}
-
 
 Segment Data Lakes generates reports with operational metrics about each sync to your data lake so you can monitor sync performance. These sync reports are stored in your S3 bucket and Glue Data Catalog. This means you have access to the raw data, so you can query it to answer questions and set up alerting and monitoring tools.
 

--- a/src/connections/storage/warehouses/index.md
+++ b/src/connections/storage/warehouses/index.md
@@ -1,9 +1,8 @@
 ---
 title: Data Warehouses
 redirect_from: '/connections/warehouses/'
+plan: warehouses
 ---
-
-{% include content/plan-grid.md name="warehouses" %}
 
 ## What's a Warehouse?
 

--- a/src/guides/what-is-replay.md
+++ b/src/guides/what-is-replay.md
@@ -1,8 +1,7 @@
 ---
 title: Replay
+plan: replay
 ---
-
-{% include content/plan-grid.md name="replay" %}
 
 Replay takes an archived copy of your Segment data, and re-sends it to new or existing tools.
 

--- a/src/privacy/data-controls.md
+++ b/src/privacy/data-controls.md
@@ -1,8 +1,7 @@
 ---
 title: Privacy Controls & Alerts
+plan: privacy
 ---
-{% include content/plan-grid.md name="privacy" %}
-
 
 The Privacy Portal gives you control over whether specific data is allowed to
 enter Segment.

--- a/src/privacy/portal.md
+++ b/src/privacy/portal.md
@@ -1,7 +1,7 @@
 ---
 title: Privacy Portal
+plan: privacy
 ---
-{% include content/plan-grid.md name="privacy" %}
 
 When preparing for new privacy regulations (like HIPAA, the GDPR, or the CCPA), the
 best practice is to create a comprehensive data inventory which includes details

--- a/src/protocols/apis-and-extensions/anomaly_detection.md
+++ b/src/protocols/apis-and-extensions/anomaly_detection.md
@@ -1,8 +1,7 @@
 ---
 title: 'Anomaly Detection'
+plan: protocols
 ---
-
-{% include content/plan-grid.md name="protocols" %}
 
 If you're using Protocols, you might want to get notifications when an anomaly in event volumes or [Protocols violation](/docs/protocols/validate/forward-violations/) counts occurs. This document clarifies what we mean by anomaly detection, gives examples of anomalies that might be relevant to your business, and provides some example solutions of how to monitor and alert on anomalies using some standard tools available today.
 

--- a/src/protocols/apis-and-extensions/index.md
+++ b/src/protocols/apis-and-extensions/index.md
@@ -1,8 +1,7 @@
 ---
 title: 'Protocols: APIs and Extensions'
+plan: protocols
 ---
-
-{% include content/plan-grid.md name="protocols" %}
 
 Built from the ground up, Protocols addresses a wide range of customer needs.
 

--- a/src/protocols/enforce/forward-blocked-events.md
+++ b/src/protocols/enforce/forward-blocked-events.md
@@ -1,8 +1,7 @@
 ---
 title: Forward blocked events
+plan: protocols
 ---
-{% include content/plan-grid.md name="protocols" %}
-
 
 If you're concerned about permanently discarding blocked events, you can enable blocked event forwarding on a Segment Source. To set up forwarding, navigate to the settings tab of the Source, then Schema Configuration. 
 

--- a/src/protocols/enforce/schema-configuration.md
+++ b/src/protocols/enforce/schema-configuration.md
@@ -1,9 +1,8 @@
 ---
 title: Customize your schema controls
 redirect_from: '/protocols/enforce/'
+plan: protocols
 ---
-
-{% include content/plan-grid.md name="protocols" %}
 
 The Schema Configuration settings for each source can be used to selectively block events, or omit properties and traits from `.track()`, `.identify()` and `.group()` calls. Segment can permanently drop events that are not included in your Tracking Plan, depending on the settings you select. Segment can also block events with invalid properties or invalid property values.
 

--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -1,9 +1,7 @@
 ---
 title: Protocols Frequently Asked Questions
+plan: protocols
 ---
-
-{% include content/plan-grid.md name="protocols" %}
-
 
 ## Protocols Notifications
 

--- a/src/protocols/tracking-plan/libraries.md
+++ b/src/protocols/tracking-plan/libraries.md
@@ -1,9 +1,7 @@
 ---
 title: Tracking Plan Libraries
+plan: protocols
 ---
-
-{% include content/plan-grid.md name="protocols" %}
-
 
 Tracking Plan Libraries make it easy to scale Tracking Plan creation within your workspace. You can create libraries for track events or track event properties. Editing Tracking Plan Libraries is identical to [editing Tracking Plans](/docs/protocols/tracking-plan/create/).
 

--- a/src/protocols/transform/index.md
+++ b/src/protocols/transform/index.md
@@ -1,9 +1,8 @@
 ---
 title: Use Transformations to fix bad data
 redirect_from: '/protocols/transformations/'
+plan: protocols
 ---
-
-{% include content/plan-grid.md name="protocols" %}
 
 ## What is a Transformation?
 

--- a/src/protocols/validate/connect-sources.md
+++ b/src/protocols/validate/connect-sources.md
@@ -1,10 +1,8 @@
 ---
 title: Connect a Tracking Plan
 redirect_from: '/protocols/validate/'
+plan: protocols
 ---
-
-{% include content/plan-grid.md name="protocols" %}
-
 
 With your Tracking Plan complete, it's time to apply the Tracking Plan to one or more Sources. Select **Connect Source** from the right hand menu for your specific Tracking Plan.
 

--- a/src/protocols/validate/forward-violations.md
+++ b/src/protocols/validate/forward-violations.md
@@ -1,9 +1,7 @@
 ---
 title: Forward Violations
+plan: protocols
 ---
-
-{% include content/plan-grid.md name="protocols" %}
-
 
 You can forward Violations (data that does not conform to your Protocols tracking plan) to a Segment Source to enable custom notifications, dashboards and further analysis in any Segment destination that accepts cloud-mode data. 
 

--- a/src/protocols/validate/review-violations.md
+++ b/src/protocols/validate/review-violations.md
@@ -1,9 +1,7 @@
 ---
 title: Review and Resolve Event Violations
+plan: protocols
 ---
-
-{% include content/plan-grid.md name="protocols" %}
-
 
 Upon connecting your Tracking Plan to a Source, you will be able to view violations grouped by event. To view violations, click on the Violations button located on the Schema tab in a Source. A filter can be applied to only show events with violations within the past 24 hrs, 7 days and 30 days.
 

--- a/src/segment-app/iam/concepts.md
+++ b/src/segment-app/iam/concepts.md
@@ -1,8 +1,7 @@
 ---
 title: Access Management Concepts
+plan: iam
 ---
-{% include content/plan-grid.md name="iam" %}
-
 
 ## Team Members
 

--- a/src/segment-app/iam/index.md
+++ b/src/segment-app/iam/index.md
@@ -1,13 +1,10 @@
 ---
 title: Identity & Access Management Overview
 redirect_from: '/segment-app/iam/add-a-team-member/'
+plan: iam
 ---
-{% include content/plan-grid.md name="iam" %}
-
 
 Segment's access management tools let workspace owners manage which users can access different parts of their Segment workspaces.
-
-
 
 The Access Management page has three tabs: [Users (team members)](/docs/segment-app/iam/concepts/#team-members), [User Groups](/docs/segment-app/iam/concepts/#user-groups), and [Tokens](/docs/segment-app/iam/concepts/#tokens). You can select a user in the table to see their [roles](/docs/segment-app/iam/roles).
 

--- a/src/segment-app/iam/labels.md
+++ b/src/segment-app/iam/labels.md
@@ -1,8 +1,7 @@
 ---
 title: Using Label-Based Access Control
+plan: iam
 ---
-{% include content/plan-grid.md name="iam" %}
-
 
 Labels allow workspace owners to assign permissions to users to grant them access to groups. Groups represent collections of Sources, or collections of Spaces.
 

--- a/src/segment-app/iam/membership.md
+++ b/src/segment-app/iam/membership.md
@@ -1,9 +1,8 @@
 ---
 title: Manage Workspace Access
 redirect_from: '/segment-app/iam/groups/'
+plan: iam
 ---
-{% include content/plan-grid.md name="iam" %}
-
 
 This page explains how to add [Team Members](/docs/segment-app/iam/concepts/#team-members) and [User Groups](/docs/segment-app/iam/concepts/#user-groups) to your team's workspace, how to assign them [roles](/docs/segment-app/iam/roles), and how to remove them.
 

--- a/src/segment-app/iam/mfa.md
+++ b/src/segment-app/iam/mfa.md
@@ -1,8 +1,8 @@
 ---
 title: Multi-Factor Authentication (MFA)
----
-{% include content/plan-grid.md name="mfa" %}
+plan: mfa
 
+---
 
 Multi-factor Authentication (MFA) provides an additional layer of security when logging into your Segment account. When MFA is enabled, users must enter their username and password, and a one-time use code. Users can either enable MFA for their own account, or workspace owners can require that all users in a workspace use MFA. These security settings are available in the workspace from the "Advanced Settings" section.
 

--- a/src/segment-app/iam/scim.md
+++ b/src/segment-app/iam/scim.md
@@ -1,8 +1,7 @@
 ---
 title: "System for Cross-domain Identity Management (SCIM) Configuration Guide"
+plan: sso
 ---
-
-{% include content/plan-grid.md name="sso" %}
 
 The SCIM specification is designed to make managing user identities in cloud-based applications like Segment easier. SCIM allows your Identity Provider (IdP) to manage users and groups within your Segment workspace.
 

--- a/src/segment-app/iam/sso.md
+++ b/src/segment-app/iam/sso.md
@@ -1,8 +1,7 @@
 ---
 title: "Single Sign On team management"
+plan: sso
 ---
-{% include content/plan-grid.md name="sso" %}
-
 
 Segment supports Single Sign On for Business Tier accounts. You can use any SAML-based Identity Provider (IdP), for example Okta, Bitium, OneLogin, or Centrify, or use GSuite to serve as your identity provider, delegating access to the application based on rules you create in your central identity management solution.
 


### PR DESCRIPTION
### Proposed changes
Converted all `{% include content/plan-grid.md name="SLUG_NAME" %}` strings in the body of a page to frontmatter (`plan: SLUG_NAME`) so that they'll build correctly

(except for {% include content/plan-grid.md name="actions" %} - I've gotta do more digging on that one)

### Merge timing
ASAP

### Related issues (optional)
#5129 
