### PR TITLE
Add info about CSV Uploader and MTUs count

### DIFF
--- a/src/engage/profiles/csv-upload.md
+++ b/src/engage/profiles/csv-upload.md
@@ -12,7 +12,7 @@ You can also [set subscription states](#set-user-subscriptions) for each email a
 > Uploading a CSV creates new profiles and updates existing profiles. These profile updates may lead to users entering existing audiences or message campaigns.
 
 > info ""
-> Using the CSV Uploader to upload user profiles to Engage will **not** increase your MTUs count. For more information about MTUs and Engage, see [here](/docs/guides/usage-and-billing/mtus-and-throughput/#mtus-and-engage).
+> Using the CSV Uploader to upload user profiles to Engage will **not** increase your MTUs count. [Learn more](/docs/guides/usage-and-billing/mtus-and-throughput/#mtus-and-engage) about MTUs and Engage.
 
 
 ## Upload a CSV file

--- a/src/engage/profiles/csv-upload.md
+++ b/src/engage/profiles/csv-upload.md
@@ -9,7 +9,11 @@ When you upload a CSV file, Engage adds new profiles and updates existing user p
 You can also [set subscription states](#set-user-subscriptions) for each email and phone number that you upload in the CSV. Subscription states help you track which email addresses and numbers you have permission to market to.
 
 > warning ""
-> Uploading a CSV creates new profiles and updates existing profiles. These profile updates may lead to users entering existing audiences or message campaigns. 
+> Uploading a CSV creates new profiles and updates existing profiles. These profile updates may lead to users entering existing audiences or message campaigns.
+
+> info ""
+> Using the CSV Uploader to upload user profiles to Engage will **not** increase your MTUs count. For more information about MTUs and Engage, see [here](/docs/guides/usage-and-billing/mtus-and-throughput/#mtus-and-engage).
+
 
 ## Upload a CSV file
 


### PR DESCRIPTION
### Proposed changes
Add a note in our public docs about CSV Uploader and MTUs count:

> Using the CSV Uploader to upload user profiles to Engage will **not** increase your MTUs count. For more information about MTUs and Engage, see [here](https://segment.com/docs/guides/usage-and-billing/mtus-and-throughput/#mtus-and-engage).


### Merge timing
ASAP once approved
