### PR TITLE
Added the Failed and Archived statuses

### DIFF
--- a/src/engage/journeys/key-terms.md
+++ b/src/engage/journeys/key-terms.md
@@ -39,6 +39,8 @@ Keep the following terms in mind as you begin to explore Journeys.
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | Draft Journey            | A Journey which is not yet computing nor sending data to destinations. <br /><br />For more information, see [Draft Journeys](#draft-journeys). |
 | Published (live) Journey | A Journey that is computing and sending data to destinations. <br /><br />For more information, see [Published Journeys](#published-journeys).                  |
+| Archived Journey         | A Journey that has been archived. <br /><br />For more information, see [Archive a Journey](https://segment.com/docs/engage/journeys/build-journey/#archive-a-journey).                  |
+| Failed (live) Journey    | A Journey that has been published, but failed during the live computations due to an unforeseen error. <br /><br />Contact [Segment Support](https://segment.com/help/contact/) to learn more. |
 
 ## Steps with Audiences
 

--- a/src/engage/journeys/key-terms.md
+++ b/src/engage/journeys/key-terms.md
@@ -39,7 +39,7 @@ Keep the following terms in mind as you begin to explore Journeys.
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | Draft Journey            | A Journey which is not yet computing nor sending data to destinations. <br /><br />For more information, see [Draft Journeys](#draft-journeys). |
 | Published (live) Journey | A Journey that is computing and sending data to destinations. <br /><br />For more information, see [Published Journeys](#published-journeys).                  |
-| Archived Journey         | A Journey that has been archived. <br /><br />For more information, see [Archive a Journey](https://segment.com/docs/engage/journeys/build-journey/#archive-a-journey).                  |
+| Archived Journey         | A Journey that has been archived. <br /><br />For more information, see [Archive a Journey](/docs/engage/journeys/build-journey/#archive-a-journey).                  |
 | Failed (live) Journey    | A Journey that has been published, but failed during the live computations due to an unforeseen error. <br /><br />Contact [Segment Support](https://segment.com/help/contact/) to learn more. |
 
 ## Steps with Audiences


### PR DESCRIPTION
Added the "failed" and "archived" statuses, each with a description, to the table in the journey glossary docs page.

### Proposed changes

Created a row in the Status table for the "archived" and "failed" status that can be seen in the UI in Engage > Journeys.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
