### PR TITLE
Add note about sending Track events with a custom Group Key to Mixpanel

### DIFF
--- a/src/connections/destinations/catalog/actions-mixpanel/index.md
+++ b/src/connections/destinations/catalog/actions-mixpanel/index.md
@@ -135,3 +135,8 @@ If you want to confirm, you can configure the new destination to point to a diff
 
 If the Mixpanel (Actions) destination uses $group_id as the group key, ensure that the mappings handling your `track` events have the field for **Group ID** mapped to a valid value. By default, this field maps to the event variable `context.groupId`.
 
+To send Track events with a custom Group Key, you can include the key as a property of Track events. For example:
+```js
+analytics.track('Example Event', { custom_group_key : 'group1' });
+```
+


### PR DESCRIPTION
### Proposed changes
Currently, our Mixpanel (Actions) destination uses `$group_id` as the standard Group Key for Track events. Integration code here:
- https://github.com/segmentio/action-destinations/blob/main/packages/destination-actions/src/destinations/mixpanel/trackEvent/functions.ts#L40

 
However, a customer asked about how can they send a custom Group Key in this case. And I discovered a workaround for this - all they need to do is to include their custom Group Key as a property of Track events. 

For example (I'm using `company_id` as the custom Group Key):

```
analytics.track('Example Event', { company_id: 'group1' });
```

### Merge timing
ASAP once approved
