### PR TITLE
GA4 Actions mapping note hotfix

### DIFF
--- a/src/_includes/components/actions-fields.html
+++ b/src/_includes/components/actions-fields.html
@@ -84,10 +84,6 @@
 
 Build your own Mappings. Combine supported [triggers](/docs/connections/destinations/actions/#components-of-a-destination-action) with the following {{currentIntegration.display_name | remove: " (Actions)"}}-supported actions:
 
-> warning ""
-> View the [Google Analytics documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#purchase){:target="_blank"} for the most up-to-date list of required fields.
-
-
 <div class="premonition info">
   <div class="fa fa-info-circle"></div>
   <div class="content">


### PR DESCRIPTION
### Proposed changes
A note that only pertains to the GA4 web (actions) destination appears on all Actions destination pages. I'd like to remove it temporarily while we fix the include

### Merge timing
asap!

### Related issues (optional)
#5517 
