### PR TITLE
explain the dedupe window

### DIFF
--- a/src/guides/duplicate-data.md
+++ b/src/guides/duplicate-data.md
@@ -6,7 +6,7 @@ Segment guarantees that 99% of your data won't have duplicates within an approxi
 
 ## 99% deduplication
 
-Segment has a special deduplication service that sits behind the `api.segment.com` endpoint and attempts to drop 99% of duplicate data. To achieve it, Segment stores at least 24 hours worth of event `messageId`s, which allows Segment systems to deduplicate any data that appears with the same `messageId` within the stored values.
+Segment has a special deduplication service that sits behind the `api.segment.com` endpoint and attempts to drop 99% of duplicate data. Segment stores at least 24 hours' worth of event `messageId`s, which allows Segment to deduplicate any data that appears with the same `messageId` within the stored values.
 
 Segment deduplicates on the event's `messageId`, _not_ on the contents of the event payload. Segment doesn't have a built-in way to deduplicate data for events that don't generate `messageId`s.
 

--- a/src/guides/duplicate-data.md
+++ b/src/guides/duplicate-data.md
@@ -6,7 +6,7 @@ Segment guarantees that 99% of your data won't have duplicates within an approxi
 
 ## 99% deduplication
 
-Segment has a special deduplication service that sits behind the `api.segment.com` endpoint and attempts to drop 99% of duplicate data. Segment stores at least 24 hours worth of event `messageId`s, allowing Segment to deduplicate any data that appears within a 24 hour rolling window.
+Segment has a special deduplication service that sits behind the `api.segment.com` endpoint and attempts to drop 99% of duplicate data. To achieve it, Segment stores at least 24 hours worth of event `messageId`s, which allows Segment systems to deduplicate any data that appears with the same `messageId` within the stored values.
 
 Segment deduplicates on the event's `messageId`, _not_ on the contents of the event payload. Segment doesn't have a built-in way to deduplicate data for events that don't generate `messageId`s.
 


### PR DESCRIPTION
It’s more concise to publish that we do not only deduplicating `meesageId` within a 24-hour rolling window

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->
