### PR TITLE
Add information regarding default limit number of functions

### DIFF
--- a/src/connections/functions/usage.md
+++ b/src/connections/functions/usage.md
@@ -69,3 +69,7 @@ for (const response of responses) {
 ```
 
 If you're only issuing a single request in your function and it is slow, you might want to contact the owner of the external API for support.
+
+## Default limit number
+
+Each workspace has a default limit of 25 functions in total. Adding the different types of functions, you cannot create more than 25 functions. If you want to create more than 25, please reach out to friends@segment.com.

--- a/src/connections/functions/usage.md
+++ b/src/connections/functions/usage.md
@@ -72,4 +72,4 @@ If you're only issuing a single request in your function and it is slow, you mig
 
 ## Default limit number
 
-Each workspace has a default limit of 25 Functions in total across Source, Insert, and Destination Functions. If you want to create more than 25, please reach out to friends@segment.com.
+Each workspace has a default limit of 25 Functions in total across Source, Insert, and Destination Functions. If you want to create more, please reach out to [Segment](mailto:friends@segment.com).

--- a/src/connections/functions/usage.md
+++ b/src/connections/functions/usage.md
@@ -72,4 +72,4 @@ If you're only issuing a single request in your function and it is slow, you mig
 
 ## Default limit number
 
-Each workspace has a default limit of 25 functions in total. Adding the different types of functions, you cannot create more than 25 functions. If you want to create more than 25, please reach out to friends@segment.com.
+Each workspace has a default limit of 25 Functions in total across Source, Insert, and Destination Functions. If you want to create more than 25, please reach out to friends@segment.com.


### PR DESCRIPTION
### Proposed changes
Customer encountered error when trying to create more than 25 functions.

Add the following information regarding default limit number of function in each workspace.

"Default limit number

Each workspace has a default limit of 25 functions in total. Adding the different types of functions, you cannot create more than 25 functions. If you want to create more than 25, please reach out to friends@segment.com."


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
Engineering comment on the default limit number of functions: https://twilio.slack.com/archives/CH44TB529/p1690781731211629

Sample ticket: https://segment.zendesk.com/agent/tickets/518958
