### PR TITLE
Updating Clevertap connection modes table

### DIFF
--- a/src/_data/catalog/overrides.yml
+++ b/src/_data/catalog/overrides.yml
@@ -42,7 +42,7 @@ items:
       mobile: true
       server: false
     cloud:
-      web: true
+      web: false
       mobile: true
       server: true
 - slug: criteo-app-web-events


### PR DESCRIPTION
### Proposed changes
Removing indicated support for cloud mode web connections for the Clevertap classic destination.

### Merge timing
ASAP once approved!

### Related issues (optional)
Closes issue #5164.

Related to issue #2303, which was resolved by PR #3016.
