### PR TITLE
Add Group ID is for mapping of track event to group key $group_id

### DIFF
--- a/src/connections/destinations/catalog/actions-mixpanel/index.md
+++ b/src/connections/destinations/catalog/actions-mixpanel/index.md
@@ -133,5 +133,5 @@ If you want to confirm, you can configure the new destination to point to a diff
 
 ### Track events are not attributed to Mixpanel Groups
 
-Ensure that the mapping(s) handling your `track` events have the field for **Group ID** mapped to a valid value. By default, this field is mapped to the event variable `context.groupId`.
+For Mixpanel (Actions) destination that uses $group_id as the group key, ensure that the mapping(s) handling your `track` events have the field for **Group ID** mapped to a valid value. By default, this field is mapped to the event variable `context.groupId`.
 


### PR DESCRIPTION
### Proposed changes
In the Troubleshooting section, modify the following (original) statement:

"Ensure that the mapping(s) handling your track events have the field for Group ID mapped to a valid value. By default, this field is mapped to the event variable context.groupId."

To the following that mentioned using of group key $group_id:

"For Mixpanel (Actions) destination that uses $group_id as the group key, ensure that the mapping(s) handling your track events have the field for Group ID mapped to a valid value. By default, this field is mapped to the event variable"context.groupId."

Customer included a valid value in Group ID but still did not see the track event mapped to the group in Mixpanel. After customer created the group under the group key $group_id, then the track event was mapped to the relevant group.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
https://segment.zendesk.com/agent/tickets/520524
https://segment.zendesk.com/agent/tickets/518710
