### PR TITLE
Fix: GA4 action-fields note only appears on GA4 Web Actions destination page

### DIFF
--- a/src/_includes/components/actions-fields.html
+++ b/src/_includes/components/actions-fields.html
@@ -82,11 +82,22 @@
 
 ## Available Actions
 
+<!-- IG 10/2023 - The customer success engineers wanted to add this note due to some breaking changes. Originally made in PR #5387 -->
+
+{% if currentIntegration.id == '63ed446fe60a1b56c5e6f130' %}
+  <div class="premonition warning">
+    <div class="fa fa-check-square"></div>
+    <div class="content">
+      <p class="header">Required fields may have changed</p>
+      <p markdown=1>
+        View the [Google Analytics documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#purchase){:target="_blank"} for the most up-to-date list of required fields.
+      </p>
+    </div>
+  </div>
+
+{% endif %}
+
 Build your own Mappings. Combine supported [triggers](/docs/connections/destinations/actions/#components-of-a-destination-action) with the following {{currentIntegration.display_name | remove: " (Actions)"}}-supported actions:
-
-> warning ""
-> View the [Google Analytics documentation](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#purchase){:target="_blank"} for the most up-to-date list of required fields.
-
 
 <div class="premonition info">
   <div class="fa fa-info-circle"></div>


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Fixed note that rendered on all actions destinations pages - it only renders on the GA4 Web Actions Destination page now

### Merge timing
ASAP!

### Related issues (optional)
#5387, #5517, #5518
