### PR TITLE
Updating Databricks Setup Guide with suggestions on connection type

### DIFF
--- a/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
+++ b/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
@@ -44,7 +44,7 @@ To set up Databricks as your Reverse ETL source:
 9. Select **Databricks** and click **Add Source**. 
 10. Enter the configuration settings for your Databricks source. 
     * Copy the Hostname, Http Path, and Port from the Databricks console from step 5.
-    * The Http Path in the above step should contain `/sql/1.0/warehouses`. Note that Segment does not support `/sql/protocolv1`.
+    * The Http Path in the above step should contain `/sql/1.0/warehouses`. Note that Segment doesn't support `/sql/protocolv1`.
     * To generate a **Token**, follow the steps listed in the [Databricks docs](https://docs.databricks.com/dev-tools/auth.html#pat){:target="_blank"}. Segment recommends you create a token with no expiration date by leaving the lifetime field empty when creating it. If you already have a token with an expiration date, be sure to keep track of the date and renew it on time.     
 11. Click **Test Connection** to see if the connection works. If the connection fails, make sure you have the right permissions and credentials, then try again.
 12. Click **Create Source** if the test connection is successful. 

--- a/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
+++ b/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
@@ -36,7 +36,7 @@ To set up Databricks as your Reverse ETL source:
 1. Log in to your Databricks account.
 2. Navigate to **Workspaces** and select the workspace you want to use. 
 3. Select **SQL** in the main navigation. 
-4. Select **SQL Warehouses** and select the warehouse you want to use. 
+4. Select **SQL Warehouses**(make sure SQL Warehouses and not Compute) and select the warehouse you want to use. 
 5. Go to the **Connection details** tab.
 6. In a new tab on your browser, go to the Segment app. 
 7. Navigate to **Connections > Sources > Reverse ETL**.
@@ -44,6 +44,7 @@ To set up Databricks as your Reverse ETL source:
 9. Select **Databricks** and click **Add Source**. 
 10. Enter the configuration settings for your Databricks source. 
     * Copy the Hostname, Http Path, and Port from the Databricks console from step 5. 
+    * Please ensure Http Path in the above step begins like `/sql/1.0/warehouses/` and not `/sql/protocolv1/`. The latter one is for compute and that does not .
     * To generate a **Token**, follow the steps listed in the [Databricks docs](https://docs.databricks.com/dev-tools/auth.html#pat){:target="_blank"}. Segment recommends you create a token with no expiration date by leaving the lifetime field empty when creating it. If you already have a token with an expiration date, be sure to keep track of the date and renew it on time.     
 11. Click **Test Connection** to see if the connection works. If the connection fails, make sure you have the right permissions and credentials, then try again.
 12. Click **Create Source** if the test connection is successful. 

--- a/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
+++ b/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
@@ -36,15 +36,15 @@ To set up Databricks as your Reverse ETL source:
 1. Log in to your Databricks account.
 2. Navigate to **Workspaces** and select the workspace you want to use. 
 3. Select **SQL** in the main navigation. 
-4. Select **SQL Warehouses**(make sure SQL Warehouses and not Compute) and select the warehouse you want to use. 
+4. Select **SQL Warehouses** and select the warehouse you want to use. Note that Segment does not support Compute.
 5. Go to the **Connection details** tab.
 6. In a new tab on your browser, go to the Segment app. 
 7. Navigate to **Connections > Sources > Reverse ETL**.
 8. Click **+ Add Reverse ETL source**. 
 9. Select **Databricks** and click **Add Source**. 
 10. Enter the configuration settings for your Databricks source. 
-    * Copy the Hostname, Http Path, and Port from the Databricks console from step 5. 
-    * Please ensure Http Path in the above step begins like `/sql/1.0/warehouses/` and not `/sql/protocolv1/`. The latter one is for compute and that is not supported.
+    * Copy the Hostname, Http Path, and Port from the Databricks console from step 5.
+    * The Http Path in the above step should contain `/sql/1.0/warehouses`. Note that Segment does not support `/sql/protocolv1`.
     * To generate a **Token**, follow the steps listed in the [Databricks docs](https://docs.databricks.com/dev-tools/auth.html#pat){:target="_blank"}. Segment recommends you create a token with no expiration date by leaving the lifetime field empty when creating it. If you already have a token with an expiration date, be sure to keep track of the date and renew it on time.     
 11. Click **Test Connection** to see if the connection works. If the connection fails, make sure you have the right permissions and credentials, then try again.
 12. Click **Create Source** if the test connection is successful. 

--- a/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
+++ b/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
@@ -44,7 +44,7 @@ To set up Databricks as your Reverse ETL source:
 9. Select **Databricks** and click **Add Source**. 
 10. Enter the configuration settings for your Databricks source. 
     * Copy the Hostname, Http Path, and Port from the Databricks console from step 5. 
-    * Please ensure Http Path in the above step begins like `/sql/1.0/warehouses/` and not `/sql/protocolv1/`. The latter one is for compute and that does not .
+    * Please ensure Http Path in the above step begins like `/sql/1.0/warehouses/` and not `/sql/protocolv1/`. The latter one is for compute and that is not supported.
     * To generate a **Token**, follow the steps listed in the [Databricks docs](https://docs.databricks.com/dev-tools/auth.html#pat){:target="_blank"}. Segment recommends you create a token with no expiration date by leaving the lifetime field empty when creating it. If you already have a token with an expiration date, be sure to keep track of the date and renew it on time.     
 11. Click **Test Connection** to see if the connection works. If the connection fails, make sure you have the right permissions and credentials, then try again.
 12. Click **Create Source** if the test connection is successful. 

--- a/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
+++ b/src/connections/reverse-etl/reverse-etl-source-setup-guides/databricks-setup.md
@@ -36,7 +36,7 @@ To set up Databricks as your Reverse ETL source:
 1. Log in to your Databricks account.
 2. Navigate to **Workspaces** and select the workspace you want to use. 
 3. Select **SQL** in the main navigation. 
-4. Select **SQL Warehouses** and select the warehouse you want to use. Note that Segment does not support Compute.
+4. Select **SQL Warehouses** and select the warehouse you want to use. Note that Segment doesn't support the `Compute` connection parameter.
 5. Go to the **Connection details** tab.
 6. In a new tab on your browser, go to the Segment app. 
 7. Navigate to **Connections > Sources > Reverse ETL**.


### PR DESCRIPTION
This change updates the Databricks Setup Guide for ReverseETL with hint about providing connection parameter for `Warehouse` and not `Compute`. 

### Proposed changes
1. `The Http Path in the above steps should contain /sql/1.0/warehouses. Note that Segment does not support /sql/protocolv1`

### Merge timing
ASAP once approved

### Related issues (optional)
ReverseETL customer issues which have happened with other customers as well: https://segment.atlassian.net/browse/RETL-1001
 

