### PR TITLE
Add tips regrading GTM 404 error

### DIFF
--- a/src/connections/destinations/catalog/google-tag-manager/index.md
+++ b/src/connections/destinations/catalog/google-tag-manager/index.md
@@ -80,7 +80,8 @@ Segment sends it to the `dataLayer` as an object like this:
 ## Troubleshooting
 
 ### 404 Error
-If you are seeing `404` error on the JavaScript console of your page and it is attributed to Google Tag Manager, it is likely that you have yet to publish your GTM container.
+If you are seeing `404` error on the JavaScript console of your page and it is attributed to Google Tag Manager, it is likely that you have yet to publish your GTM container. If the issue still persists, please ensure that Google's preview mode is disabled and that the [environment variable](/docs/connections/destinations/catalog/google-tag-manager/#environment) is removed from your destination settings.
+
 
 ### Duplicate Events
 If you have Google Ads enabled and see duplicate events in GTM, check to see if the event is set as a conversion in Google Ads. Duplicate conversions are common when you use both Google Ads and GTM, since Segment's Adwords destination initializes the gtag script with the dataLayer itself. So, when you fire a mapped event, Segment submits the payload directly to the dataLayer.


### PR DESCRIPTION
### Proposed changes
The customer encountered 404 error when loading GTM on their website. They have also confirmed the tag has been published.

It turns out that the issue is caused by the environment variable for gtm_preview in tag's query string. After removing the environment variable from destination settings, the issue was resolved.

### Merge timing
ASAP once approved
