### PR TITLE
Add notes on usage in serverless environments

### DIFF
--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -288,7 +288,7 @@ Setting | Details
 
 See the complete `AnalyticsSettings` interface [here](https://github.com/segmentio/analytics-next/blob/master/packages/node/src/app/settings.ts){:target="_blank"}.
 
-## Usage in AWS Lambda, Vercel Edge Functions, Cloudflare Workers, or other serverless environments
+## Usage in serverless environments
 
 When calling `.track` within functions in serverless runtime environments, wrap the call in a `Promise` and `await` it to avoid having the runtime exit or freeze:
 
@@ -298,7 +298,7 @@ await new Promise((resolve) =>
 )
 ```
 
-See the complete documentation on [Usage in AWS Lambda](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-aws-lambda), [Usage in Vercel Edge Functions](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-vercel-edge-functions), and [Usage in Cloudflare Workers](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-cloudflare-workers)
+See the complete documentation on [Usage in AWS Lambda](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-aws-lambda){:target="_blank"}, [Usage in Vercel Edge Functions](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-vercel-edge-functions){:target="_blank"}, and [Usage in Cloudflare Workers](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-cloudflare-workers){:target="_blank"}
 
 ## Graceful shutdown
 Avoid losing events after shutting down your console. Call `.closeAndFlush()` to stop collecting new events and flush all existing events. If a callback on an event call is included, this also waits for all callbacks to be called, and any of their subsequent promises to be resolved.

--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -288,6 +288,18 @@ Setting | Details
 
 See the complete `AnalyticsSettings` interface [here](https://github.com/segmentio/analytics-next/blob/master/packages/node/src/app/settings.ts){:target="_blank"}.
 
+## Usage in AWS Lambda, Vercel Edge Functions, Cloudflare Workers, or other serverless environments
+
+When calling `.track` within functions in serverless runtime environments, wrap the call in a `Promise` and `await` it to avoid having the runtime exit or freeze:
+
+```js
+await new Promise((resolve) =>
+  analytics().track({ ... }, resolve)
+)
+```
+
+See the complete documentation on [Usage in AWS Lambda](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-aws-lambda), [Usage in Vercel Edge Functions](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-vercel-edge-functions), and [Usage in Cloudflare Workers](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-cloudflare-workers)
+
 ## Graceful shutdown
 Avoid losing events after shutting down your console. Call `.closeAndFlush()` to stop collecting new events and flush all existing events. If a callback on an event call is included, this also waits for all callbacks to be called, and any of their subsequent promises to be resolved.
 


### PR DESCRIPTION
- We need to wrap `.track` calls in a `Promise` in these environments, which isn't mentioned in this doc. 
- Link to the [README in the repo for analytics-node](https://github.com/segmentio/analytics-next/blob/master/packages/node/README.md#usage-in-aws-lambda) for full details

### Proposed changes

Added some documentation here in hopes of saving other developers the several hours I unfortunately spent thinking that just calling `await closeAndFlush()` would suffice for serverless environments—I needed to do the combination of both:

1. Wrapping `analytics.track` calls in a `Promise` and `await`ing it
2. Instantiate new instances of `analytics()`— otherwise my big batch of events just never getting sent despite calling `closeAndFlush()` and having that return. I didn't add this to the documentation since I'm not sure if I'm doing this correctly— any feedback would be appreciated. Happy to update the documentation with this additional information if this is actually necessary. The README seems to suggest it's only necessary if using plugins.

### Merge timing
ASAP to prevent any other developers upgrading from the deprecated `analytics-node` to this library that use it in a serverless environment and previously depended on `await analytics.flush()`.

### Related issues (optional)
- https://github.com/segmentio/analytics-node/issues/309

