### PR TITLE
Add faq that date string need to be ISO-8601 for time conditions to work

### DIFF
--- a/src/engage/faqs.md
+++ b/src/engage/faqs.md
@@ -125,6 +125,9 @@ An audience/computed trait Run or a Sync may fail on its first attempt, but Enga
 
 If your team would like to avoid receiving the notifications for transient failures, please **[reach out to support](https://segment.com/help/contact/)**, who upon request can disable transient failure notifications.
 
+## Why is the time condition, such as a rolling time window condition of within last N number of days, configured on a trait not working in my audience?
+
+For time conditions to work on a trait, please check that the date string of the trait is in ISO-8601 format. Further information on the date string requirement is mentioned in [document on Spec: Common Fields regarding timestamp](https://segment.com/docs/connections/spec/common/#timestamps).
 
 ## Why is the user count in a journey step greater than the entry/previous step of the journey?
 


### PR DESCRIPTION
### Proposed changes
There have been several tickets where customer's audiences did not work due to time conditions on traits where the date string is not in ISO-8601 format.

Added the following FAQ:

"Why is the time condition, such as a rolling time window condition of within last N number of days, configured on a trait not working in my audience?

For time conditions to work on a trait, please check that the date string of the trait is in ISO-8601 format. Further information on the date string requirement is mentioned in [document on Spec: Common Fields regarding timestamp](https://segment.com/docs/connections/spec/common/#timestamps)."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
Example tickets:
- https://segment.zendesk.com/agent/tickets/523292
- https://segment.zendesk.com/agent/tickets/486019
- https://segment.zendesk.com/agent/tickets/493660

