### PR TITLE
Add note on delivery overview if no mapping for event

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -194,7 +194,7 @@ When you send an event with an actions destination Event Tester that doesn't mat
 If no mappings are enabled to trigger on an event that has been received from the connected source, the destination will not send any events. Ensure that at least one mapping has been configured and enabled in the destination mappings for an event that you would like to reach downstream. 
 
 > info ""
-> Events without mappings enabled to handle them can show as being discarded due to "No matching mapping" in a destination's Delivery Overview.
+> Events without mappings enabled to handle them display as being discarded due to "No matching mapping" in a destination's Delivery Overview.
 
 ### Multiple mappings triggered by the same event
 


### PR DESCRIPTION
### Proposed changes

Added note to FAQs that clarifies that a destination's Delivery Overview can show an event as being discarded due to "no matching mappings" if the destination does not have a mapping enabled and configured to handle it. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
