### PR TITLE
Move note about traits to first sentence of the section

### DIFF
--- a/src/guides/filtering-data.md
+++ b/src/guides/filtering-data.md
@@ -80,7 +80,7 @@ The events filtered out of individual destinations using this method still arriv
 
 ## Schema event filters
 
-You can use Schema Event Filters to discard and permanently remove Page, Screen and Track events from event-based sources, preventing them from reaching any destinations or warehouses. Use this if you know that you'll never want to access this data again. This functionality is similar to filtering with the Integrations object, however it can be changed from within the Segment app without touching any code.
+You can use Schema Event Filters to discard and permanently remove Page, Screen and Track events from event-based sources, preventing them from reaching any destinations or warehouses, as well as omit identify traits and group properties. Use this if you know that you'll never want to access this data again. This functionality is similar to filtering with the Integrations object, however it can be changed from within the Segment app without touching any code.
 
 When you enable these filters, Segment stops forwarding the data to all of your Cloud- and device-mode destinations, including warehouses, and your data is no longer stored in Segment's warehouses for later replay.
 


### PR DESCRIPTION
### Proposed changes

Move the line about "traits" to the first sentence of the topic to make it clear that traits can also be blocked by schema filters.

### Merge timing
- ASAP once approved


### Related issues (optional)

Slack: https://twilio.slack.com/archives/C010W2FMYN5/p1693327567480589
