### PR TITLE
Add supported destinations

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/apple/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/index.md
@@ -122,9 +122,9 @@ Once you've installed the Analytics-Swift library, you can start collecting data
 ## Destinations
 Destinations are the business tools or apps that Segment forwards your data to. Adding Destinations allow you to act on your data and learn more about your customers in real time.
 
-Check out our documentation for (Device-mode Destinations)[https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/] for a full list of (suppoprted device-mode plugins)[https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/#supported-device-mode-plugins].  
+Check out our documentation for [Device-mode Destinations](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/) for a full list of [suppoprted device-mode plugins](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/#supported-device-mode-plugins).  
 
-Browse our (Cloud-mode destinations)[https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/cloud-mode-destinations/] for a full list of available cloud-mode destinations that Swift supports. 
+Browse our [Cloud-mode destinations](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/cloud-mode-destinations/) for a full list of available cloud-mode destinations that Swift supports. 
 
 <br>Segment offers support for two different types of Destinations, learn more about the differences between the two [here]().
 

--- a/src/connections/sources/catalog/libraries/mobile/apple/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/index.md
@@ -122,9 +122,9 @@ Once you've installed the Analytics-Swift library, you can start collecting data
 ## Destinations
 Destinations are the business tools or apps that Segment forwards your data to. Adding Destinations allow you to act on your data and learn more about your customers in real time.
 
-Check out our documentation for [Device-mode Destinations](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/) for a full list of [suppoprted device-mode plugins](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/#supported-device-mode-plugins).  
+See Segment's documentation for [device-mode destinations](/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/) for a full list of [supported device-mode plugins](/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/#supported-device-mode-plugins).  
 
-Browse our [Cloud-mode destinations](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/cloud-mode-destinations/) for a full list of available cloud-mode destinations that Swift supports. 
+See Segment's [cloud-mode destinations](/docs/connections/sources/catalog/libraries/mobile/apple/cloud-mode-destinations/) for a full list of available cloud-mode destinations that Swift supports. 
 
 <br>Segment offers support for two different types of Destinations, learn more about the differences between the two [here]().
 

--- a/src/connections/sources/catalog/libraries/mobile/apple/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/index.md
@@ -122,6 +122,10 @@ Once you've installed the Analytics-Swift library, you can start collecting data
 ## Destinations
 Destinations are the business tools or apps that Segment forwards your data to. Adding Destinations allow you to act on your data and learn more about your customers in real time.
 
+Check out our documentation for (Device-mode Destinations)[https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/] for a full list of (suppoprted device-mode plugins)[https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/destination-plugins/#supported-device-mode-plugins].  
+
+Browse our (Cloud-mode destinations)[https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/apple/cloud-mode-destinations/] for a full list of available cloud-mode destinations that Swift supports. 
+
 <br>Segment offers support for two different types of Destinations, learn more about the differences between the two [here]().
 
 <div class="double">


### PR DESCRIPTION
### Proposed changes

- Add link to supported device-mode and cloud-mode destinations under the Destinations subsection in our Swift docs, so that customers know which Destinations are supported. 
- Customers can click on device-mode destinations and cloud-mode destinations on the left-hand side of the page, but I thought it would be helpful to reference those pages under the Destinations subsection just in case customers miss the navigation links on the left for any reason.

### Merge timing
- ASAP once approved?

