### PR TITLE
Add info about CleverTap repo ownership

### DIFF
--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -14,7 +14,6 @@ You can integrate CleverTap using a server-side or mobile destination (iOS or An
 All server-side destination requests require both the Segment `anonymousId` and `userId` in the payload. This is a requirement from CleverTap. 
 
 CleverTap maintains the server-side and mobile integrations:
-
 - [Android](https://github.com/CleverTap/clevertap-segment-android)
 - [iOS](https://github.com/CleverTap/clevertap-segment-ios)
 

--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -14,7 +14,7 @@ You can integrate CleverTap using a server-side or mobile destination (iOS or An
 For server-side destination requests, CleverTap requires both the Segment `anonymousId` and `userId` in the payload.  
 
 CleverTap maintains the server-side and mobile integrations:
-- [Android](https://github.com/CleverTap/clevertap-segment-android)
+- [Android](https://github.com/CleverTap/clevertap-segment-android){:target="_blank"}
 - [iOS](https://github.com/CleverTap/clevertap-segment-ios)
 
 For any issues with the server-side and mobile integrations, [contact the CleverTap Support team](https://help.clevertap.com/hc/en-us/requests/new){:target="_blank"}.

--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -7,12 +7,18 @@ cmode-override: true
 
 Once the Segment library is integrated, toggle CleverTap on in your Segment destinations, and add your CleverTap Account ID and CleverTap Account Token which you can find in the CleverTap Dashboard under Settings.
 
-You can integrate CleverTap using a server-side or mobile destination (iOS or Android). If you are interested in using CleverTap's push notifications or in-app notifications products, you should use the mobile destinations.
-
-All server-side destination requests require both the Segment `anonymousId` and `userId` in the payload. This is a requirement from CleverTap. CleverTap maintains the server-side integration. For any issues with the server-side integration, [contact the CleverTap Support team](https://help.clevertap.com/hc/en-us/requests/new){:target="_blank"}.
-
 CleverTap supports the `identify`, `track`, `page` (server-side only), and `screen` (iOS and server-side only) methods.
 
+You can integrate CleverTap using a server-side or mobile destination (iOS or Android). If you are interested in using CleverTap's push notifications or in-app notifications products, you should use the mobile destinations.
+
+All server-side destination requests require both the Segment `anonymousId` and `userId` in the payload. This is a requirement from CleverTap. 
+
+CleverTap maintains the server-side and mobile integrations:
+
+- [Android](https://github.com/CleverTap/clevertap-segment-android)
+- [iOS](https://github.com/CleverTap/clevertap-segment-ios)
+
+For any issues with the server-side and mobile integrations, [contact the CleverTap Support team](https://help.clevertap.com/hc/en-us/requests/new){:target="_blank"}.
 
 ## Identify
 

--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -11,7 +11,7 @@ CleverTap supports the Identify, Track, Page (server-side only), and Screen (iOS
 
 You can integrate CleverTap using a server-side or mobile destination (iOS or Android). If you are interested in using CleverTap's push notifications or in-app notifications products, you should use the mobile destinations.
 
-All server-side destination requests require both the Segment `anonymousId` and `userId` in the payload. This is a requirement from CleverTap. 
+For server-side destination requests, CleverTap requires both the Segment `anonymousId` and `userId` in the payload.  
 
 CleverTap maintains the server-side and mobile integrations:
 - [Android](https://github.com/CleverTap/clevertap-segment-android)

--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -15,7 +15,7 @@ For server-side destination requests, CleverTap requires both the Segment `anony
 
 CleverTap maintains the server-side and mobile integrations:
 - [Android](https://github.com/CleverTap/clevertap-segment-android){:target="_blank"}
-- [iOS](https://github.com/CleverTap/clevertap-segment-ios)
+- [iOS](https://github.com/CleverTap/clevertap-segment-ios){:target="_blank"}
 
 For any issues with the server-side and mobile integrations, [contact the CleverTap Support team](https://help.clevertap.com/hc/en-us/requests/new){:target="_blank"}.
 

--- a/src/connections/destinations/catalog/clevertap/index.md
+++ b/src/connections/destinations/catalog/clevertap/index.md
@@ -7,7 +7,7 @@ cmode-override: true
 
 Once the Segment library is integrated, toggle CleverTap on in your Segment destinations, and add your CleverTap Account ID and CleverTap Account Token which you can find in the CleverTap Dashboard under Settings.
 
-CleverTap supports the `identify`, `track`, `page` (server-side only), and `screen` (iOS and server-side only) methods.
+CleverTap supports the Identify, Track, Page (server-side only), and Screen (iOS and server-side only) methods.
 
 You can integrate CleverTap using a server-side or mobile destination (iOS or Android). If you are interested in using CleverTap's push notifications or in-app notifications products, you should use the mobile destinations.
 


### PR DESCRIPTION
### Proposed changes
Our Mobile-CleverTap integrations are actually maintained by the CleverTap team:
- https://github.com/CleverTap/clevertap-segment-android
- https://github.com/CleverTap/clevertap-segment-ios

Add this information to our public documentation so that our customers can contact the appropriate team for assistance.


### Merge timing
ASAP once approved