### PR TITLE
Add faq that insert function can only be connected to one destination

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -317,7 +317,7 @@ No, destination insert functions are currently available as cloud-mode destinati
 
 ##### Can I connect an insert function to multiple destinations?
 
-No, a Destination Insert Function currently can be connected to one destination only.
+No, an insert function can only be connected to one destination.
 
 ##### How do I publish a destination to the public Segment catalog?
 

--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -315,6 +315,10 @@ No, Segment can't guarantee the order in which the events are delivered to an en
 
 No, destination insert functions are currently available as cloud-mode destinations only. Segment is in the early phases of exploration and discovery for supporting customer "web plugins" for custom device-mode destinations and other use cases, but this is unsupported today.
 
+##### Can I connect an insert function to multiple destinations?
+
+No, a destination insert function currently can be connected to one destinations only.
+
 ##### How do I publish a destination to the public Segment catalog?
 
 If you are a partner, looking to publish your destination and distribute your app through Segment catalog, visit the [Developer Center](https://segment.com/partners/developer-center/){:target="_blank"} and check out the Segment [partner docs](/docs/partners/).

--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -317,7 +317,7 @@ No, destination insert functions are currently available as cloud-mode destinati
 
 ##### Can I connect an insert function to multiple destinations?
 
-No, a destination insert function currently can be connected to one destinations only.
+No, a Destination Insert Function currently can be connected to one destination only.
 
 ##### How do I publish a destination to the public Segment catalog?
 


### PR DESCRIPTION
### Proposed changes

Added the following faq that insert function can only be connected to one destination only.

"Can I connect an insert function to multiple destinations?

No, a destination insert function currently can be connected to one destinations only."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->

https://segment.zendesk.com/agent/tickets/517992
