### PR TITLE
Use account-level SQL traits to associate users to the account

### DIFF
--- a/src/engage/audiences/account-audiences.md
+++ b/src/engage/audiences/account-audiences.md
@@ -66,7 +66,7 @@ Use-cases for account-level computed traits include:
 > info ""
 > Use SQL traits for complex calculations not supported by computed traits. For example, you would use SQL traits to calculate the number of unique users associated with an account who have logged in during the past month.
 
-### Use account-level SQL traits to associate users to the account
+### Use account-level SQL traits to associate users to an account
 
 To associate users to an account via SQL traits, we have to return both group_id and user_id in the account level SQL trait - this will fire a group call with the userId and the groupId in question, which is the method that Segment uses to add users to groups in destinations.
 

--- a/src/engage/audiences/account-audiences.md
+++ b/src/engage/audiences/account-audiences.md
@@ -70,7 +70,7 @@ Use-cases for account-level computed traits include:
 
 To associate users to an account with SQL traits, you must return both the `group_id` and `user_id` in the account level SQL trait. This fires a Group call which Segment uses to add users to groups in destinations.
 
-There is a limitation on Segment end when a group (account) contains more than one user, the query will return duplicate group_ids (mapped to unique user_ids). Segment won't allow us to return duplicate group_id's in the Group(account level) SQL trait., So we can't map the users to the accounts on many-to-many situation.
+When a group (account) contains more than one user, the query returns duplicate `group_id`s (mapped to unique `user_id`s). However, Segment doesn't return duplicate `group_id`s in the account-level SQL trait. As a result, you can't map users to accounts in a many-to-many situation.
 
 ### Use account-level computed and SQL traits as account-level audience conditions
 

--- a/src/engage/audiences/account-audiences.md
+++ b/src/engage/audiences/account-audiences.md
@@ -66,6 +66,12 @@ Use-cases for account-level computed traits include:
 > info ""
 > Use SQL traits for complex calculations not supported by computed traits. For example, you would use SQL traits to calculate the number of unique users associated with an account who have logged in during the past month.
 
+### Use account-level SQL traits to associate users to the account
+
+To associate users to an account via SQL traits, we have to return both group_id and user_id in the account level SQL trait - this will fire a group call with the userId and the groupId in question, which is the method that Segment uses to add users to groups in destinations.
+
+There is a limitation on Segment end when a group (account) contains more than one user, the query will return duplicate group_ids (mapped to unique user_ids). Segment won't allow us to return duplicate group_id's in the Group(account level) SQL trait., So we can't map the users to the accounts on many-to-many situation.
+
 ### Use account-level computed and SQL traits as account-level audience conditions
 
 Once created, you can connect account-level computed and SQL traits to downstream destinations. You can also use them as conditions in account-level audiences, enabling you to build audiences based on the set of events triggered by all users associated with a given account.

--- a/src/engage/audiences/account-audiences.md
+++ b/src/engage/audiences/account-audiences.md
@@ -68,7 +68,7 @@ Use-cases for account-level computed traits include:
 
 ### Use account-level SQL traits to associate users to an account
 
-To associate users to an account via SQL traits, we have to return both group_id and user_id in the account level SQL trait - this will fire a group call with the userId and the groupId in question, which is the method that Segment uses to add users to groups in destinations.
+To associate users to an account with SQL traits, you must return both the `group_id` and `user_id` in the account level SQL trait. This fires a Group call which Segment uses to add users to groups in destinations.
 
 There is a limitation on Segment end when a group (account) contains more than one user, the query will return duplicate group_ids (mapped to unique user_ids). Segment won't allow us to return duplicate group_id's in the Group(account level) SQL trait., So we can't map the users to the accounts on many-to-many situation.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Use account-level SQL traits to associate users to the account

To associate users to an account via SQL traits, we have to return both group_id and user_id in the account level SQL trait - this will fire a group call with the userId and the groupId in question, which is the method that Segment uses to add users to groups in destinations.

There is a limitation on Segment end when a group (account) contains more than one user, the query will return duplicate group_ids (mapped to unique user_ids). Segment won't allow us to return duplicate group_id's in the Group(account level) SQL trait., So we can't map the users to the accounts on many-to-many situation.

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
