### PR TITLE
Update Audit Trail docs [DOC-752]

### DIFF
--- a/src/_data/products.yml
+++ b/src/_data/products.yml
@@ -101,7 +101,7 @@ items:
     add-on: false
 - product_display_name: Audit Trail
   slug: audit-trail
-  plan-note: "Audit Trail is available as an add-on for customers with the Business plan."
+  plan-note: "Audit Trail is only available in Business plan workspaces."
   plans:
     free: false
     team: false

--- a/src/segment-app/iam/audit-trail.md
+++ b/src/segment-app/iam/audit-trail.md
@@ -1,6 +1,7 @@
 ---
 title: Audit Trail
 plan: audit-trail
+hide_toc: true
 ---
 
 Workspace Owners can view user and system activity in the Audit Trail. You can filter for specific actions or actors to see who made changes to specific resources in the app. Actors can include both logged-in users as well as access tokens. 

--- a/src/segment-app/iam/audit-trail.md
+++ b/src/segment-app/iam/audit-trail.md
@@ -1,29 +1,56 @@
 ---
 title: Audit Trail
 plan: audit-trail
-hide_toc: true
 ---
 
-Workspace Owners can view user and system activity in the Audit Trail. You can filter for specific actions or actors to see who made changes to specific resources in the app. Actors can include both logged-in users as well as access tokens. 
+The Audit Trail allows you can view user and system activity, filter activity for specific actions or actors, and export your data to an event streams source or CSV file. 
 
-You can export the information to a CSV for download, or [forward the activity to a Segment source](#audit-forwarding). For example, you can forward Audit Trail activity to set up real-time Slack alerts and quickly revert changes that could cause unwanted downstream effects, such as a user unintentionally disabling a warehouse.
+> info "Viewing the Audit Trail requires Workspace Owner permissions"
+> You must have the Workspace Owner role to view the Audit Trail page. For more information about roles and permissions within Segment, see the [Roles documentation](/docs/segment-app/iam/roles/). 
 
 To view the Audit Trail:
 1. From the Segment app, select **Settings**. 
 2. From the Settings tab, select **Admin**. 
 
-You can find a list of all events surfaced in the Audit Trail by accessing Audit Trail, clicking **Filters**, and selecting the **Events** dropdown. 
+## Audit Trail events
+
+The Audit Trail returns information about the following Segment product areas: 
+
+- Sources
+- Functions
+- Warehouses
+- Destinations
+- Storage
+- Tracking Plans
+- Destination Filters
+- Transformations
+- Audiences
+- Computed Traits
+- Engage Warehouse Sources
+- Profiles Sync
+- Spaces
+- Users
+- Journeys
+- Broadcasts 
+- Workspace
+<!--- IG, 11/2023: Add consent to this list when this goes to public beta (q1 '24?)--->
+
+To find a list of all events surfaced in the Audit Trail: open the Audit Trail, click **Filters**, and select the **Events** dropdown. 
 
 <!--- IG, 11/2023: PM for CX suggested directing to the Filter part in the app for a full list of events. PAPI support for a list of all events is on the roadmap, so at some point we can probably build a list automagically instead of using the Filters workaround --->
 
+## Filtering events
+
+The Filters dropdown allows you to refine your search results by filtering by actions or actors to see who made changes on specific resources in the app. Actors include both logged-in users and access tokens. 
+
 ## Audit forwarding
 
-You can forward events in your workspace to an [event streams source](/docs/connections/sources/#event-streams-sources).
+You can forward events in your workspace to an [event streams source](/docs/connections/sources/#event-streams-sources) to set up real-time alerts and quickly revert changes (like a user unintentionally disabling a warehouse) that could cause unwanted downstream effects.
 
-To forward Audit Trail events:
+> info "Segment recommends creating a dedicated source for audit trail events"
+> Segment recommends forwarding all events to an instance of the [HTTP API](/docs/connections/sources/catalog/libraries/server/http-api/) source.  Segment passes all forwarded events through its entire processing pipeline. This ensures that Tracking Plans, Filters, and other features work with the audit events, and also ensures you can send those events to multiple downstream destinations.
+
+To forward Audit Trail events to an event streams source:
 1. Navigate to **Settings > Workspace Settings > Audit Forwarding**.
 2. Select or create an [event streams source](/docs/connections/sources/#event-streams-sources) to which you'll forward workspace events.
 3. Toggle the setting to **On** and click **Save Changes**.
-
-> info "Segment recommends creating a dedicated source for audit trail events"
-> Segment recommends forwarding all events to one instance of the [HTTP API](/docs/connections/sources/catalog/libraries/server/http-api/) source.  Segment passes all forwarded events through its entire processing pipeline. This ensures that Tracking Plans, Filters, and other features work with the audit events, and also ensures you can send those events to multiple downstream destinations.

--- a/src/segment-app/iam/audit-trail.md
+++ b/src/segment-app/iam/audit-trail.md
@@ -3,104 +3,26 @@ title: Audit Trail
 plan: audit-trail
 ---
 
-Segment offers an in-app 90 day Audit Trail for Business Tier accounts. If you are a Workspace Owner, you view user and system activity in your workspace settings, in the "Audit Trail" tab under "Admin".
+Workspace Owners can view user and system activity in the Audit Trail. You can filter for specific actions or actors to see who made changes to specific resources in the app. Actors can include both logged-in users as well as access tokens. 
 
-You can filter for specific actions or actors to see who made changes on specific resources in the app. Actors can include both logged-in users as well as access tokens. You can export the information to a CSV for download, or forward the activity to a Segment source. For example, you can forward audit trail activity to set up real-time Slack alerts and quickly revert changes that could cause unwanted downstream effects, such as a user unintentionally disabling a warehouse.
+You can export the information to a CSV for download, or [forward the activity to a Segment source](#audit-forwarding). For example, you can forward Audit Trail activity to set up real-time Slack alerts and quickly revert changes that could cause unwanted downstream effects, such as a user unintentionally disabling a warehouse.
 
-The Audit Trail includes information on the following activity:
-### Access Management
-*   User Invite Sent
-*   User Invite Deleted
-*   User Invite Accepted
-*   User Added via SSO
-*   User Removed
-*   User Group Created
-*   User Group Updated
+To view the Audit Trail:
+1. From the Segment app, select **Settings**. 
+2. From the Settings tab, select **Admin**. 
 
-### Source
-*   Source Created
-*   Source Enabled
-*   Source Disabled
-*   Source Modified
-*   Source Deleted
+You can find a list of all events surfaced in the Audit Trail by accessing Audit Trail, clicking **Filters**, and selecting the **Events** dropdown. 
 
-### Integrations
-*   Integrations Created
-*   Integrations Enabled
-*   Integrations Disabled
-*   Integrations Modified
-*   Integrations Deleted
-
-### Functions
-*   Source Function Created
-*   Source Function Deleted
-*   Source Function Modified
-*   Destination Function Created
-*   Destination Function Deleted
-*   Destination Function Modified
-
-### Destination Filters
-*   Destination Filters Created
-*   Destination Filters Modified
-*   Destination Filters Deleted
-
-### Warehouses
-*   Warehouses Created
-*   Warehouses Enabled
-*   Warehouses Disabled
-*   Warehouses Modified
-*   Warehouses Deleted
-*   Warehouse Run Failed
-
-### Protocols
-*   Tracking Plan Created
-*   Tracking Plan Modified
-*   Tracking Plan Deleted
-*   Source Connected to Tracking Plan
-*   Source Disconnected From Tracking Plan
-*   Tracking Plan Inferred
-*   Tracking Plan New Event Blocked
-*   Tracking Plan New Event Allowed
-*   Tracking Plan New Group Trait Omitted
-*   Tracking Plan New Identify Trait Omitted
-*   Tracking Plan New Track Property Omitted
-*   Tracking Plan Operations Updated
-*   Tracking Plan Updated
-*   Violations Detected
-
-### Engage
-*   Source Connected To Space
-*   Source Disconnected From Space
-*   Space Created
-*   Space Modified
-*   Space Deleted
-*   Computed Trait Created
-*   Computed Trait Modified
-*   Computed Trait Deleted
-*   Computed Trait CSV Downloaded
-*   Computed Trait Run Failed
-*   Computed Trait Destination Sync Failed
-*   Audience Created
-*   Audience Modified
-*   Audience Deleted
-*   Audience CSV Downloaded
-*   Audience Run Failed
-*   Audience Destination Sync Failed
-*   Engage Warehouse Source Created
-*   Engage Warehouse Source Modified
-*   Engage Warehouse Source Deleted
-
+<!--- IG, 11/2023: PM for CX suggested directing to the Filter part in the app for a full list of events. PAPI support for a list of all events is on the roadmap, so at some point we can probably build a list automagically instead of using the Filters workaround --->
 
 ## Audit forwarding
 
-You can forward events in your workspace to supported sources that you have configured in the workspace.
+You can forward events in your workspace to an [event streams source](/docs/connections/sources/#event-streams-sources).
 
 To forward Audit Trail events:
-
 1. Navigate to **Settings > Workspace Settings > Audit Forwarding**.
 2. Select or create an [event streams source](/docs/connections/sources/#event-streams-sources) to which you'll forward workspace events.
 3. Toggle the setting to **On** and click **Save Changes**.
 
 > info "Segment recommends creating a dedicated source for audit trail events"
 > Segment recommends forwarding all events to one instance of the [HTTP API](/docs/connections/sources/catalog/libraries/server/http-api/) source.  Segment passes all forwarded events through its entire processing pipeline. This ensures that Tracking Plans, Filters, and other features work with the audit events, and also ensures you can send those events to multiple downstream destinations.
-

--- a/src/segment-app/iam/audit-trail.md
+++ b/src/segment-app/iam/audit-trail.md
@@ -3,7 +3,7 @@ title: Audit Trail
 plan: audit-trail
 ---
 
-The Audit Trail allows you can view user and system activity, filter activity for specific actions or actors, and export your data to an event streams source or CSV file. 
+The Audit Trail allows you to view user and system activity, filter activity for specific actions or actors, and export your data to an event streams source or CSV file. 
 
 > info "Viewing the Audit Trail requires Workspace Owner permissions"
 > You must have the Workspace Owner role to view the Audit Trail page. For more information about roles and permissions within Segment, see the [Roles documentation](/docs/segment-app/iam/roles/). 
@@ -35,19 +35,19 @@ The Audit Trail returns information about the following Segment product areas:
 - Workspace
 <!--- IG, 11/2023: Add consent to this list when this goes to public beta (q1 '24?)--->
 
-To find a list of all events surfaced in the Audit Trail, open the Audit Trail, click **Filters**, and select the **Events** dropdown. 
+To view a list of all events Segment surfaces in the Audit Trail, open the Audit Trail, click **Filters**, and select the **Events** dropdown. 
 
 <!--- IG, 11/2023: PM for CX suggested directing to the Filter part in the app for a full list of events. PAPI support for a list of all events is on the roadmap, so at some point we can probably build a list automagically instead of using the Filters workaround --->
 
 ## Filtering events
 
-The Filters dropdown allows you to refine your search results by filtering by actions or actors to see who made changes on specific resources in the app. Actors include both logged-in users and access tokens. 
+Use the Filters dropdown to refine your search results and filter by actions or actors to see who made changes on specific resources in the app. Actors include both logged-in users and access tokens. 
 
 ## Audit forwarding
 
 You can forward events in your workspace to an [event streams source](/docs/connections/sources/#event-streams-sources) to set up real-time alerts and quickly revert changes (like a user unintentionally disabling a warehouse) that could cause unwanted downstream effects.
 
-> info "Segment recommends creating a dedicated source for audit trail events"
+> info "Segment recommends creating a dedicated source for Audit Trail events"
 > Segment recommends forwarding all events to an instance of the [HTTP API](/docs/connections/sources/catalog/libraries/server/http-api/) source.  Segment passes all forwarded events through its entire processing pipeline. This ensures that Tracking Plans, Filters, and other features work with the audit events, and also ensures you can send those events to multiple downstream destinations.
 
 To forward Audit Trail events to an event streams source:

--- a/src/segment-app/iam/audit-trail.md
+++ b/src/segment-app/iam/audit-trail.md
@@ -35,7 +35,7 @@ The Audit Trail returns information about the following Segment product areas:
 - Workspace
 <!--- IG, 11/2023: Add consent to this list when this goes to public beta (q1 '24?)--->
 
-To find a list of all events surfaced in the Audit Trail: open the Audit Trail, click **Filters**, and select the **Events** dropdown. 
+To find a list of all events surfaced in the Audit Trail, open the Audit Trail, click **Filters**, and select the **Events** dropdown. 
 
 <!--- IG, 11/2023: PM for CX suggested directing to the Filter part in the app for a full list of events. PAPI support for a list of all events is on the roadmap, so at some point we can probably build a list automagically instead of using the Filters workaround --->
 


### PR DESCRIPTION
### Proposed changes
PM for Consent noted that the Audit Trail docs didn't include a full list of events - I updated them to remove the old list and tentatively [replaced the list of events with product areas](https://twilio.slack.com/archives/C04HNRG3VF1/p1698790770117419), as support for a PAPI-generated list of events the Audit Trail controls for is on the roadmap. Updated the plan note to reflect that [it's no longer an addon for BT customers](https://twilio.slack.com/archives/C04HNRG3VF1/p1699907416367319). Also did some Vale fixes and IA work. 

### Merge timing
ASAP

### Related issues (optional)
