### PR TITLE
Adding missing directory to image link on Testing Connections page

### DIFF
--- a/src/connections/test-connections.md
+++ b/src/connections/test-connections.md
@@ -37,7 +37,7 @@ The event payload from your debugger that you just selected will automatically l
 
 This is a real event that will appear in your end tool alongside your existing data. If you're not comfortable with this, then select "Cancel" and do not send the event. 
 
-![Screenshot of the popup that appears when you click the Send test event button.](/guides/images/asset_Yxw1DJqb.png)
+![Screenshot of the popup that appears when you click the Send test event button.](/docs/guides/images/asset_Yxw1DJqb.png)
 
 **5. View the Partner API response**
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Image in step 4 of the procedure on the Testing Connections page wouldn't load because it was missing a directory level - it should load now

### Merge timing
ASAP

