### PR TITLE
Add values separated by Tabs can be input for operator "equals one of"

### DIFF
--- a/src/unify/Traits/computed-traits.md
+++ b/src/unify/Traits/computed-traits.md
@@ -154,6 +154,8 @@ The following operators are available.
 - equals one of
 - contains one of
 
+To input multiple values for operators "equals one of" and "contains one of", you can paste in a string of values that are separated by Tabs.
+
 ## Connecting your Computed Trait to a Destination
 
 Segment sends user-level computed Traits to destinations using the [Identify call](/docs/connections/spec/identify/) for user traits, or using the [Track call](/docs/connections/spec/track/) for event properties. Segment includes the trait value and property in the identify and track calls.


### PR DESCRIPTION
### Proposed changes

Add the following sentence in the Conditions section:

"To input multiple values for operators "equals one of" and "contains one of", you can paste in a string of values that are separated by Tabs."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
https://twilio.slack.com/archives/C01K6RTRSSW/p1693384003322009
https://segment.atlassian.net/browse/JO-2007
https://segment.zendesk.com/agent/tickets/521725
