### PR TITLE
[STRATCONN-3072]-Update pinterest conversions doc

### DIFF
--- a/src/connections/destinations/catalog/actions-pinterest-conversions-api/index.md
+++ b/src/connections/destinations/catalog/actions-pinterest-conversions-api/index.md
@@ -130,7 +130,7 @@ Segment automatically maps User Data fields to their corresponding parameters [a
 
 ### Custom Data Parameters
 
-Segment automatically maps Custom Data fields to their corresponding parameters [as expected by the Conversions API](https://developers.pinterest.com/docs/conversions/best/#Authenticating%20for%20the%20Conversion%20Tracking%20endpoint#The%20%2Cuser_data%2C%20and%20%2Ccustom_data%2C%20objects#Required%2C%20recommended%2C%20and%20optional%20fields#Required%2C%20recommended%2C%20and%20optional%20fields#User_data%2C%20and%20%2Ccustom_data%2C%20objects){:target="_blank"} before sending to Pinterest Conversions:
+Segment automatically maps Custom Data fields (excluding `content_ids`, `contents`, `num_items`, `opt_out_type`) to their corresponding parameters [as expected by the Conversions API](https://developers.pinterest.com/docs/conversions/best/#Authenticating%20for%20the%20Conversion%20Tracking%20endpoint#The%20%2Cuser_data%2C%20and%20%2Ccustom_data%2C%20objects#Required%2C%20recommended%2C%20and%20optional%20fields#Required%2C%20recommended%2C%20and%20optional%20fields#User_data%2C%20and%20%2Ccustom_data%2C%20objects){:target="_blank"} before sending to Pinterest Conversions:
 
 | User Data Field | Conversions API Custom Data Parameter |
 | --------------- | ------------------------------------- |


### PR DESCRIPTION
### Proposed changes

Pinterest Conversions destination only map fields that line up with the segment spec and only for which we have default values. Since the segment spec does not have content_ids, contents, num_items, opt_out_type, we do not have defaults and it is dependent on the event/payload the customer is sending.

Updating the docs to Clarify and set correct expectations for customers. 

### Merge timing
- ASAP once approved

### Related issues (optional)

https://segment.atlassian.net/browse/STRATCONN-3072
