### PR TITLE
Network carrier no longer returned for iOS

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/ios/ios-faqs.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/ios-faqs.md
@@ -255,3 +255,7 @@ As of [Version 4.1.0](https://github.com/segmentio/analytics-ios/releases/tag/4.
 ## AppClip tracking support
 
 If you are tracking App Clips using iOS or Swift libraries, there is a chance that you may encounter zeros in your device ID. Segment recommends that you set your own device ID in this instance to avoid running into this issue.
+
+## Why am I seeing a value of -- set for the network carrier?
+
+As from iOS [16.4](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-16_4-release-notes#Core-Telephony), Apple has deprecated the method to return the network carrier. As such, the iOS library can no longer return a valid value for the network carrier on devices using iOS 16.4 or later. You will likely see `--` set for the `context.network.carrier` field.

--- a/src/connections/sources/catalog/libraries/mobile/ios/ios-faqs.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/ios-faqs.md
@@ -258,4 +258,4 @@ If you are tracking App Clips using iOS or Swift libraries, there is a chance th
 
 ## Why am I seeing a value of -- set for the network carrier?
 
-As from iOS [16.4](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-16_4-release-notes#Core-Telephony), Apple has deprecated the method to return the network carrier. As such, the iOS library can no longer return a valid value for the network carrier on devices using iOS 16.4 or later. You will likely see `--` set for the `context.network.carrier` field.
+With iOS [16.4](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-16_4-release-notes#Core-Telephony){:target="_blank"}, Apple deprecated the method to return the network carrier. The iOS library can no longer return a valid value for the network carrier on devices using iOS 16.4 or later. As a result, you will likely see `--` set for the `context.network.carrier` field.


### PR DESCRIPTION
### Proposed changes
Apple have deprecated the method that returns the network carrier. As this is for the older iOS SDK, eng will not release a change to remove the field etc. Adding info to our FAQs.