### PR TITLE
Remove beta info for RETL Postgres and Databricks sources

### DIFF
--- a/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
+++ b/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
@@ -2,9 +2,6 @@
 title: Databricks Reverse ETL Setup
 ---
 
-> info ""
-> The Databricks Reverse ETL source is in beta and Segment is actively working on this feature. Segment's [First-Access and Beta terms](https://segment.com/legal/first-access-beta-preview/) govern this feature. 
-
 Set up Databricks as your Reverse ETL source. 
 
 At a high level, when you set up Databricks for Reverse ETL, the configured user needs read permissions for any resources (databases, schemas, tables) the query needs to access. Segment keeps track of changes to your query results with a managed schema (`__SEGMENT_REVERSE_ETL`), which requires the configured user to allow write permissions for that schema.

--- a/src/connections/reverse-etl/reverse-etl-source-setup-guides/postgres-setup.md
+++ b/src/connections/reverse-etl/reverse-etl-source-setup-guides/postgres-setup.md
@@ -2,9 +2,6 @@
 title: Postgres Reverse ETL Setup
 ---
 
-> info ""
-> The Postgres Reverse ETL source is in beta and Segment is actively working on this feature. Segment's [First-Access and Beta terms](https://segment.com/legal/first-access-beta-preview/) govern this feature. 
-
 Set up Postgres as your Reverse ETL source.
 
 At a high level, when you set up Postgres for Reverse ETL, the configured user/role needs read permissions for any resources (databases, schemas, tables) the query needs to access. Segment keeps track of changes to your query results with a managed schema (`__SEGMENT_REVERSE_ETL`), which requires the configured user to allow write permissions for that schema.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

This PR removed the beta info sections for RETL Postgres and Databricks sources as they will become public on 9/12/2023.

### Merge timing
ASAP once approved?

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
