### PR TITLE
Add note on connecting new mappings to model

### DIFF
--- a/src/connections/reverse-etl/index.md
+++ b/src/connections/reverse-etl/index.md
@@ -97,7 +97,7 @@ To add your first destination:
 After you’ve added a destination, you can create mappings from your warehouse to the destination. Mappings enable you to map the data you extract from your warehouse to the fields in your destination.
 
 > info ""
-> When adding new mappings to an existing model, only the changes that have transpired since the last sync will be synchronized, not the entire dataset. For a comprehensive data synchronization, we advise you to first recreate the model, followed by establishing a one-to-one mapping with the new model. This approach ensures that all data synchronizes effectively.
+> When you add new mappings to an existing model, Segment only syncs changes that have transpired since the last sync, not the entire dataset. For a comprehensive data synchronization, Segment recommends that you first recreate the model, then establish a one-to-one mapping with the new model. This ensures that all data syncs effectively.
 
 To create a mapping:
 1. Navigate to **Conections > Destinations** and select the **Reverse ETL** tab.

--- a/src/connections/reverse-etl/index.md
+++ b/src/connections/reverse-etl/index.md
@@ -96,6 +96,9 @@ To add your first destination:
 ### Step 4: Create mappings
 After you’ve added a destination, you can create mappings from your warehouse to the destination. Mappings enable you to map the data you extract from your warehouse to the fields in your destination.
 
+> info ""
+> When adding new mappings to an existing model, only the changes that have transpired since the last sync will be synchronized, not the entire dataset. For a comprehensive data synchronization, we advise you to first recreate the model, followed by establishing a one-to-one mapping with the new model. This approach ensures that all data synchronizes effectively.
+
 To create a mapping:
 1. Navigate to **Conections > Destinations** and select the **Reverse ETL** tab.
 2. Select the destination that you want to create a mapping for.  


### PR DESCRIPTION
### Proposed changes

Add note to clarify that currently, connection between reverse ETL model and mapping should be one:one to sync an entire dataset, otherwise only the diffs will sync.

Relevant Slack thread: https://twilio.slack.com/archives/C03NK2Y2GTC/p1685476363083219

"with the current design - any subsequently added mappings/destinations to an existing model will only sync the diffs. For now, customers should recreate the model and then add a mapping/destination (e.g. one model to one mapping) to sync all the data."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
