### PR TITLE
Add information to save the Sandbox enabled settings before authenticate

### DIFF
--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -116,7 +116,7 @@ Review the tables below to see how settings from Salesforce (Classic) were migra
 ## FAQ
 
 ### How do I enable a sandbox instance?
-To send data to a Salesforce sandbox instance, navigate to **Settings > Advanced Settings**, toggle on the "Sandbox Instance" setting, and authenticate. If you are already authenticated, please disconnect and reconnect with your sandbox username. 
+To send data to a Salesforce sandbox instance, navigate to **Settings > Advanced Settings**, toggle on the "Sandbox Instance" setting, save the setting and then authenticate. If you are already authenticated, please disconnect and reconnect with your sandbox username. 
 
 Your Salesforce sandbox username appends the sandbox name to your Salesforce production username. For example, if a username for a production org is `user@acme.com` and the sandbox is named `test`, the username to log in to the sandbox is `user@acme.com.test`.
 


### PR DESCRIPTION

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
<!--Tell us what you did and why-->
Add information in the faq on "How do I enable a sandbox instance?", to save the settings, then authenticate.

Change from:
"To send data to a Salesforce sandbox instance, navigate to Settings > Advanced Settings, toggle on the “Sandbox Instance” setting, and authenticate."

To:
"To send data to a Salesforce sandbox instance, navigate to Settings > Advanced Settings, toggle on the "Sandbox Instance" setting, save the setting and then authenticate. “

If customers do not save the Sandbox instance on setting, they will still see the Salesforce Production URL, and not the Salesforce Sandbox URL when they authenticate.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
https://segment.zendesk.com/agent/tickets/520101

