### PR TITLE
Update kotlin-android-plugin-architecture.md

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-plugin-architecture.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-plugin-architecture.md
@@ -27,9 +27,8 @@ For example, if you want to add something to the context object of any event pay
 ```java
 class SomePlugin: Plugin {
     override val type = Plugin.Type.Enrichment
-    override val name = "SomePlugin"
 
-    override var lateinit analytics: Analytics
+    override lateinit var analytics: Analytics
 
     override fun execute(event: BaseEvent): BaseEvent? {
         event.putInContext("foo", "bar")
@@ -96,9 +95,8 @@ analytics.add(amplitudePlugin) // add amplitudePlugin to the analytics client
 
 val amplitudeEnrichment = object: Plugin {
     override val type = Plugin.Type.Enrichment
-    override val name = "SomePlugin"
 
-    override var lateinit analytics: Analytics
+    override lateinit var analytics: Analytics
 
     override fun execute(event: BaseEvent): BaseEvent? {
         event.putInContext("foo", "bar")
@@ -124,9 +122,8 @@ Here's an example of adding a plugin to the context object of any event payload 
 ```java
 class SomePlugin: Plugin {
     override val type = Plugin.Type.Enrichment
-    override val name = "SomePlugin"
 
-    override var lateinit analytics: Analytics
+    override lateinit var analytics: Analytics
 
     override fun execute(event: BaseEvent): BaseEvent? {
         event.putInContext("foo", "bar")


### PR DESCRIPTION
Update plugin examples to remove non-existent `name` field and fix order of `lateinit` property

### Proposed changes

The simple plugin examples were overriding a field that doesn't exist on the `Plugin` interface. Also, the `lateinit` keyword has to come before the `var` keyword.


### Merge timing

Not urgent, but also it is just a docs change, so might as well push it out as it doesn't change any underlying code.

### Related issues (optional)

