### PR TITLE
Added note about algorithm used to generate keys to HIPAA Eligible Segment 

### DIFF
--- a/src/privacy/hipaa-eligible-segment.md
+++ b/src/privacy/hipaa-eligible-segment.md
@@ -35,7 +35,7 @@ These logs can be provided upon request. For specific requests, please reach out
 
 ## Data encryption
 
-Segment encrypts the data in select fields [marked as yellow in the Privacy Portal](/docs/privacy/portal/#default-pii-matchers) before sending them to event stream, cloud mode destinations, further supporting HIPAA compliance in your destinations. Segment's public and private key pairs are generated using a RSAES OAEP SHA 256 algorithm.
+Segment encrypts the data in select fields [marked as yellow in the Privacy Portal](/docs/privacy/portal/#default-pii-matchers) before sending them to event stream, cloud mode destinations, further supporting HIPAA compliance in your destinations. Segment encrypts data using a RSAES OAEP SHA 256 algorithm.
 
 > info "Data encryption is currently in public beta"
 > Data encryption only supports event-stream, cloud-mode destinations. Only data fields in `context`, `traits`, and `property` objects can be encrypted. 

--- a/src/privacy/hipaa-eligible-segment.md
+++ b/src/privacy/hipaa-eligible-segment.md
@@ -35,7 +35,7 @@ These logs can be provided upon request. For specific requests, please reach out
 
 ## Data encryption
 
-Segment encrypts the data in select fields [marked as yellow in the Privacy Portal](/docs/privacy/portal/#default-pii-matchers) before sending them to event stream, cloud mode destinations, further supporting HIPAA compliance in your destinations. 
+Segment encrypts the data in select fields [marked as yellow in the Privacy Portal](/docs/privacy/portal/#default-pii-matchers) using a RSAES OAEP SHA 256 algorithm before sending them to event stream, cloud mode destinations, further supporting HIPAA compliance in your destinations. 
 
 > info "Data encryption is currently in public beta"
 > Data encryption only supports event-stream, cloud-mode destinations. Only data fields in `context`, `traits`, and `property` objects can be encrypted. 

--- a/src/privacy/hipaa-eligible-segment.md
+++ b/src/privacy/hipaa-eligible-segment.md
@@ -35,7 +35,7 @@ These logs can be provided upon request. For specific requests, please reach out
 
 ## Data encryption
 
-Segment encrypts the data in select fields [marked as yellow in the Privacy Portal](/docs/privacy/portal/#default-pii-matchers) before sending them to event stream, cloud mode destinations, further supporting HIPAA compliance in your destinations. Segment's public and private key pairs are generated using a a RSAES OAEP SHA 256 algorithm.
+Segment encrypts the data in select fields [marked as yellow in the Privacy Portal](/docs/privacy/portal/#default-pii-matchers) before sending them to event stream, cloud mode destinations, further supporting HIPAA compliance in your destinations. Segment's public and private key pairs are generated using a RSAES OAEP SHA 256 algorithm.
 
 > info "Data encryption is currently in public beta"
 > Data encryption only supports event-stream, cloud-mode destinations. Only data fields in `context`, `traits`, and `property` objects can be encrypted. 

--- a/src/privacy/hipaa-eligible-segment.md
+++ b/src/privacy/hipaa-eligible-segment.md
@@ -35,7 +35,7 @@ These logs can be provided upon request. For specific requests, please reach out
 
 ## Data encryption
 
-Segment encrypts the data in select fields [marked as yellow in the Privacy Portal](/docs/privacy/portal/#default-pii-matchers) using a RSAES OAEP SHA 256 algorithm before sending them to event stream, cloud mode destinations, further supporting HIPAA compliance in your destinations. 
+Segment encrypts the data in select fields [marked as yellow in the Privacy Portal](/docs/privacy/portal/#default-pii-matchers) before sending them to event stream, cloud mode destinations, further supporting HIPAA compliance in your destinations. Segment's public and private key pairs are generated using a a RSAES OAEP SHA 256 algorithm.
 
 > info "Data encryption is currently in public beta"
 > Data encryption only supports event-stream, cloud-mode destinations. Only data fields in `context`, `traits`, and `property` objects can be encrypted. 


### PR DESCRIPTION
### Proposed changes
Added note that Segment uses a a RSAES OAEP SHA 256 algorithm to encrypt data to the HIPAA Eligible Segment page

### Merge timing
ASAP once approved!

### Related issues (optional)
#5233 
