### PR TITLE
Add information that Group ID is for mapping of track event to group …

### DIFF
--- a/src/connections/destinations/catalog/actions-mixpanel/index.md
+++ b/src/connections/destinations/catalog/actions-mixpanel/index.md
@@ -133,5 +133,7 @@ If you want to confirm, you can configure the new destination to point to a diff
 
 ### Track events are not attributed to Mixpanel Groups
 
-Ensure that the mapping(s) handling your `track` events have the field for **Group ID** mapped to a valid value. By default, this field is mapped to the event variable `context.groupId`.
+For Mixpanel (Actions) destination that uses `$group_id` as the group key, ensure that the mapping(s) handling your `track` events have the field for **Group ID** mapped to a valid value. By default, this field is mapped to the event variable `context.groupId`.
+
+
 


### PR DESCRIPTION
…key $group_id

In the Troubleshooting section, modify the following (original) statement:

"Ensure that the mapping(s) handling your track events have the field for Group ID mapped to a valid value. By default, this field is mapped to the event variable context.groupId."

To the following that mentioned using of group key `$group_id`:

"For Mixpanel (Actions) destination that uses `$group_id` as the group key, ensure that the mapping(s) handling your `track` events have the field for **Group ID** mapped to a valid value. By default, this field is mapped to the event variable"`context.groupId`."

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
