### PR TITLE
Add a section to clarify the support for Remarketing

### DIFF
--- a/src/connections/destinations/catalog/google-ads-gtag/index.md
+++ b/src/connections/destinations/catalog/google-ads-gtag/index.md
@@ -97,9 +97,9 @@ If you are an enterprise that uses multiple Google Ads Gtag accounts (usually ma
 
 Google offers two primary types of remarketing: 
 
-* [Standard Remarketing](https://support.google.com/google-ads/answer/2453998): allows advertisers to show targeted ads to users who have previously visited their website. Advertisers can create custom remarketing lists based on user behavior, such as pages viewed or specific actions taken on the website.
-* [Dynamic Remarketing](https://support.google.com/google-ads/answer/3103357): takes personalized advertising a step further by showing users specific products or services they viewed on an advertiser's website. This type of remarketing is particularly beneficial for e-commerce businesses as it displays dynamic product ads to previous visitors, reminding them of products they showed interest in.
+* [Standard Remarketing](https://support.google.com/google-ads/answer/2453998){:target="_blank"} : allows advertisers to show targeted ads to users who have previously visited their website. Advertisers can create custom remarketing lists based on user behavior, such as pages viewed or specific actions taken on the website.
+* [Dynamic Remarketing](https://support.google.com/google-ads/answer/3103357){:target="_blank"} : takes personalized advertising a step further by showing users specific products or services they viewed on an advertiser's website. This type of remarketing is particularly beneficial for e-commerce businesses as it displays dynamic product ads to previous visitors, reminding them of products they showed interest in.
 
-> info ""
-> The Google Ads (Gtag) Destination supports Standard by default, it does not support Dynamic Remarketing. 
+> warning "Google Ads (Gtag) Destination does not support Dynamic Remarketing"
+> Segment's Google Ads (Gtag) Destination only supports Standard Remarketing. 
 

--- a/src/connections/destinations/catalog/google-ads-gtag/index.md
+++ b/src/connections/destinations/catalog/google-ads-gtag/index.md
@@ -92,3 +92,14 @@ To figure out if an event is flagged for conversion, follow these steps:
 ## Multiple Google Ads Accounts
 
 If you are an enterprise that uses multiple Google Ads Gtag accounts (usually managed by various third party agencies) you can override the top level default Google Conversion ID at the event level by entering it into the settings.
+
+## Remarketing Support 
+
+Google offers two primary types of remarketing: 
+
+* [Standard Remarketing](https://support.google.com/google-ads/answer/2453998): allows advertisers to show targeted ads to users who have previously visited their website. Advertisers can create custom remarketing lists based on user behavior, such as pages viewed or specific actions taken on the website.
+* [Dynamic Remarketing](https://support.google.com/google-ads/answer/3103357): takes personalized advertising a step further by showing users specific products or services they viewed on an advertiser's website. This type of remarketing is particularly beneficial for e-commerce businesses as it displays dynamic product ads to previous visitors, reminding them of products they showed interest in.
+
+> info ""
+> The Google Ads (Gtag) Destination supports Standard by default, it does not support Dynamic Remarketing. 
+


### PR DESCRIPTION
Google offers two types of remarketing, adding a note to our docs to clarify that only one type of remarketing is supported with our integration.

<!-- When should this get merged/published?
- ASAP once approved

### Related issues (optional)

https://twilio.slack.com/archives/C010W2FMYN5/p1696005087687449?thread_ts=1695999574.057309&cid=C010W2FMYN5