### PR TITLE
Information about the available actions of SFMC destination.

### DIFF
--- a/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
@@ -58,6 +58,10 @@ Once you save the API integration and add permissions, you will see a Summary pa
 
 {% include components/actions-fields.html settings="true"%}
 
+>info ""
+>Under the hood both of the actions **send contact to data extension** and **send event to data extension** do the same thing, but **send contact to data extension** is set up to handle a pre defined structure of contacts being filled into a data extension, for any customization the **send event to data extension action** can be used.
+>For example, **contactKey** is the fixed Primary Key that will be available on **send contact to data extension** action and the same has to be created as a Primary Key in SFMC too. But the Primary Key can be set as per our requirement in the **send event to data extension** action.
+
 ## FAQ & Troubleshooting
 
 ### Batching Data to SFMC

--- a/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
@@ -59,7 +59,7 @@ Once you save the API integration and add permissions, you will see a Summary pa
 {% include components/actions-fields.html settings="true"%}
 
 > info ""
->Under the hood both of the actions **send contact to data extension** and **send event to data extension** do the same thing, but **send contact to data extension** is set up to handle a pre defined structure of contacts being filled into a data extension, for any customization the **send event to data extension action** can be used.
+> Note that **send contact to data extension** handles a pre-defined structure of contacts being filled into a data extension, whereas **send event to data extension action** customizes event data extensions. 
 >For example, **contactKey** is the fixed Primary Key that will be available on **send contact to data extension** action and the same has to be created as a Primary Key in SFMC too. But the Primary Key can be set as per our requirement in the **send event to data extension** action.
 
 ## FAQ and troubleshooting

--- a/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
@@ -58,7 +58,7 @@ Once you save the API integration and add permissions, you will see a Summary pa
 
 {% include components/actions-fields.html settings="true"%}
 
->info ""
+> info ""
 >Under the hood both of the actions **send contact to data extension** and **send event to data extension** do the same thing, but **send contact to data extension** is set up to handle a pre defined structure of contacts being filled into a data extension, for any customization the **send event to data extension action** can be used.
 >For example, **contactKey** is the fixed Primary Key that will be available on **send contact to data extension** action and the same has to be created as a Primary Key in SFMC too. But the Primary Key can be set as per our requirement in the **send event to data extension** action.
 

--- a/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
@@ -60,7 +60,7 @@ Once you save the API integration and add permissions, you will see a Summary pa
 
 > info ""
 > Note that **send contact to data extension** handles a pre-defined structure of contacts being filled into a data extension, whereas **send event to data extension action** customizes event data extensions. 
->For example, **contactKey** is the fixed Primary Key that will be available on **send contact to data extension** action and the same has to be created as a Primary Key in SFMC too. But the Primary Key can be set as per our requirement in the **send event to data extension** action.
+> For example, `contactKey` is the fixed Primary Key that is available when you use **send contact to data extension** action, which you also have to create as a Primary Key in SFMC. However, the Primary Key can be set as per Segment's requirements using **send event to data extension**.
 
 ## FAQ and troubleshooting
 

--- a/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce-marketing-cloud/index.md
@@ -62,7 +62,7 @@ Once you save the API integration and add permissions, you will see a Summary pa
 >Under the hood both of the actions **send contact to data extension** and **send event to data extension** do the same thing, but **send contact to data extension** is set up to handle a pre defined structure of contacts being filled into a data extension, for any customization the **send event to data extension action** can be used.
 >For example, **contactKey** is the fixed Primary Key that will be available on **send contact to data extension** action and the same has to be created as a Primary Key in SFMC too. But the Primary Key can be set as per our requirement in the **send event to data extension** action.
 
-## FAQ & Troubleshooting
+## FAQ and troubleshooting
 
 ### Batching Data to SFMC
 


### PR DESCRIPTION

### Proposed changes

>info ""
>Under the hood both of the actions **send contact to data extension** and **send event to data extension** do the same thing, but **send contact to data extension** is set up to handle a pre defined structure of contacts being filled into a data extension, for any customization the **send event to data extension action** can be used.
>For example, **contactKey** is the fixed Primary Key that will be available on **send contact to data extension** action and the same has to be created as a Primary Key in SFMC too. But the Primary Key can be set as per our requirement in the **send event to data extension** action.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
