### PR TITLE
Clarify HubSpot sync info

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/hubspot/index.md
+++ b/src/connections/sources/catalog/cloud-apps/hubspot/index.md
@@ -27,7 +27,7 @@ Voila! We'll begin syncing your HubSpot data into Segment momentarily, and it wi
 
 ### Sync
 
-The HubSpot source is built with a sync component, which means we'll make requests to their API on your behalf on a 3 hour interval to pull nearly all data into Segment. In the initial sync, we'll grab all the HubSpot objects (and their corresponding properties) according to the Collections Table below. The objects will be written into a separate schema, corresponding to the source instance's schema name you designated upon creation (ie. my_source.charges).
+The HubSpot source is built with a sync component, which means Segment makes requests to their API on your behalf on a three hour interval to pull nearly all data into Segment. In the initial sync, Segment will grab all the HubSpot objects (and their corresponding properties) according to the Collections Table below. The objects will be written into a separate schema, corresponding to the source instance's schema name you designated upon creation (for example, `my_source.charges`).
 
 Our sync component uses an upsert API, so the data in your warehouse loaded using sync will reflect the latest state of the corresponding resource in HubSpot. For example, if `deals` goes from `open` to `closed` between syncs, on its next sync that deal's status will be `closed`.
 

--- a/src/connections/sources/catalog/cloud-apps/hubspot/index.md
+++ b/src/connections/sources/catalog/cloud-apps/hubspot/index.md
@@ -27,7 +27,7 @@ Voila! We'll begin syncing your HubSpot data into Segment momentarily, and it wi
 
 ### Sync
 
-The HubSpot source is built with a sync component, which means we'll make requests to their API on your behalf on a 3 hour interval to pull the latest data into Segment. In the initial sync, we'll grab all the HubSpot objects (and their corresponding properties) according to the Collections Table below. The objects will be written into a separate schema, corresponding to the source instance's schema name you designated upon creation (ie. my_source.charges).
+The HubSpot source is built with a sync component, which means we'll make requests to their API on your behalf on a 3 hour interval to pull nearly all data into Segment. In the initial sync, we'll grab all the HubSpot objects (and their corresponding properties) according to the Collections Table below. The objects will be written into a separate schema, corresponding to the source instance's schema name you designated upon creation (ie. my_source.charges).
 
 Our sync component uses an upsert API, so the data in your warehouse loaded using sync will reflect the latest state of the corresponding resource in HubSpot. For example, if `deals` goes from `open` to `closed` between syncs, on its next sync that deal's status will be `closed`.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Customers often write to Support to confirm why HubSpot syncs all data when the doc suggests that only the latest data is synced. So, this change is suggested to rectify the verbiage and offer more clarity. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
