### PR TITLE
Add limitation 'Event Type is Page'

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -75,8 +75,9 @@ Google may take [24-48 hours](https://support.google.com/analytics/answer/933379
 ### Data is not sent to Google
 
 In order for data to be sent downstream to Google Analytics, check your mappings to ensure that:
-1. The **setConfigurationFields** mapping is enabled in your mappings
-2. You've added at least one other event mapping for an event you want to send to Google Analytics. 
+1. The **setConfigurationFields** mapping is enabled in your mappings.
+2. You've added at least one other event mapping for an event you want to send to Google Analytics.
+3. Your event mapping doesn't use the condition 'Event Type is Page,' which depends on the page event that's triggered when your site loads. The initial 'Page' event is claimed by the GA config command, so it can't be used for triggering additional events in GA4. We recommend using [analytics.track()](https://segment.com/docs/connections/spec/track/) for any extra events you'd like to appear in GA4. This ensures your events go through after the initial 'config' has loaded.
 
 The **setConfigurationFields** mapping is required in order for data to be sent downstream. If no other mappings are enabled, the destination does not send events.
 

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -77,7 +77,7 @@ Google may take [24-48 hours](https://support.google.com/analytics/answer/933379
 In order for data to be sent downstream to Google Analytics, check your mappings to ensure that:
 1. The **setConfigurationFields** mapping is enabled in your mappings.
 2. You've added at least one other event mapping for an event you want to send to Google Analytics.
-3. Your event mapping doesn't use the condition 'Event Type is Page'. The GA config command uses a Page event when your page loads, so it can't be used for triggering additional events in GA4. Segment recommends using a [Track call](/docs/connections/spec/track/) for any additional events you'd like to appear in GA4. This ensures your events go through after the initial 'config' loads.
+3. Your event mapping doesn't use the condition 'Event Type is Page'. The GA config command uses a Page event when your page loads, so Page calls can't be used for triggering additional events in GA4. Segment recommends using a [Track call](/docs/connections/spec/track/) for any additional events you'd like to appear in GA4 so your events can go through after the initial 'config' loads.
 
 The **setConfigurationFields** mapping is required in order for data to be sent downstream. If no other mappings are enabled, the destination does not send events.
 

--- a/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4-web/index.md
@@ -77,7 +77,7 @@ Google may take [24-48 hours](https://support.google.com/analytics/answer/933379
 In order for data to be sent downstream to Google Analytics, check your mappings to ensure that:
 1. The **setConfigurationFields** mapping is enabled in your mappings.
 2. You've added at least one other event mapping for an event you want to send to Google Analytics.
-3. Your event mapping doesn't use the condition 'Event Type is Page,' which depends on the page event that's triggered when your site loads. The initial 'Page' event is claimed by the GA config command, so it can't be used for triggering additional events in GA4. We recommend using [analytics.track()](https://segment.com/docs/connections/spec/track/) for any extra events you'd like to appear in GA4. This ensures your events go through after the initial 'config' has loaded.
+3. Your event mapping doesn't use the condition 'Event Type is Page'. The GA config command uses a Page event when your page loads, so it can't be used for triggering additional events in GA4. Segment recommends using a [Track call](/docs/connections/spec/track/) for any additional events you'd like to appear in GA4. This ensures your events go through after the initial 'config' loads.
 
 The **setConfigurationFields** mapping is required in order for data to be sent downstream. If no other mappings are enabled, the destination does not send events.
 


### PR DESCRIPTION
### Proposed changes

Adding a note about the limitation around using condition 'Event Type is Page' with GA4 mappings. 

Slack thread for more info: https://twilio.slack.com/archives/C01282F7QE8/p1696601817477719  

### Merge timing
- ASAP once approved.

### Related issues (optional)
https://segment.atlassian.net/browse/STRATCONN-3250