### PR TITLE
Add section on Set Once/Set Always fields

### DIFF
--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -216,7 +216,15 @@ Keep the following in mind if you plan to move to Amplitude (Actions) from a cla
 You configure the Amplitude (Actions) destination through Filters and Actions. Consult the table below for information about configuring your Amplitude (Actions) destination similarly to your classic Amplitude destination.
 
 > info ""
-> Contact Segment support if you find features missing from the Amplitude (Actions) destination that were available in the classic Amplitude destination.
+> Contact Segment support if you find features missing from the Amplitude (Actions) destination that were available in the classic Amplitude destination. 
+
+### Set Once/Set Always fields
+
+Amplitude restricts the mixing of top-level user properties with $set, $setOnce, or $setAlways operations in a single request, [as outlined in Amplitude’s documentation](https://www.docs.developers.amplitude.com/analytics/apis/identify-api/#user_properties-supported-operations). 
+
+To circumvent this within Segment, users can opt to exclusively map event parameters to either the User Properties field or to one of the user property operations (Set Once and/or Set Always) available in mappings, avoiding mixing them in the same request. Specifically, if you are utilizing Set Once and/or Set Always fields, include all relevant fields in their respective mappings and do not configure mappings for User Properties in the same request.
+
+Conversely, to send top-level user properties, map only to the User Properties field and exclude mappings for Set Once and Set Always fields. 
 
 {% include components/actions-map-table.html name="amplitude" %}
 

--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -220,11 +220,11 @@ You configure the Amplitude (Actions) destination through Filters and Actions. C
 
 ### Set Once/Set Always fields
 
-Amplitude restricts the mixing of top-level user properties with $set, $setOnce, or $setAlways operations in a single request, [as outlined in Amplitude’s documentation](https://www.docs.developers.amplitude.com/analytics/apis/identify-api/#user_properties-supported-operations). 
+Amplitude restricts the mixing of top-level user properties with `$set`, `$setOnce`, or `$setAlways` operations in a single request, [as outlined in Amplitude’s documentation](https://www.docs.developers.amplitude.com/analytics/apis/identify-api/#user_properties-supported-operations){:target="_blank"}. 
 
-To circumvent this within Segment, users can opt to exclusively map event parameters to either the User Properties field or to one of the user property operations (Set Once and/or Set Always) available in mappings, avoiding mixing them in the same request. Specifically, if you are utilizing Set Once and/or Set Always fields, include all relevant fields in their respective mappings and do not configure mappings for User Properties in the same request.
+To circumvent this within Segment, users can opt to exclusively map event parameters to either the **User Properties** field or to one of the user property operations (Set Once and/or Set Always) available in mappings. If you use the **Set Once** and/or **Set Always** fields, include all relevant fields in their respective mappings and do not configure mappings for **User Properties** in the same request.
 
-Conversely, to send top-level user properties, map only to the User Properties field and exclude mappings for Set Once and Set Always fields. 
+Conversely, to send top-level user properties, map only to the **User Properties** field and exclude mappings for the **Set Once** and **Set Always** fields. 
 
 {% include components/actions-map-table.html name="amplitude" %}
 


### PR DESCRIPTION
### Proposed changes

[Amplitude's docs](https://www.docs.developers.amplitude.com/analytics/apis/identify-api/#user_properties-supported-operations) mention the following on user_properties operations:

"You can't mix user property operations with actual top-level user properties. Instead, include them inside the $set operation. If you are using one of these operators then this dictionary can contain only user property operations and you can't combine it with the above format. For example. you can't do {"$append":{"interests":"Music"}, "subscription type":"paid"} in the same request."

Add section to docs that calls out this limitation and how to circumnavigate it when using this destination. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
