### PR TITLE
Add info to return event in handler to sent through destination

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -54,7 +54,7 @@ Segment invokes a separate part of the function (called a "handler") for each ev
 > info ""
 > Your function isn't invoked for an event if you've configured a [destination filter](/docs/connections/destinations/destination-filters/), and the event doesn't pass the filter.
 
-The default source code template includes handlers for all event types. You don't need to implement all of them - just use the ones you need, and skip the ones you don't.
+The default source code template includes handlers for all event types. You don't need to implement all of them - just use the ones you need, and skip the ones you don't. For event types that you want to sent through the destination, return the event in the respective event handlers.
 
 > info ""
 > Removing the handler for a specific event type results in blocking the events of that type from arriving at their destination. 

--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -54,7 +54,7 @@ Segment invokes a separate part of the function (called a "handler") for each ev
 > info ""
 > Your function isn't invoked for an event if you've configured a [destination filter](/docs/connections/destinations/destination-filters/), and the event doesn't pass the filter.
 
-The default source code template includes handlers for all event types. You don't need to implement all of them - just use the ones you need, and skip the ones you don't. For event types that you want to sent through the destination, return the event in the respective event handlers.
+The default source code template includes handlers for all event types. You don't need to implement all of them - just use the ones you need, and skip the ones you don't. For event types that you want to send through the destination, return the event in the respective event handlers.
 
 > info ""
 > Removing the handler for a specific event type results in blocking the events of that type from arriving at their destination. 


### PR DESCRIPTION
### Proposed changes
If event is not returned in the event handler, the event will not be sent through the destination.

Added the following statement in - Code the destination insert function section:

"For event types that you want to sent through the destination, return the event in the respective event handlers.”


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
Sample tickets related to this:
https://segment.zendesk.com/agent/tickets/523805
https://segment.zendesk.com/agent/tickets/526400
