### PR TITLE
Add faq that retries could account for events not filtered by Destination Filter

### DIFF
--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -226,3 +226,7 @@ Destination Filters can't target properties or traits with spaces in the field n
 #### Can I use destination filters to drop events unsupported by a destination?
 
 The check for unsupported events types happens before any destination filter checks. As a result, Destination Filters can't prevent unsupported event type errors. To filter these events, use the [Integrations Object](/docs/guides/filtering-data/#filtering-with-the-integrations-object).
+
+#### Why do I see events being sent through after I just added a destination filter?
+
+If Event Delivery page shows events have been retried, the retries could account for events that did not get filtered when the Destination Filter is just added. Such scenario can occur when an event was sent to the destination and encountered timeout error, and retries for the events are attempted. While the retries are attempted, and a Destination Filter is then added, these retries will not subject to the filtering since these are from the events sent before the Destination Filter is added.

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -227,6 +227,8 @@ Destination Filters can't target properties or traits with spaces in the field n
 
 The check for unsupported events types happens before any destination filter checks. As a result, Destination Filters can't prevent unsupported event type errors. To filter these events, use the [Integrations Object](/docs/guides/filtering-data/#filtering-with-the-integrations-object).
 
-#### Why do I see events being sent through after I just added a destination filter?
+#### Why do I see events sent through after I just added a destination filter?
 
-If Event Delivery page shows events have been retried, the retries could account for events that did not get filtered when the Destination Filter is just added. Such scenario can occur when an event was sent to the destination and encountered timeout error, and retries for the events are attempted. While the retries are attempted, and a Destination Filter is then added, these retries will not subject to the filtering since these are from the events sent before the Destination Filter is added.
+Destination filters only filter events sent after filter setup. If you just added a destination filter but still see some events going through, you're likely seeing retries from failed events that occurred before you set up the filter.
+
+When Segment sends an event to a destination but encounters a timeout error, it attempts to send the event again. As a result, if you add a destination filter while Segment is trying to send a failed event, these retries could filter through, since they reflect events that occurred before filter setup.


### PR DESCRIPTION
### Proposed changes
Customers are confused that sometimes they are still seeing events flowing through after adding Destination Filter. Added the following faq to indicate that retries could account for these events not filtered by Destination Filter

"Why do I see events being sent through after I just added a destination filter?

If Event Delivery page shows events have been retried, the retries could account for events that did not get filtered when the Destination Filter is just added. Such scenario can occur when an event was sent to the destination and encountered timeout error, and retries for the events are attempted. While the retries are attempted, and a Destination Filter is then added, these retries will not subject to the filtering since these are from the events sent before the Destination Filter is added."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->

https://segment.zendesk.com/agent/tickets/518110
https://segment.zendesk.com/agent/tickets/380271
