### PR TITLE
fix typo

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -210,7 +210,7 @@ You can manually test your code from the functions editor:
 - Logs display any messages to console.log() from the function.
 
 > warning ""
-> The Event Tester won't make use of an Insert Function, show how an Insert Function impacts your data, or send data downstream through the Insert Function pipeline. The Event Tester is not impacted by an Insert Function at all. Please use the Function tester rather than the Event Tester to see how your Insert Function impacts your data.
+> The Event Tester won't make use of an Insert Function, show how an Insert Function impacts your data, or send data downstream through the Insert Function pipeline. The Event Tester is not impacted by an Insert Function at all. Use the Function tester rather than the Event Tester to see how your Insert Function impacts your data.
 
 ## Save and deploy the destination insert function
 

--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -209,8 +209,8 @@ You can manually test your code from the functions editor:
 - Error messages display errors surfaced from your function.
 - Logs display any messages to console.log() from the function.
 
-- > info ""
-> The Event Tester won't make use of an Insert Function, show how an Insert Function impacts your data, or send data downstream through the Insert Function pipeline.
+> warning ""
+> The Event Tester won't make use of an Insert Function, show how an Insert Function impacts your data, or send data downstream through the Insert Function pipeline. The Event Tester is not impacted by an Insert Function at all. Please use the Function tester rather than the Event Tester to see how your Insert Function impacts your data.
 
 ## Save and deploy the destination insert function
 


### PR DESCRIPTION
### Proposed changes

There was a typo that made the text not appear in an info or warning box. I also added some context to make this more clear.

### Merge timing
ASAP is fine