### PR TITLE
Remove Outdated Journeys Section

### DIFF
--- a/src/engage/journeys/faq-best-practices.md
+++ b/src/engage/journeys/faq-best-practices.md
@@ -30,14 +30,6 @@ Unlike lists associated with Engage Audiences, users who are added to a journey 
 
 Save your Journey in a draft state so that you can review before you publish it. Once you publish a Journey, you cannot edit select portions of a Journey and Journeys sends data to destinations.
 
-### Make a copy to edit published Journeys
-
-Once you publish a Journey, you cannot add, delete, or edit the steps within the Journey. You can edit the Journey name, description, and destinations.
-
-To edit the steps within a published Journey, make a copy of the Journey you wish to edit, make adjustments, delete the original Journey, and then publish the revised Journey.
-
-When you do this, the key used for syncing to destinations will be different from the copied Journey. Make sure you change the reference key used in the downstream destinations accordingly.
-
 ### Know how to incorporate historical data
 
 Aside from the entry condition, all Journey step conditions are triggered by future events and existing trait memberships. Event-based conditions only evaluate events that occur *after* the Journey is published.


### PR DESCRIPTION
### Proposed changes

- Removed a section from the Journeys Best Practices page.  The section said that you have to make a copy of a journey to edit it, which is no longer the case.

### Merge timing

- ASAP once approved.