### PR TITLE
Engage context about filtered events.md

### DIFF
--- a/src/connections/delivery-overview.md
+++ b/src/connections/delivery-overview.md
@@ -60,6 +60,9 @@ Delivery Overview is useful to diagnose delivery errors in the following scenari
 - **When data is missing from your destination**: The pipeline view can help you see where your data is getting "stuck" on the way to your destination, which can help you quickly diagnose and address problems in your data pipeline.
 - **When emission or delivery volume fluctuates out of expected norms**: Delivery Overview will highlight where the largest rate change(s) occurred and what events were associated with the change.
 
+> info "Delivery Overview in Engage Destinations"
+> Having "filtered at destination" events, with the integrations object, in destinations linked to Engage is expected. Engage will use its sources for multiple reasons, not only to send events to a particular destination. Engage uses the integrations object to route events to the destinations you have added to your audiences, traits and journey steps, so events that were filtered due to the integrations object are simply events that are not meant to be delivered by this destination, and hence, are filtered.
+
 ## Where do I find Delivery Overview?
 To view the Delivery Overview page:
 1. Sign into Segment.

--- a/src/connections/delivery-overview.md
+++ b/src/connections/delivery-overview.md
@@ -61,7 +61,7 @@ Delivery Overview is useful to diagnose delivery errors in the following scenari
 - **When emission or delivery volume fluctuates out of expected norms**: Delivery Overview will highlight where the largest rate change(s) occurred and what events were associated with the change.
 
 > info "Delivery Overview in Engage Destinations"
-> Having "filtered at destination" events, with the integrations object, in destinations linked to Engage is expected. Engage will use its sources for multiple reasons, not only to send events to a particular destination. Engage uses the integrations object to route events to the destinations you have added to your audiences, traits and journey steps, so events that were filtered due to the integrations object are simply events that are not meant to be delivered by this destination, and hence, are filtered.
+> Because Engage uses sources for multiple purposes, you can expect to see `filtered at destination` events with the integrations object in destinations linked to Engage. Engage uses the integrations object to route events to destinations you've added to your audiences, traits, and journey steps. As a result, some events aren't meant to be delivered by the destination, so the integrations object filters them.
 
 ## Where do I find Delivery Overview?
 To view the Delivery Overview page:


### PR DESCRIPTION
Clients are confused about filtered events due to the integrations object in their engage destinations, thinking that something is not correct or broken. However, this is expected due to the way Engage handles routing.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved

### Related issues (optional)
https://segment.zendesk.com/agent/tickets/520434
https://segment.zendesk.com/agent/tickets/518096
https://segment.zendesk.com/agent/tickets/518778
