### PR TITLE
WebEngage Connection Mode override

### DIFF
--- a/src/_data/catalog/overrides.yml
+++ b/src/_data/catalog/overrides.yml
@@ -41,7 +41,7 @@ items:
       mobile: true
       server: false
     cloud:
-      web: true
+      web: false
       mobile: false
       server: true
 - slug: clevertap

--- a/src/_data/catalog/overrides.yml
+++ b/src/_data/catalog/overrides.yml
@@ -33,7 +33,17 @@ items:
       web: false
       mobile: true
       server: true
-
+- slug: webengage
+  id: 54521fdc25e721e32a72ef02
+  connection_modes: 
+    device: 
+      web: true
+      mobile: true
+      server: false
+    cloud:
+      web: true
+      mobile: false
+      server: true
 - slug: clevertap
   id: 5711271880412f644ff13150
   connection_modes:


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
As requested by @joeynmq, updated the WebEngage destination's connection modes table to indicate support for cloud-mode web & server connections

### Merge timing
ASAP once approved

### Related issues (optional)
Closes #4977 
