### PR TITLE
Update roles.md to include reverse etl info

### DIFF
--- a/src/segment-app/iam/roles.md
+++ b/src/segment-app/iam/roles.md
@@ -29,13 +29,13 @@ The following roles are only available to Segment Business Tier accounts.
 * **Scope:** Grants access to *all* Identity settings.
 
 #### Source Read-only
-* Read access to assigned source(s), source settings, connected streaming destinations, schema, transformations, and live data in the debugger.
-* **Scope:** Grants access to either: all current and future Sources, or only specific Sources, or Sources with a specific Label (BT only).
+* Read access to assigned source(s), source settings, connected streaming destinations, schema, transformations, and live data in the debugger. Reverse ETL sources are also included.
+* **Scope:** Grants access to either: all current and future Sources, or only specific Sources, or Sources with a specific Label (BT only). 
 
 
 #### Source Admin
-* Edit access to assigned source(s), source settings, connected streaming destinations, schema, transformations, the source's [write key](/docs/connections/find-writekey/) and live data in the debugger.
-* **Scope:** Grants access to either: all current and future Sources, or only specific Sources, or Sources with a specific Label (BT only).
+* Edit access to assigned source(s), source settings, connected streaming destinations, schema, transformations, the source's [write key](/docs/connections/find-writekey/) and live data in the debugger. Reverse ETL sources are also included.
+* **Scope:** Grants access to either: all current and future Sources, or only specific Sources, or Sources with a specific Label (BT only). 
 
 #### Unify and Engage Admin
 * Edit access to Unify settings and if purchased, Engage Audiences, Traits, Journeys, Content, and settings.


### PR DESCRIPTION
add info about roles required for reverse etl

### Proposed changes

Added a small reference to reverse ETL under Source admin/read-only roles which should suffice. Tested in my own workspace that only Source Admin/Source read-only grants access to edit/view Reverse ETL sources. 

### Merge timing
- ASAP once approved

### Related issues 

KCS - https://segment.atlassian.net/browse/KCS-469