### PR TITLE
Refactor Segment plugin to use latest 1Flow SDK

### DIFF
--- a/src/connections/destinations/catalog/1flow-mobile-plugin/index.md
+++ b/src/connections/destinations/catalog/1flow-mobile-plugin/index.md
@@ -84,8 +84,9 @@ defaultConfig {
     }
 dependencies {
         ....
+        
     implementation 'com.segment.analytics.android:analytics:4.11.3'
-    implementation "com.github.1Flow-Inc:segment-1flow-android:2023.09.16"
+    implementation "com.github.1Flow-Inc:segment-1flow-android:2023.09.26"
 }
 ```
 


### PR DESCRIPTION
### Proposed changes
Android Segment plugin was using static version of 1Flow SDK. After this version, Segment plugin will refer to latest 1Flow SDK. Now releasing new version of 1Flow Android SDK will not require to update Segment plugin unless there is some method signature changes in future.

### Merge timing
- ASAP once approved?

### Related issues (optional)
NA