### PR TITLE
Add info about Mixpanel's distinct_id

### DIFF
--- a/src/connections/destinations/catalog/mixpanel/index.md
+++ b/src/connections/destinations/catalog/mixpanel/index.md
@@ -488,7 +488,7 @@ If you're testing in Xcode remember you must first background the app, then the 
 
 ### Distinct ID
 
-In Device-mode, when a `distinct_id` is present in the browser, it will be automatically sent to Mixpanel. While in Cloud-mode, the `distinct_id` is set to Segment's `userId` if one is present. If there is no `userId` on the payload, `anonymousId` is set instead.
+In Device-mode, when a `distinct_id` is present in the browser, it is automatically sent to Mixpanel. In Cloud-mode, the `distinct_id` is set to Segment's `userId` if one is present. If there is no `userId` on the payload, `anonymousId` is set instead.
 
 
 ### IP

--- a/src/connections/destinations/catalog/mixpanel/index.md
+++ b/src/connections/destinations/catalog/mixpanel/index.md
@@ -485,6 +485,12 @@ If you're testing in Xcode remember you must first background the app, then the 
 
 ## Appendices
 
+
+### Distinct ID
+
+In Device-mode, when a `distinct_id` is present in the browser, it will be automatically sent to Mixpanel. While in Cloud-mode, the `distinct_id` is set to Segment's `userId` if one is present. If there is no `userId` on the payload, `anonymousId` is set instead.
+
+
 ### IP
 
 If an `ip` property is passed to Mixpanel, the value will be interpreted as the IP address of the request and therefore automatically parsed into Mixpanel geolocation properties (City, Country, Region). After that IP address has been parsed, they will throw out the IP address and only hold onto those resulting geolocation properties. As such, if you want to display an IP address as a property within the Mixpanel UI or within raw data, you will simply want to slightly modify the naming convention for that property.


### PR DESCRIPTION
### Proposed changes
Our public documentation does not contain information regarding how distinct_id is set when customers use Mixpanel (legacy) in cloud-mode.

Source code: https://github.com/segmentio/integrations/blob/master/integrations/mixpanel/lib/index.js#L749-L755

### Merge timing
ASAP once approved