### PR TITLE
Update server side event information

### DIFF
--- a/src/connections/destinations/catalog/appsflyer/index.md
+++ b/src/connections/destinations/catalog/appsflyer/index.md
@@ -139,9 +139,12 @@ analytics.track({
 ```
 > Check your specific [server-side library docs](/docs/connections/sources/#server) for specifics on how to format the method properly.
 
+> info ""
+> Please see the **Can Omit AppsFlyerId** and **Fallback to send IDFV when advertisingId key not present (Server-Side Only)** settings descriptions for more details on excluding the above fields in server side events.
+
 Finally, the server-side component will look for the following `properties` and handle them specially:
 
-- `ip` (this should be the `ip` of your customer--this is not collected by Segment's libraries out-of-the-box)
+- `ip` (this should be the `ip` of your customer--this is not collected by Segment's libraries out-of-the-box. This should be passed into the payload under context in order to be properly attributed by AppsFlyer)
 - `timestamp` (refer to AppsFlyer's docs on [how they process timestamps](https://support.appsflyer.com/hc/en-us/articles/207034486-Server-to-Server-In-App-Events-API-HTTP-API-){:target="blank"}. Since the libraries generate a [timestamp](/docs/connections/spec/common/#timestamps), Segment always sets this value)
 - `currency` (defaults to `"USD"`)
 - `revenue` (For `Order Completed` events, precedence is given to `total`, falling back to `properties.revenue`)

--- a/src/connections/destinations/catalog/appsflyer/index.md
+++ b/src/connections/destinations/catalog/appsflyer/index.md
@@ -140,11 +140,11 @@ analytics.track({
 > Check your specific [server-side library docs](/docs/connections/sources/#server) for specifics on how to format the method properly.
 
 > info ""
-> Please see the **Can Omit AppsFlyerId** and **Fallback to send IDFV when advertisingId key not present (Server-Side Only)** settings descriptions for more details on excluding the above fields in server side events.
+> See the **Can Omit AppsFlyerId** and **Fallback to send IDFV when advertisingId key not present (Server-Side Only)** settings descriptions for details on excluding the previous fields in server-side events.
 
 Finally, the server-side component will look for the following `properties` and handle them specially:
 
-- `ip` (this should be the `ip` of your customer--this is not collected by Segment's libraries out-of-the-box. This should be passed into the payload under context in order to be properly attributed by AppsFlyer)
+- `ip` (this should be the `ip` of your customer--this is not collected by Segment's libraries out-of-the-box. Pass this into the payload under context so that AppsFlyer can properly attribute it.)
 - `timestamp` (refer to AppsFlyer's docs on [how they process timestamps](https://support.appsflyer.com/hc/en-us/articles/207034486-Server-to-Server-In-App-Events-API-HTTP-API-){:target="blank"}. Since the libraries generate a [timestamp](/docs/connections/spec/common/#timestamps), Segment always sets this value)
 - `currency` (defaults to `"USD"`)
 - `revenue` (For `Order Completed` events, precedence is given to `total`, falling back to `properties.revenue`)


### PR DESCRIPTION

### Proposed changes

Added details about sending IP address for server side events in the context object. The current documentation indicates it should be sent in properties, but this does not put it on the top level of the payload as AppsFlyer expects. 

Also added a note for customers to see the **Can Omit AppsFlyerId** and **Fallback to IDFV** setting descriptions if they intend to omit any of the required properties for server side events. These descriptions adequately explain that if AppsFlyerId is omitted, then IDFA will be used and if IDFA is not there, they need to enable fallback to IDFV and include `device.id`.  Many customers do not read this and will enable **Can Omit AppsFlyerId** without including an IDFA or IDFV value to fallback on.


### Merge timing

- ASAP once approved

### Related issues (optional)

n/a
