### PR TITLE
Remove Beta Flags from Marketo and SFMC Sources [DOC-730]

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/marketo/index.md
+++ b/src/connections/sources/catalog/cloud-apps/marketo/index.md
@@ -3,19 +3,16 @@ title: Marketo Source
 rewrite: true
 source-type: object
 strat: adobe
-beta: true
 id: VOXa199Bdm
 ---
 <!-- Marketo is listed as an object source, but doesn't appear in our configapi source catalog, so leave the "source-type" set here -->
 
 
-[Marketo](https://www.marketo.com/) is a leader in marketing automation. Use the Marketo source to load your campaigns, emails, leads and other collections into your data warehouse.
+[Marketo](https://www.marketo.com/){:target="_blank"} is a leader in marketing automation. Use the Marketo source to load your campaigns, emails, leads, and other collections into your data warehouse.
 
-This will allow you to write SQL to analyze your analyze your email marketing campaigns ROI, or join your email data to other data sources like web and mobile events, Salesforce, and Zendesk to tie nurture emails to re-activation rates in your app.
+This will allow you to write SQL to analyze your email marketing campaigns ROI, or join your email data to other data sources like web and mobile events, Salesforce, and Zendesk to tie nurture emails to re-activation rates in your app.
 
-{% include content/beta-note.md %}
-
-## Getting Started
+## Getting started
 
 ### Permissions
 
@@ -33,10 +30,10 @@ You will need Admin permissions to your Marketo account.
 > In Marketo's settings, the Lead Activity Type IDs field is labeled as optional, but is required to see the `lead_activities` table. Segment recommends that you complete this field to see all available data.
 
 
-### Configure your Marketo Source
+### Configure your Marketo source
 
-1. Open Marketo
-2. Go to Admin > Munchkin to find your Munchkin Account ID
+1. Open Marketo.
+2. Go to **Admin > Munchkin** to find your Munchkin Account ID.
 ![Screenshot of the Tracking Code section of Marketo's Munchkin page.](images/Image2018-04-30at5.28.54PM.png)
 3. Go to Admin > LaunchPoint
   a. If you don't already have a REST service setup, follow [these steps](http://developers.marketo.com/rest-api/custom-services/).
@@ -44,7 +41,7 @@ You will need Admin permissions to your Marketo account.
   ![Screenshot of the Details section of the LaunchPoint page.](images/Image2018-04-30at5.29.32PM.png)
   c. Paste the "Client ID" and "Client Secret" into the Segment Marketo source settings.
 
-Data should start flowing into your Warehouse in the next few hours.
+Data should start flowing into your warehouse in the next few hours.
 
 
 ## Components
@@ -56,7 +53,7 @@ The Marketo source is built with a sync component, which means Segment makes req
 
 The sync component uses an upsert API, so the data in your warehouse loaded using sync will reflect the latest state of the corresponding resource in Marketo. For example, if `first_name` goes from `Jess` to `Jessica` between syncs, on its next sync that field will be `Jessica`.
 
-The source syncs and warehouse syncs are independent processes. Source runs pull your data into the Segment Hub, and warehouse runs flush that data to your warehouse. Sources will sync with Segment every 3 hours. Depending on your Warehouses plan, Segment pushes the Source data to your warehouse on the interval associated with your billing plan.
+The source syncs and warehouse syncs are independent processes. Source runs pull your data into the Segment Hub, and warehouse runs flush that data to your warehouse. Sources will sync with Segment every three hours. Depending on your Warehouses plan, Segment pushes the Source data to your warehouse on the interval associated with your billing plan.
 
 ## Collections
 
@@ -78,7 +75,7 @@ Collections are the groupings of resources Segment pulls from your source. In yo
 | `segments`                      | object | Segments inside a given segmentation.                                       |
 
 
-## Collection Properties
+## Collection properties
 
 ### Leads
 
@@ -133,7 +130,7 @@ Collections are the groupings of resources Segment pulls from your source. In yo
 | `updated_at`    | Date Email last updated                                     |
 
 
-### Landing Pages
+### Landing pages
 
 | Property Name    | Description                                                       |
 | ---------------- | ----------------------------------------------------------------- |
@@ -172,7 +169,7 @@ Collections are the groupings of resources Segment pulls from your source. In yo
 | `updated_at`     | Date List last updated  |
 
 
-### Lead Activities
+### Lead activities
 
 | Property Name              | Description                                  |
 | -------------------------- | -------------------------------------------- |
@@ -186,7 +183,7 @@ Collections are the groupings of resources Segment pulls from your source. In yo
 | `activity_date`              | Datetime of the activity type                |
 
 
-### Lead Activity Attributes
+### Lead activity attributes
 
 | Property Name              | Description                                                                             |
 | -------------------------- | --------------------------------------------------------------------------------------- |
@@ -198,7 +195,7 @@ Collections are the groupings of resources Segment pulls from your source. In yo
 | `value`                      | value of the Attribute                                                                  |
 
 
-### Lead Activity Types
+### Lead activity types
 
 | Property Name               | Description                    |
 | --------------------------- | ------------------------------ |
@@ -209,7 +206,7 @@ Collections are the groupings of resources Segment pulls from your source. In yo
 | `primary_attribute_data_type` | Type of the primary attribute  |
 
 
-### Lead Activity Type Attributes
+### Lead activity type attributes
 
 | Property Name    | Description                                              |
 | ---------------- | -------------------------------------------------------- |
@@ -273,7 +270,7 @@ Collections are the groupings of resources Segment pulls from your source. In yo
 
 ## Adding Destinations
 
-Currently, Warehouses are the only supported destination for object-cloud sources
+Currently, Warehouses are the only supported destination for object-cloud sources.
 
 
 ## FAQs

--- a/src/connections/sources/catalog/cloud-apps/salesforce-marketing-cloud/index.md
+++ b/src/connections/sources/catalog/cloud-apps/salesforce-marketing-cloud/index.md
@@ -1,6 +1,5 @@
 ---
 title: Salesforce Marketing Cloud Source
-beta: true
 source-type: object
 strat: salesforce
 id: oQ5dZPW0Ii
@@ -8,26 +7,20 @@ id: oQ5dZPW0Ii
 <!-- SFMC is listed as an object source, but doesn't appear in our configapi source catalog, so leave the "source-type" set here-->
 
 
-
-[Salesforce Marketing Cloud](https://www.salesforce.com/ca/products/marketing-cloud/overview/), formerly known as
-ExactTarget, is a marketing automation suite with the ability to build complete customer journeys as well as creating,
-targeting, tracking, and managing email and digital media campaigns.
+[Salesforce Marketing Cloud](https://www.salesforce.com/ca/products/marketing-cloud/overview/){:target="_blank"}, formerly known as ExactTarget, is a marketing automation suite with the ability to build complete customer journeys as well as creating, targeting, tracking, and managing email and digital media campaigns.
 
 With the Segment Salesforce Marketing Cloud Source, you can extract data from Marketing Cloud and send them
 to a data warehouse such as Redshift or Big Query with ease, avoiding having to build your own expensive custom solutions.
 
 If you are trying to set up Salesforce Marketing Cloud as a destination to receive data from Segment, check out
-[Salesforce Marketing Cloud Destination](https://segment.com/docs/connections/destinations/catalog/salesforce-marketing-cloud/).
-
-> note ""
-> *NOTE:* The Salesforce Marketing Cloud Source is currently in beta. This means that component names and functionality may change. For all feedback, [send us a note](https://segment.com/help/contact).
+[Salesforce Marketing Cloud Destination](/docs/connections/destinations/catalog/salesforce-marketing-cloud/).
 
 > success ""
-> **Good to know**: This page is about the Salesforce Marketing Cloud Segment source, which sends data _into_ Segment. There's also a page about the [Salesforce Marketing Cloud Segment destination](/docs/connections/destinations/catalog/salesforce-marketing-cloud/), which receives data from Segment!
+> **Good to know**: This page is about the Salesforce Marketing Cloud Segment source, which sends data _into_ Segment. There's also a page about the [Salesforce Marketing Cloud Segment destination](/docs/connections/destinations/catalog/salesforce-marketing-cloud/), which receives data from Segment.
 
-## Getting Started
+## Getting started
 
-###  API Access
+###  API access
 
 To access the Salesforce Marketing Cloud data on your behalf, Segment requires the client ID, client secret and
 subdomain from your Salesforce Marketing Cloud integration. The integration must also have the following permissions:
@@ -46,7 +39,7 @@ client secret and subdomain set up for the destination. To enable the permission
 2. Click your name in the top-right corner of the screen and select "Administration".
 3. Navigate to the existing package with the the Segment destination API Integration.
 4. Adjust the scope according to the permission table above.
-5. Click "Save".
+5. Click **Save**.
 
 **If you do not have a Salesforce Marketing Cloud Segment Destination**, follow the steps below to acquire the client ID
 and client secret:
@@ -54,11 +47,10 @@ and client secret:
 1. Log in to your Salesforce Marketing Cloud account.
 2. Click your name in the top-right corner of the screen and select "Administration".
 3. Click the "Account" menu at the top-left corner of the page and select "Installed Packages".
-4. If you want to use an existing package, click on that one or click "New" to create a new one. We recommend giving it
-   a name like "Segment".
+4. If you want to use an existing package, click on that one or click "New" to create a new one. Segment recommends giving it a name like "Segment".
 5. Click "Add Component".
 6. Select "API Integration" and click "Next".
-7. Select Server-to-Server
+7. Select Server-to-Server.
 8. Enable the permissions as specified in the table above.
 9. Click "Save".
 
@@ -67,7 +59,7 @@ You should now see a Summary page with a Components section. This section lists 
 ### Set up your subdomain
 Segment will use your unique Salesforce subdomain to make API calls to SFMC. Your subdomain is represented by a 28-character string starting with the letters "mc" in any of your base URIs. For example, in the base URI `mc563885gzs27c5t9-63k636ttgm.rest.marketingcloudapis.com`, the subdomain is `mc563885gzs27c5t9-63k636ttgm`.
 
-### Enable the Salesforce Marketing Cloud Source
+### Enable the Salesforce Marketing Cloud source
 
 1. From your Segment workspace's `/Sources` page, click `Add Source`.
 2. Under the Email Marketing category, choose Salesforce Marketing Cloud and click `Connect`.
@@ -81,34 +73,29 @@ Segment will use your unique Salesforce subdomain to make API calls to SFMC. You
 
 ### Sync
 
-The Salesforce Marketing Cloud source is built with a sync component, which means we'll make requests to their API on
-your behalf on a 3 hour interval to pull the latest data into Segment. In the initial sync, we'll grab all the
-Salesforce objects (and their corresponding properties) according to the Collections Table below. The objects will be
-written into a separate schema, corresponding to the source instance's schema name you designated upon creation.
-For example, if you went with `sfmc_prod`, the `campaigns` collection will be accessible at `sfmc_prod.campaigns` in SQL.
+The Salesforce Marketing Cloud source is built with a sync component, which means Segment makes requests to their API on your behalf on a three-hour interval to pull the latest data into Segment. In the initial sync, Segment grabs all the Salesforce objects (and their corresponding properties) according to the Collections Table below. 
+
+The objects will be written into a separate schema, corresponding to the source instance's schema name you designated upon creation. For example, if you went with `sfmc_prod`, the `campaigns` collection will be accessible at `sfmc_prod.campaigns` in SQL.
 
 Each sync will only sync the data that has been modified since the previous sync.
 
 The source syncs and warehouse syncs are independent processes. Source runs pull your data into the Segment Hub,
-and warehouse runs flush that data to your warehouse. Sources will sync with Segment every 3 hours. Depending on your
-Warehouses plan, we will push the Source data to your warehouse on the interval associated with your billing plan.
+and warehouse runs flush that data to your warehouse. Sources will sync with Segment every three hours. Depending on your Warehouses plan, Segment will push the source data to your warehouse on the interval associated with your billing plan.
 
 ## Collections
 
-Collections are the groupings of resources we pull from your source. In your warehouse, each collection gets its own table.
+Collections are the groupings of resources Segment pulls from your source. In your warehouse, each collection gets its own table.
 
 
-| Collection      | Type   | Description                                                                                                                                                                                 |
-| --------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| campaigns       | Object | A campaign in your account. Corresponds to [Campaigns](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/getCampaignCollection.htm)                          |
-| campaign_assets | Object | The assets associated with each campaign. Corresponds to [campaign_assets](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/getCampaignAssetCollection.htm) |
-| lists           | Object | A mailing list. Corresponds to [Lists](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/list.htm)                                                           |
+| Collection      | Type   | Description                                                                                                                                                                                                   |
+| --------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| campaigns       | Object | A campaign in your account. Corresponds to [Campaigns](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/getCampaignCollection.htm){:target="_blank"}                          |
+| campaign_assets | Object | The assets associated with each campaign. Corresponds to [campaign_assets](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/getCampaignAssetCollection.htm){:target="_blank"} |
+| lists           | Object | A mailing list. Corresponds to [Lists](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/list.htm){:target="_blank"}                                                           |
 
 ## Collection Properties
 
-Segment performs a one-to-one mapping of all publicly available fields from Salesforce Marketing Cloud. Below are tables
-outlining the properties included in the collections listed above. To see the full description of each property,
-refer to the Salesforce Marketing Cloud documentation linked in each [collection](#collections) above.
+Segment performs a one-to-one mapping of all publicly available fields from Salesforce Marketing Cloud. The tables in this section outline the properties included in the collections listed above. To see the full description of each property,refer to the Salesforce Marketing Cloud documentation linked in each [collection](#collections) above.
 
 ### Campaigns
 


### PR DESCRIPTION
### Proposed changes

- Removed beta flags from Marketo and Salesforce Marketing Cloud sources.
- Minor cleanup (links, typos, other random stuff).

### Merge timing

- ASAP once approved.
