### PR TITLE
After renewal, Engage spaces are in disabled state.

### DIFF
--- a/src/engage/faqs.md
+++ b/src/engage/faqs.md
@@ -130,3 +130,6 @@ If your team would like to avoid receiving the notifications for transient failu
 
 Each step of a Journey is an Engage audience under the hood. The conditions stack, so a user must be a member of the previous step (audience) and meet all conditions to be added to subsequent steps. However, if the user no longer meets entry conditions for a particular step, they'll exit and you'll see the user count reduced. For any subsequent steps a user is still a part of, they'll remain until they no longer meet entry conditions. 
 
+## Why is my Engage space not showing over my workspace after renewing with a new plan?
+
+If the Engage plan was downgraded from any of the Engage plan to Unify/Unify+ the spaces limit is set back to zero until overridden in billing dashboard. Please contact the support team to request provision for Space access and enable the available Engage space.


### PR DESCRIPTION
## Why is the user count in a journey step greater than the entry/previous step of the journey?

Each step of a Journey is an Engage audience under the hood. The conditions stack, so a user must be a member of the previous step (audience) and meet all conditions to be added to subsequent steps. However, if the user no longer meets entry conditions for a particular step, they'll exit and you'll see the user count reduced. For any subsequent steps a user is still a part of, they'll remain until they no longer meet entry conditions.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
