### PR TITLE
LIBWEB-1531 - TikTok Pixel - updating docs to explain 'Use Existing Pixel' setting

### DIFF
--- a/src/connections/destinations/catalog/actions-tiktok-pixel/index.md
+++ b/src/connections/destinations/catalog/actions-tiktok-pixel/index.md
@@ -26,10 +26,19 @@ This destination is maintained by TikTok. For any issues with the destination, [
 4. Select an existing JavaScript Source to connect to TikTok Pixel.
 5. Give the Destination a name.
 6. On the Settings screen, provide the Pixel Code. This can be found in the TikTok Events Manager (TTEM).
-    - Ensure that the Use Existing Pixel field is **off** if you want Segment to load the TikTok Pixel JavaScript code onto your website.
-    - Ensure that the Use Existing Pixel field is **on** if you want Segment to detect and keep using the existing TikTok Pixel JavaScript snippet which has already been loaded on your website.
+    - Ensure that the "Use Existing Pixel" setting is **off** if you want Segment to load the TikTok Pixel JavaScript code onto your website. This is the default and recommended behavior. 
+    - Ensure that the "Use Existing Pixel" setting is **on** if you want Segment to detect a pre-existing TikTok Pixel which is already loaded to your website independently of Segment. If you enable this option and do not have TikTok Pixel loaded to your website, your data collection to Segment may be disrupted. See [The "Use Existing Pixel" setting](#use-existing-pixel-setting) for more information on how to use this setting safely.  
 7. Toggle on the Destination using the **Enable Destination** toggle.
 8. Click **Save Change**.
+
+<a id="use-existing-pixel-setting"></a>
+## The "Use Existing Pixel" setting
+
+The TikTok Pixel Destination's default behavior is to load a TikTok Pixel Javascript library onto your website when the page loads. However if you already have TikTok Pixel on your website before enabling this Destination, you might prefer that Segment detects and uses your pre-existing TikTok Pixel Javascript library instead of loading a new TikTok Pixel library. 
+
+Toggling "off" the "Use Existing Pixel" will prevent Segment from loading a TikTok Pixel library onto the web page. Instead, Segment will attempt to detect your pre-loaded TikTok Pixel library and will use it when forwarding events to TikTok. 
+
+Care should be taken when toggling the "Use Existing Pixel" setting to "off" as doing so could result in disruption to data collection if Segment doesn't detect TikTok Pixel on the website. 
 
 ### Mappings enabled by default
 

--- a/src/connections/destinations/catalog/actions-tiktok-pixel/index.md
+++ b/src/connections/destinations/catalog/actions-tiktok-pixel/index.md
@@ -36,7 +36,7 @@ This destination is maintained by TikTok. For any issues with the destination, [
 
 The TikTok Pixel Destination's default behavior is to load a TikTok Pixel Javascript library onto your website when the page loads. However if you already have TikTok Pixel on your website before enabling this Destination, you might prefer that Segment detects and uses your pre-existing TikTok Pixel Javascript library instead of loading a new TikTok Pixel library. 
 
-Toggling "off" the "Use Existing Pixel" will prevent Segment from loading a TikTok Pixel library onto the web page. Instead, Segment will attempt to detect your pre-loaded TikTok Pixel library and will use it when forwarding events to TikTok. 
+Toggling "on" the "Use Existing Pixel" will prevent Segment from loading a TikTok Pixel library onto the web page. Instead, Segment will attempt to detect your pre-loaded TikTok Pixel library and will use it when forwarding events to TikTok. 
 
 Care should be taken when toggling the "Use Existing Pixel" setting to "off" as doing so could result in disruption to data collection if Segment doesn't detect TikTok Pixel on the website. 
 

--- a/src/connections/destinations/catalog/actions-tiktok-pixel/index.md
+++ b/src/connections/destinations/catalog/actions-tiktok-pixel/index.md
@@ -27,18 +27,19 @@ This destination is maintained by TikTok. For any issues with the destination, [
 5. Give the Destination a name.
 6. On the Settings screen, provide the Pixel Code. This can be found in the TikTok Events Manager (TTEM).
     - Ensure that the "Use Existing Pixel" setting is **off** if you want Segment to load the TikTok Pixel JavaScript code onto your website. This is the default and recommended behavior. 
-    - Ensure that the "Use Existing Pixel" setting is **on** if you want Segment to detect a pre-existing TikTok Pixel which is already loaded to your website independently of Segment. If you enable this option and do not have TikTok Pixel loaded to your website, your data collection to Segment may be disrupted. See [The "Use Existing Pixel" setting](#use-existing-pixel-setting) for more information on how to use this setting safely.  
+    - Ensure that the "Use Existing Pixel" setting is **on** if you want Segment to detect a pre-existing TikTok Pixel that's already loaded to your website independently of Segment. If you enable this option and don't have TikTok Pixel loaded to your website, your data collection to Segment may be disrupted. See [the "Use Existing Pixel" setting](#use-existing-pixel-setting) for more information on how to use this setting safely.  
 7. Toggle on the Destination using the **Enable Destination** toggle.
 8. Click **Save Change**.
 
 <a id="use-existing-pixel-setting"></a>
-## The "Use Existing Pixel" setting
+## The Use Existing Pixel setting
 
-The TikTok Pixel Destination's default behavior is to load a TikTok Pixel Javascript library onto your website when the page loads. However if you already have TikTok Pixel on your website before enabling this Destination, you might prefer that Segment detects and uses your pre-existing TikTok Pixel Javascript library instead of loading a new TikTok Pixel library. 
+> warning ""
+> Use caution when you toggle on the **Use Existing Pixel** setting; it could result in disruption to data collection if Segment doesn't detect TikTok Pixel on the website. 
 
-Toggling "on" the "Use Existing Pixel" will prevent Segment from loading a TikTok Pixel library onto the web page. Instead, Segment will attempt to detect your pre-loaded TikTok Pixel library and will use it when forwarding events to TikTok. 
+The TikTok Pixel destination's default behavior is to load a TikTok Pixel JavaScript library onto your website when the page loads. However, if you already have TikTok Pixel on your website before enabling this Destination, you may want Segment to detect and use your pre-existing TikTok Pixel JavaScript library instead of loading a new TikTok Pixel library. 
 
-Care should be taken when toggling the "Use Existing Pixel" setting to "on" as doing so could result in disruption to data collection if Segment doesn't detect TikTok Pixel on the website. 
+Toggling the **Use Existing Pixel** setting on will prevent Segment from loading a TikTok Pixel library onto the web page. Instead, Segment will attempt to detect your pre-loaded TikTok Pixel library and will use it when forwarding events to TikTok. 
 
 ### Mappings enabled by default
 

--- a/src/connections/destinations/catalog/actions-tiktok-pixel/index.md
+++ b/src/connections/destinations/catalog/actions-tiktok-pixel/index.md
@@ -38,7 +38,7 @@ The TikTok Pixel Destination's default behavior is to load a TikTok Pixel Javasc
 
 Toggling "on" the "Use Existing Pixel" will prevent Segment from loading a TikTok Pixel library onto the web page. Instead, Segment will attempt to detect your pre-loaded TikTok Pixel library and will use it when forwarding events to TikTok. 
 
-Care should be taken when toggling the "Use Existing Pixel" setting to "off" as doing so could result in disruption to data collection if Segment doesn't detect TikTok Pixel on the website. 
+Care should be taken when toggling the "Use Existing Pixel" setting to "on" as doing so could result in disruption to data collection if Segment doesn't detect TikTok Pixel on the website. 
 
 ### Mappings enabled by default
 


### PR DESCRIPTION
Related to SEV - inc-sev2-6364-tiktok-pixel-is-preventing-ajs-from-tracking-events-2023-10-02

Slack: https://twilio.slack.com/archives/C05USP6KDC3/p1696264024954719

JIRA ticket to fix Actions code: https://segment.atlassian.net/browse/LIBWEB-1531

This PR updates the TikTok Pixel docs to provide a clearer explanation of how to use the 'Use Existing Pixel', and the risks involved with disabling it. 