### PR TITLE
Update Facebook App Events docs to include Swift

### DIFF
--- a/src/connections/destinations/catalog/facebook-app-events/index.md
+++ b/src/connections/destinations/catalog/facebook-app-events/index.md
@@ -4,7 +4,9 @@ rewrite: true
 strat: facebook
 id: 56fc7e4680412f644ff12fb9
 ---
-[Facebook App Events](https://developers.facebook.com/docs/app-events){:target="_blank"} collects required information from one of Segment's mobile SDKs ([iOS](/docs/connections/sources/catalog/libraries/mobile/ios/){:target="_blank"} or [Android](/docs/connections/sources/catalog/libraries/mobile/android/){:target="_blank"}) and sends it from Segment's servers to Facebook App Events servers. This *server-to-server* connection will not work with our server-side libraries. The Facebook App Events Destination is open-source. You can browse the code on GitHub for [iOS](https://github.com/segment-integrations/analytics-ios-integration-facebook-app-events){:target="_blank"}.
+[Facebook App Events](https://developers.facebook.com/docs/app-events){:target="_blank"} collects required information from one of Segment's mobile SDKs ([iOS](/docs/connections/sources/catalog/libraries/mobile/ios/){:target="_blank"}, [Android](/docs/connections/sources/catalog/libraries/mobile/android/){:target="_blank"}, or [Swift](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/){:target="_blank"}) and sends it from Segment's servers to Facebook App Events servers. This *server-to-server* connection will not work with our server-side libraries. 
+
+The Facebook App Events Destination is open-source. You can browse the code on GitHub for [iOS](https://github.com/segment-integrations/analytics-ios-integration-facebook-app-events){:target="_blank"}.
 
 
 ## Other Facebook Destinations Supported by Segment

--- a/src/connections/destinations/catalog/facebook-app-events/index.md
+++ b/src/connections/destinations/catalog/facebook-app-events/index.md
@@ -6,7 +6,7 @@ id: 56fc7e4680412f644ff12fb9
 ---
 [Facebook App Events](https://developers.facebook.com/docs/app-events){:target="_blank"} collects required information from one of Segment's mobile SDKs ([iOS](/docs/connections/sources/catalog/libraries/mobile/ios/){:target="_blank"}, [Android](/docs/connections/sources/catalog/libraries/mobile/android/){:target="_blank"}, or [Swift](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/){:target="_blank"}) and sends it from Segment's servers to Facebook App Events servers. 
 
-The iOS device-mode connection for the Facebook App Events destination is open-source and can be viewed on [here](https://github.com/segment-integrations/analytics-ios-integration-facebook-app-events). 
+The iOS device-mode connection for the Facebook App Events destination is open-source and can be viewed on GitHub [here](https://github.com/segment-integrations/analytics-ios-integration-facebook-app-events). 
 
 Segment also has an (Analytics Swift Facebook App Events Plugin)[https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/facebook-app-events-swift/) for the Facebook App Events device-mode connection available. The open-source integration code can be viewed on GitHub [here](https://github.com/segment-integrations/analytics-swift-facebook-app-events){:target="_blank"}. 
 

--- a/src/connections/destinations/catalog/facebook-app-events/index.md
+++ b/src/connections/destinations/catalog/facebook-app-events/index.md
@@ -4,11 +4,11 @@ rewrite: true
 strat: facebook
 id: 56fc7e4680412f644ff12fb9
 ---
-[Facebook App Events](https://developers.facebook.com/docs/app-events){:target="_blank"} collects required information from one of Segment's mobile SDKs ([iOS](/docs/connections/sources/catalog/libraries/mobile/ios/){:target="_blank"}, [Android](/docs/connections/sources/catalog/libraries/mobile/android/){:target="_blank"}, or [Swift](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/){:target="_blank"}) and sends it from Segment's servers to Facebook App Events servers. 
+[Facebook App Events](https://developers.facebook.com/docs/app-events){:target="_blank"} collects required information from one of Segment's mobile SDKs ([iOS](/docs/connections/sources/catalog/libraries/mobile/ios/){:target="_blank"}, [Android](/docs/connections/sources/catalog/libraries/mobile/android/){:target="_blank"}, or [Swift](/docs/connections/sources/catalog/libraries/mobile/apple/){:target="_blank"}) and sends it from Segment's servers to Facebook App Events servers. 
 
-The iOS device-mode connection for the Facebook App Events destination is open-source and can be viewed on GitHub [here](https://github.com/segment-integrations/analytics-ios-integration-facebook-app-events). 
+The iOS device-mode connection for the Facebook App Events destination is open source and [available on GitHub](https://github.com/segment-integrations/analytics-ios-integration-facebook-app-events){:target="_blank"}. 
 
-Segment also has an (Analytics Swift Facebook App Events Plugin)[https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/facebook-app-events-swift/) for the Facebook App Events device-mode connection available. The open-source integration code can be viewed on GitHub [here](https://github.com/segment-integrations/analytics-swift-facebook-app-events){:target="_blank"}. 
+Segment also has an [Analytics Swift Facebook App Events Plugin](/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/facebook-app-events-swift/) for the Facebook App Events device-mode connection available. You can view the [open-source integration code on GitHub](https://github.com/segment-integrations/analytics-swift-facebook-app-events){:target="_blank"}. 
 
 
 ## Other Facebook Destinations Supported by Segment

--- a/src/connections/destinations/catalog/facebook-app-events/index.md
+++ b/src/connections/destinations/catalog/facebook-app-events/index.md
@@ -4,9 +4,11 @@ rewrite: true
 strat: facebook
 id: 56fc7e4680412f644ff12fb9
 ---
-[Facebook App Events](https://developers.facebook.com/docs/app-events){:target="_blank"} collects required information from one of Segment's mobile SDKs ([iOS](/docs/connections/sources/catalog/libraries/mobile/ios/){:target="_blank"}, [Android](/docs/connections/sources/catalog/libraries/mobile/android/){:target="_blank"}, or [Swift](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/){:target="_blank"}) and sends it from Segment's servers to Facebook App Events servers. This *server-to-server* connection will not work with our server-side libraries. 
+[Facebook App Events](https://developers.facebook.com/docs/app-events){:target="_blank"} collects required information from one of Segment's mobile SDKs ([iOS](/docs/connections/sources/catalog/libraries/mobile/ios/){:target="_blank"}, [Android](/docs/connections/sources/catalog/libraries/mobile/android/){:target="_blank"}, or [Swift](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/){:target="_blank"}) and sends it from Segment's servers to Facebook App Events servers. 
 
-The Facebook App Events Destination is open-source. You can browse the code on GitHub for [iOS](https://github.com/segment-integrations/analytics-ios-integration-facebook-app-events){:target="_blank"}.
+The iOS device-mode connection for the Facebook App Events destination is open-source and can be viewed on [here](https://github.com/segment-integrations/analytics-ios-integration-facebook-app-events). 
+
+Segment also has an (Analytics Swift Facebook App Events Plugin)[https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/facebook-app-events-swift/) for the Facebook App Events device-mode connection available. The open-source integration code can be viewed on GitHub [here](https://github.com/segment-integrations/analytics-swift-facebook-app-events){:target="_blank"}. 
 
 
 ## Other Facebook Destinations Supported by Segment


### PR DESCRIPTION
### Proposed changes
- It looks like this (plugin)[https://github.com/segment-integrations/analytics-swift-facebook-app-events] was built for Facebook App Events for Swift, so Swift is also supported. 

### Merge timing
- ASAP once approved
