### PR TITLE
Add note on event order in debugger

### DIFF
--- a/src/connections/sources/debugger.md
+++ b/src/connections/sources/debugger.md
@@ -4,6 +4,9 @@ title: Using the Source Debugger
 
 The Source Debugger is a real-time tool that helps you confirm that API calls made from your website, mobile app, or servers arrive to your Segment Source, so you can troubleshoot your Segment set up even quicker. With the Debugger, you can check that calls are sent in the expected format without having to wait for any data processing.
 
+> info ""
+> The Source Debugger's event order may not reflect how events are sent downstream or received by connected destinations. The Debugger primarily confirms incoming data and provides a basic view of its structure. For a reliable record of the data you send to Segment, it's advisable to attach a raw storage destination to your sources. 
+
 ![A screenshot of the debugger view, with a Track event selected and the pretty view opened.](images/debugger_view.png)
 
 The Debugger is separate from your workspace's data pipeline and is not an exhaustive view of all the events ever sent to your Segment workspace. The Debugger only shows a sample of the events that the Source receives in real time, with a cap of 500 events. The Debugger is a great way to test specific parts of your implementation to validate that events are being fired successfully and arriving to your Source.

--- a/src/connections/sources/debugger.md
+++ b/src/connections/sources/debugger.md
@@ -5,7 +5,7 @@ title: Using the Source Debugger
 The Source Debugger is a real-time tool that helps you confirm that API calls made from your website, mobile app, or servers arrive to your Segment Source, so you can troubleshoot your Segment set up even quicker. With the Debugger, you can check that calls are sent in the expected format without having to wait for any data processing.
 
 > info ""
-> The Source Debugger's event order may not reflect how events are sent downstream or received by connected destinations. The Debugger primarily confirms incoming data and provides a basic view of its structure. For a reliable record of the data you send to Segment, it's advisable to attach a raw storage destination to your sources. 
+> The Source Debugger's event order may not reflect how events send downstream or are received by connected destinations. The Debugger primarily confirms incoming data and provides a basic view of its structure. For a reliable record of the data you send to Segment, Segment advises you to attach a raw storage destination to your sources. 
 
 ![A screenshot of the debugger view, with a Track event selected and the pretty view opened.](images/debugger_view.png)
 


### PR DESCRIPTION
### Proposed changes

Added note that clarifies the source debugger is meant to display a sampling of events, and it is not guaranteed to be in exact order, and that Segment recommends attaching a data warehouse to sources to serve as a source of truth.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
