### PR TITLE
feat(code): remove public api token requirement for segment profiles destination

### DIFF
--- a/src/connections/destinations/catalog/actions-segment-profiles/index.md
+++ b/src/connections/destinations/catalog/actions-segment-profiles/index.md
@@ -15,16 +15,12 @@ The Segment Profiles destination allows you to send your warehouse data back to 
 
 To use this destination, you must have an active Segment Profile space. If you have not yet created a Segment Profile space, please follow the steps in the [Profiles Onboarding Guide](/docs/profiles/quickstart/).
 
-### Create a Public API token
-
-To enable the Segment Profiles destination to send data to an existing Profile space, provide an authentication token for the Segment Public API. See [Segment's Public API documentation](https://docs.segmentapis.com/tag/Getting-Started#section/Get-an-API-token){:target="_blank"} for information on how to create a token. The token must include Source Admin permissions. You will need this token in the below steps.
-
 ### Connect and configure the Segment Profiles destination
 
 1. From the Segment web app, navigate to **Reverse ETL > Destinations**.
 2. Click **Add Destination**.
 3. Select the Segment Profiles destination, click **Next**, and select the warehouse source that will send data to the Segment Profiles destination. If you have not set up a warehouse source, follow the steps in the Reverse ETL documentation on [Getting started](/docs/reverse-etl/#getting-started).
-4. On the **Settings** tab, name your destination, input the Public API token created above, select an endpoint region, and click **Save Changes**. It is recommended to configure and enable all mappings before enabling the Segment Profiles destination.
+4. On the **Settings** tab, name your destination, select an endpoint region, and click **Save Changes**. It is recommended to configure and enable all mappings before enabling the Segment Profiles destination.
 5. On the **Mappings** tab, click **Add Mapping**. Select a data model and the API call type you want to map. Identify calls will create and update user profiles and Group calls will create and update account profiles. Fill in the fields on screen to create the desired mappings, and click **Create Mapping** to complete the configuration. Repeat this step to configure multiple mappings. 
 6. Enable the configured mapping(s).
 7. On the **Settings** tab, click the **Enable Destination** toggle, and then click **Save Changes** to enable the Segment Profiles destination.
@@ -35,9 +31,6 @@ To enable the Segment Profiles destination to send data to an existing Profile s
 
 ### API Calls and MTUs
 The Segment Profiles destination is not subject to API call or MTU costs. Any users or accounts created and updated by the Segment Profiles destination will not count towards your API call or MTU usage.
-
-### Error loading options from Segment Profiles
-Make sure you have a Public API token in your settings. If the Segment Profiles Destination doesn’t have a Public API token in the settings, the **Select Mappings** section fails to find any Profile (Engage) Spaces, which means you can't set your mappings. 
 
 ### Succesful syncs but no changes on profiles
 Make sure that the Endpoint Region setting matches the region of your workspace. If the region is correct and you don't see any profile changes, [contact Segment](https://segment.com/help/contact/){:target="_blank"}.


### PR DESCRIPTION
### Proposed changes
**Before this PR:**
- The documentation for the Segment Profiles Destination included steps to create & use a Public API Token

**After this PR:**
- This requirement is no longer required as [STRATCONN-2388](https://segment.atlassian.net/browse/STRATCONN-2388) removed the need for a Public API Token

**Reason that prompted this change:**
[Slack Thread in #questions-reverse-etl](https://twilio.slack.com/archives/C03NK2Y2GTC/p1694470953510579)

### Merge timing
- ASAP once approved?


[STRATCONN-2388]: https://segment.atlassian.net/browse/STRATCONN-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ