### PR TITLE
Link to GA4 documentation for required parameters in GA4 Cloud .html

### DIFF
--- a/src/_includes/components/actions-fields.html
+++ b/src/_includes/components/actions-fields.html
@@ -84,6 +84,12 @@
 
 Build your own Mappings! Combine supported [triggers](/docs/connections/destinations/actions/#components-of-a-destination-action) with the following {{currentIntegration.display_name | remove: " (Actions)"}}-supported actions:
 
+> warning ""
+> Please refer to the [Google Analtyics](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#purchase) 
+documentation for the list of required fields, 
+We want to ensure you have the most up-to-date information, as 
+the required fields may change.
+
 <div class="premonition info">
   <div class="fa fa-info-circle"></div>
   <div class="content">


### PR DESCRIPTION
### Proposed changes

Added a link to Google Analytics documentation so customer are aware of the required parameters that need to be sent, and they can have quick access to the latest documentation from GA.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
