### PR TITLE
add condition under which GA4 will silently drop event

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -162,6 +162,7 @@ Google reserves certain event names, parameters, and user properties. Google sil
 - fields with `null` values
 - fields or events with reserved names
 - fields with a number as the key
+- fields or events with a dash (-) character in the name
  
 ### Verifying Event Meet GA4's Measurement Protocol API
 **Why are the events returning an error _Param [PARAM] has unsupported value._?**


### PR DESCRIPTION
### Proposed changes

After some end to end testing, I see that GA4 will silently drop events that have dash characters in the names or in field names.

### Merge timing
ASAP is fine