### PR TITLE
Add workaround for object cloud source <> engage space

### DIFF
--- a/src/engage/quickstart.md
+++ b/src/engage/quickstart.md
@@ -45,6 +45,8 @@ Invite teammates to your Engage dev space and grant them access to the space. Na
 2. On the screen that appears, choose one or two production sources from your Connections workspace.
    Segment recommends connecting your production website or App source as a great starting point.
 
+Note: While it is not possible to connect an object cloud source, like Zendesk, to your Engage space directly, you may consider using RETL <> Segment Connections Destination to send object cloud source data back into Segment to pipe to your Engage space. 
+
 To learn more, visit [Connect production sources](/docs/unify/quickstart/#step-3-connect-production-sources).
 
 ## Step 4: Check your profile data


### PR DESCRIPTION
### Proposed changes

- Note: While it is not possible to connect an object cloud source, like Zendesk, to your Engage space directly, you may consider using RETL <> Segment Connections Destination to send object cloud source data back into Segment to pipe to your Engage space.

### Merge timing
<!-- When should this get merged/published?
- once approved

