### PR TITLE
Fix Duplicate Table of Contents in `/connections/spec/mobile`

### DIFF
--- a/src/connections/spec/mobile.md
+++ b/src/connections/spec/mobile.md
@@ -20,39 +20,21 @@ These events pair nicely with Segment's [ecommerce spec](/docs/connections/spec/
 
 The Segment Native Mobile Spec includes the following semantic events:
 
-**Application Lifecycle Events**
-- [Overview of events](#overview-of-events)
-- [Lifecycle events](#lifecycle-events)
-  - [Application Installed](#application-installed)
-  - [Application Opened](#application-opened)
-  - [Application Backgrounded](#application-backgrounded)
-  - [Application Updated](#application-updated)
-  - [Application Uninstalled](#application-uninstalled)
-  - [Application Crashed](#application-crashed)
-- [Campaign events](#campaign-events)
-  - [Install Attributed](#install-attributed)
-  - [Push Notification Received](#push-notification-received)
-  - [Push Notification Tapped](#push-notification-tapped)
-  - [Push Notification Bounced](#push-notification-bounced)
-  - [Deep Link Opened](#deep-link-opened)
-  - [Deep Link Clicked](#deep-link-clicked)
+[**Application Lifecycle Events**](#lifecycle-events)
+- [Application Installed](#application-installed)
+- [Application Opened](#application-opened)
+- [Application Backgrounded](#application-backgrounded)
+- [Application Updated](#application-updated)
+- [Application Uninstalled](#application-uninstalled)
+- [Application Crashed](#application-crashed)
 
-**Campaign Events**
-- [Overview of events](#overview-of-events)
-- [Lifecycle events](#lifecycle-events)
-  - [Application Installed](#application-installed)
-  - [Application Opened](#application-opened)
-  - [Application Backgrounded](#application-backgrounded)
-  - [Application Updated](#application-updated)
-  - [Application Uninstalled](#application-uninstalled)
-  - [Application Crashed](#application-crashed)
-- [Campaign events](#campaign-events)
-  - [Install Attributed](#install-attributed)
-  - [Push Notification Received](#push-notification-received)
-  - [Push Notification Tapped](#push-notification-tapped)
-  - [Push Notification Bounced](#push-notification-bounced)
-  - [Deep Link Opened](#deep-link-opened)
-  - [Deep Link Clicked](#deep-link-clicked)
+[**Campaign Events**](#campaign-events)
+- [Install Attributed](#install-attributed)
+- [Push Notification Received](#push-notification-received)
+- [Push Notification Tapped](#push-notification-tapped)
+- [Push Notification Bounced](#push-notification-bounced)
+- [Deep Link Opened](#deep-link-opened)
+- [Deep Link Clicked](#deep-link-clicked)
 
 
 Segment recommends using the above event names if you're going to be integrating the events yourself. This will ensure that they can be mapped effectively in downstream tools.


### PR DESCRIPTION
Remove repeated table of contents in mobile spec

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

Saw there were duplicate table of contents in https://segment.com/docs/connections/spec/mobile/ and figured I'd fix it.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
