### PR TITLE
adding description for support of product arrays with Snap CAPI

### DIFF
--- a/src/connections/destinations/catalog/actions-snap-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-snap-conversions/index.md
@@ -75,6 +75,11 @@ It's possible to send details of either single or multiple products/items in a s
 - **Single product/item**: Use the "Item ID", "Item Category", "Brand", "Number of Items", and "Price" fields. 
 - **Multiple products/items**: Use the "Products" field which accepts an array of products / items.  
 
+### Specifying the total value of a purchase
+There are 2 ways to specify the total value of a purchase. This can be controlled using the "Track Purchase Value Per Product" field.  
+- **Price field**: Provide a single numeric value for the total purchase value via the "Price" field. This is the detault approach.   
+- **Calculate from Products field**: Calculate the total purchase value using the "Price" and "Number of Items" sub fields from the "Products" field. 
+
 ### Required parameters and hashing
 To match visitor events with Snapchat ads, Snap requires that one or a combination of the following parameters are sent to the Conversions API:
 - Email

--- a/src/connections/destinations/catalog/actions-snap-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-snap-conversions/index.md
@@ -70,6 +70,11 @@ If you want to send a Snap Event Type that Segment doesn’t have a prebuilt map
 
 The Snapchat Conversions API only supports sending Event Types that are in the [predefined `event_type` list](https://marketingapi.snapchat.com/docs/conversion.html#conversion-parameters){:target="_blank"}. This includes custom events. You must use `CUSTOM_EVENT_1`, `CUSTOM_EVENT_2`, `CUSTOM_EVENT_3`, `CUSTOM_EVENT_4`, or `CUSTOM_EVENT_5` as the Event Type. Events sent with an invalid event type will fail with an `Unrecognized event type` error.
 
+### Single or multiple products or items
+It's possible to send details of either single or multiple products / items in a single conversion event. 
+Single product / item: Use the 'Item ID', 'Item Category', 'Brand', 'Number of Items' and 'Price' fields. 
+Multiple products / items: Use the 'Products' field which accepts an array of products / items.  
+
 ### Required parameters and hashing
 To match visitor events with Snapchat ads, Snap requires that one or a combination of the following parameters are sent to the Conversions API:
 - Email

--- a/src/connections/destinations/catalog/actions-snap-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-snap-conversions/index.md
@@ -72,13 +72,11 @@ The Snapchat Conversions API only supports sending Event Types that are in the [
 
 ### Single or multiple products or items
 It's possible to send details of either single or multiple products/items in a single conversion event. 
-- **Single product/item**: Use the "Item ID", "Item Category", "Brand", "Number of Items", and "Price" fields. 
-- **Multiple products/items**: Use the "Products" field which accepts an array of products / items.  
+- **Single product/item**: Use the "Item ID", "Item Category" and "Brand" fields. 
+- **Multiple products/items**: Use the "Products" field which accepts an array of products / items. 
 
 ### Specifying the total value of a purchase
-There are 2 ways to specify the total value of a purchase. This can be controlled using the "Track Purchase Value Per Product" field.  
-- **Price field**: Provide a single numeric value for the total purchase value via the "Price" field. This is the detault approach.   
-- **Calculate from Products field**: Calculate the total purchase value using the "Price" and "Number of Items" sub fields from the "Products" field. 
+The "Price" field should be used when specifying the total value of a purchase, and should contain a numeric value only. e.g. 99.5. 
 
 ### Required parameters and hashing
 To match visitor events with Snapchat ads, Snap requires that one or a combination of the following parameters are sent to the Conversions API:

--- a/src/connections/destinations/catalog/actions-snap-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-snap-conversions/index.md
@@ -71,9 +71,9 @@ If you want to send a Snap Event Type that Segment doesn’t have a prebuilt map
 The Snapchat Conversions API only supports sending Event Types that are in the [predefined `event_type` list](https://marketingapi.snapchat.com/docs/conversion.html#conversion-parameters){:target="_blank"}. This includes custom events. You must use `CUSTOM_EVENT_1`, `CUSTOM_EVENT_2`, `CUSTOM_EVENT_3`, `CUSTOM_EVENT_4`, or `CUSTOM_EVENT_5` as the Event Type. Events sent with an invalid event type will fail with an `Unrecognized event type` error.
 
 ### Single or multiple products or items
-It's possible to send details of either single or multiple products / items in a single conversion event. 
-Single product / item: Use the 'Item ID', 'Item Category', 'Brand', 'Number of Items' and 'Price' fields. 
-Multiple products / items: Use the 'Products' field which accepts an array of products / items.  
+It's possible to send details of either single or multiple products/items in a single conversion event. 
+- **Single product/item**: Use the "Item ID", "Item Category", "Brand", "Number of Items", and "Price" fields. 
+- **Multiple products/items**: Use the "Products" field which accepts an array of products / items.  
 
 ### Required parameters and hashing
 To match visitor events with Snapchat ads, Snap requires that one or a combination of the following parameters are sent to the Conversions API:


### PR DESCRIPTION
### Proposed changes

Snap CAPI Destination needs to allow customers to pass arrays of products in conversion events. 
This capability is being added with this [action-destinations PR](https://github.com/segmentio/action-destinations/pull/1557).  

Once deployed, this docs update explains the change. 

### Merge timing
- Merge only after the PR above has been deployed. 

### Related issues (optional)
https://segment.atlassian.net/browse/PE-88
