### PR TITLE
[STRATCONN-2814]: Fix role policies for AWS destinations

### DIFF
--- a/src/connections/destinations/catalog/amazon-kinesis-firehose/index.md
+++ b/src/connections/destinations/catalog/amazon-kinesis-firehose/index.md
@@ -144,7 +144,7 @@ To attach multiple sources to your IAM role:
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::595280932656:root"
+            "AWS": "arn:aws:iam::595280932656:role/customer-firehose-access"
           },
           "Action": "sts:AssumeRole",
           "Condition": {
@@ -166,7 +166,7 @@ To attach multiple sources to your IAM role:
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::595280932656:root"
+            "AWS": "arn:aws:iam::595280932656:role/customer-firehose-access"
           },
           "Action": "sts:AssumeRole",
           "Condition": {
@@ -198,7 +198,7 @@ To set this value for a Secret ID:
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::595280932656:root"
+            "AWS": "arn:aws:iam::595280932656:role/customer-firehose-access"
           },
           "Action": "sts:AssumeRole",
           "Condition": {

--- a/src/connections/destinations/catalog/amazon-kinesis/index.md
+++ b/src/connections/destinations/catalog/amazon-kinesis/index.md
@@ -155,7 +155,7 @@ To attach multiple sources to your IAM role:
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::595280932656:root"
+            "AWS": "arn:aws:iam::595280932656:role/customer-kinesis-access"
           },
           "Action": "sts:AssumeRole",
           "Condition": {
@@ -175,7 +175,7 @@ To attach multiple sources to your IAM role:
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::595280932656:root"
+            "AWS": "arn:aws:iam::595280932656:role/customer-kinesis-access"
           },
           "Action": "sts:AssumeRole",
           "Condition": {
@@ -228,7 +228,7 @@ If you have many sources using Kinesis that it's impractical to attach all of th
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::595280932656:root"
+            "AWS": "arn:aws:iam::595280932656:role/customer-kinesis-access"
           },
           "Action": "sts:AssumeRole",
           "Condition": {

--- a/src/connections/destinations/catalog/amazon-lambda/index.md
+++ b/src/connections/destinations/catalog/amazon-lambda/index.md
@@ -146,7 +146,7 @@ To create an IAM role:
     ![A screenshot of the AWS IAM home summary, with the Trust relationships tab selected.](images/LambdaTrustRelationship.png)
 
 7. Copy and paste the following code into your trust relationship. You should replace `<your-source-id>` with either the Source ID of the attached Segment source (the default) or the External ID set in your AWS Lambda destination settings.
-  * `arn:aws:iam::595280932656:root` refers to Segment's AWS Account, and is what allows Segment's Destination to access the role to invoke your Lambda.
+  * `arn:aws:iam::595280932656:role/customer-lambda-prod-destination-access` refers to Segment's AWS Account, and is what allows Segment's Destination to access the role to invoke your Lambda.
 
 > note ""
 > **Note**: Source ID can be found by navigating to **Settings > API Keys** from your Segment source homepage.
@@ -158,7 +158,7 @@ To create an IAM role:
         {
           "Effect": "Allow",
           "Principal": {
-            "AWS": "arn:aws:iam::595280932656:root"
+            "AWS": "arn:aws:iam::595280932656:role/customer-lambda-prod-destination-access"
           },
           "Action": "sts:AssumeRole",
           "Condition": {

--- a/src/connections/destinations/catalog/amazon-personalize/index.md
+++ b/src/connections/destinations/catalog/amazon-personalize/index.md
@@ -691,7 +691,7 @@ To create an IAM role:
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::595280932656:root"
+        "AWS": "arn:aws:iam::595280932656:role/customer-personalize-prod-destination-access"
       },
       "Action": "sts:AssumeRole",
       "Condition": {


### PR DESCRIPTION
### Proposed changes

Segment documentation advises customers to trust the entire account ARN in the trust policy they set up for some AWS destinations. This PR updates the documentation as per AWS best practices to trust specific roles.

### Merge timing

- ASAP once approved

### Related issues (optional)

[SECOPS Ticket](https://segment.atlassian.net/browse/SECOPS-2742)
