### PR TITLE
hide original canny docs

### DIFF
--- a/src/connections/destinations/catalog/actions-canny/index.md
+++ b/src/connections/destinations/catalog/actions-canny/index.md
@@ -1,7 +1,6 @@
 ---
 title: Canny (Actions) Destination
 id: 6489bbade6fe3eb57c13bd6a
-beta: true
 ---
 
 {% include content/plan-grid.md name="actions" %}

--- a/src/connections/destinations/catalog/canny/index.md
+++ b/src/connections/destinations/catalog/canny/index.md
@@ -3,6 +3,8 @@ title: Canny Destination
 rewrite: true
 hide-dossier: true
 redirect_from: '/connections/destinations/catalog/canny-functions/'
+hidden: true
+private: true
 id: 609d2b40f4bd0f24a5a37fbb
 ---
 [Canny](https://canny.io) is a single place for all customer feedback. It saves you time managing all the feedback while keeping your customers in the loop. Let your customers post and vote on feedback from within your website or mobile app. You'll get an organized list of feedback that you can use to inform your roadmap.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

This canny destination has been deprecated with the release of the new actions version. This PR hides these docs, and also moves the action destination out of beta.

### Merge timing
asap
