### PR TITLE
Add note on custom traits for deleted audiences

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -35,6 +35,9 @@ You can also specify two different types of time-windows, `within` and `in betwe
 
 You can also build Audiences based on custom traits. These traits can be collected from your apps when a user completes a form or signs up using an [Identify](/docs/connections/spec/identify) call. You can view these traits in the Profile explorer, as well. Custom Traits are mutable and update to the latest value seen by the user's Identify events.
 
+> info ""
+> When an audience that previously generated Identify events is deleted, the data for the audience key is still attached to profiles that entered the audience, and becomes visible in the UI as a custom trait.
+
 ### Computed Traits
 
 You can also use computed traits in an Audience definition. For example, you can create a `total_revenue` computed trait and use it to generate an audience of `big_spender` customers that exceed a certain threshold.

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -36,7 +36,7 @@ You can also specify two different types of time-windows, `within` and `in betwe
 You can also build Audiences based on custom traits. These traits can be collected from your apps when a user completes a form or signs up using an [Identify](/docs/connections/spec/identify) call. You can view these traits in the Profile explorer, as well. Custom Traits are mutable and update to the latest value seen by the user's Identify events.
 
 > info ""
-> When an audience that previously generated Identify events is deleted, the data for the audience key is still attached to profiles that entered the audience, and becomes visible in the UI as a custom trait.
+> When an audience that previously generated Identify events is deleted, the data for the audience key is still attached to profiles that entered the audience, and becomes visible in Segment as a custom trait.
 
 ### Computed Traits
 


### PR DESCRIPTION
### Proposed changes

Docs do not currently mention how an audience key can show up as a custom trait on an Engage profile after the corresponding audience is deleted (provided the audience previously generated identify calls for users) - added as a note under "Custom Traits" section.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
