### PR TITLE
Add section about conversion tracking with LinkedIn Insight Tag

### DIFF
--- a/src/connections/destinations/catalog/linkedin-insight-tag/index.md
+++ b/src/connections/destinations/catalog/linkedin-insight-tag/index.md
@@ -53,3 +53,7 @@ From there, click **Configure LinkedIn Insight Tag** and select the source for w
 ![A screenshot of the Settings page for the LinkedIn Insight Tag destination.](images/Nmad4zYvWy.png)
 
 Select that option and paste in the LinkedIn Data Partner ID that you copied earlier. Click **Save**, then click **Activate Destination**. Our servers build the latest CDN for that source, and the LinkedIn Insight Tag loads on the sites that use that source's Segment snippet!
+
+## Tracking Conversions 
+
+Our LinkedIn Insight Tag destination is fairly unique in that all Segment does is load the LinkedIn scripts onto your website for you so you can call methods directly without having to add the script tags yourself. Any special conversion tracking would need to be done within your LinkedIn workspace, as you normally would if you were setting up LinkedIn without Segment. 

--- a/src/connections/destinations/catalog/linkedin-insight-tag/index.md
+++ b/src/connections/destinations/catalog/linkedin-insight-tag/index.md
@@ -54,6 +54,6 @@ From there, click **Configure LinkedIn Insight Tag** and select the source for w
 
 Select that option and paste in the LinkedIn Data Partner ID that you copied earlier. Click **Save**, then click **Activate Destination**. Our servers build the latest CDN for that source, and the LinkedIn Insight Tag loads on the sites that use that source's Segment snippet!
 
-## Conversion Tracking
+## Conversion tracking
 
-Our LinkedIn Insight Tag destination is fairly unique in that all Segment does is load the LinkedIn scripts onto your website for you so you can call methods directly without having to add the script tags yourself. Any special conversion tracking would need to be done within your LinkedIn workspace, as you normally would if you were setting up LinkedIn without Segment. 
+Segment's LinkedIn Insight Tag destination is fairly unique in that all Segment does is load the LinkedIn scripts onto your website for you so you can call methods directly without having to add the script tags yourself. Any special conversion tracking needs to be done within your LinkedIn workspace as you normally would if you were setting up LinkedIn without Segment. 

--- a/src/connections/destinations/catalog/linkedin-insight-tag/index.md
+++ b/src/connections/destinations/catalog/linkedin-insight-tag/index.md
@@ -54,6 +54,6 @@ From there, click **Configure LinkedIn Insight Tag** and select the source for w
 
 Select that option and paste in the LinkedIn Data Partner ID that you copied earlier. Click **Save**, then click **Activate Destination**. Our servers build the latest CDN for that source, and the LinkedIn Insight Tag loads on the sites that use that source's Segment snippet!
 
-## Tracking Conversions 
+## Conversion Tracking
 
 Our LinkedIn Insight Tag destination is fairly unique in that all Segment does is load the LinkedIn scripts onto your website for you so you can call methods directly without having to add the script tags yourself. Any special conversion tracking would need to be done within your LinkedIn workspace, as you normally would if you were setting up LinkedIn without Segment. 


### PR DESCRIPTION
### Proposed changes
- Added section letting customers know that our LinkedIn Insight Tag destination is different from our other destinations in that all Segment does is load the Insight tag onto their website for them allowing them to call native methods and that any special conversion tracking would need to be done within their LinkedIn workspace, as they normally would if they were setting up LinkedIn without Segment.

### Merge timing
- ASAP once approved
