### PR TITLE
Add faq that PII access is needed to see error messages in SQL trait

### DIFF
--- a/src/unify/Traits/sql-traits.md
+++ b/src/unify/Traits/sql-traits.md
@@ -266,5 +266,5 @@ Check that you've configured the identifier that uniquely identifies users in a 
 
 Ensure that the name given to the SQL trait is not the same name as the identifier or column name from the query. To use SQL traits to update an identifier, the identifier will need to be a column in the query of your SQL trait. The column name in the query of the SQL trait should be the one that Identity Resolution uses to generate the identifier. 
 
-### Why am I not able to see the error messages in SQL trait while the other developers can?
-To see the error messages in SQL trait, you will need to have PII Access.
+### Why can't I see error messages in SQL traits while other users can?
+To see error messages in SQL traits, you will need to have PII Access.

--- a/src/unify/Traits/sql-traits.md
+++ b/src/unify/Traits/sql-traits.md
@@ -265,3 +265,6 @@ Check that you've configured the identifier that uniquely identifies users in a 
 ### Why doesn't the identifier updated by a SQL trait show the correct value found in the column?
 
 Ensure that the name given to the SQL trait is not the same name as the identifier or column name from the query. To use SQL traits to update an identifier, the identifier will need to be a column in the query of your SQL trait. The column name in the query of the SQL trait should be the one that Identity Resolution uses to generate the identifier. 
+
+### Why am I not able to see the error messages in SQL trait while the other developers can?
+To see the error messages in SQL trait, you will need to have PII Access.


### PR DESCRIPTION
### Proposed changes
Added the following FAQ:

"Why am I not able to see the error messages in SQL trait while the other developers can? To see the error messages in SQL trait, you will need to have PII Access."


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->

- https://segment.zendesk.com/agent/tickets/524098
- https://segment.zendesk.com/agent/tickets/509597
