### PR TITLE
Fix spelling error on Privacy Portal page

### DIFF
--- a/src/privacy/portal.md
+++ b/src/privacy/portal.md
@@ -187,7 +187,7 @@ for in your workspace. You can use this feature to detect properties that are
 unique to your company or region, or that aren't already handled by the default
 matchers above. You can have up to 100 custom matchers per workspace. Custom
 Matchers detect data in your Web, Mobile, Server, and Cloud Event Sources for 
-fields under `contexts`, `traits` and `properties` objects, and
+fields under `context`, `traits` and `properties` objects, and
 the data they detect appears in the Inbox.
 
 For example, if you have a restricted data point at your company called "SIN"


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Fixed spelling error (`contexts` -> `context`) on privacy portal page, as requested by engineering

### Merge timing
ASAP

### Related issues (optional)

