### PR TITLE
Update Kotlin device mode plugin docs to address using classic destination

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/destination-plugins/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/destination-plugins/index.md
@@ -85,6 +85,10 @@ plugins:
 
 Analytics Kotlin uses its timeline/plugin architecture to support sending data to bundled SDKs when a Cloud Mode connection is not possible. Destination Plugins are similar to traditional Device Mode integrations available in Analytics Android in that Segment makes calls directly to the destination tool’s API from the device. However, Destination Plugins are more customizable, giving you the ability to control and enrich your data at a much more granular level on the device itself. 
 
+> info "Choosing the right destination"
+> Our device mode destination [plugins](https://segment.com/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-plugin-architecture/){:target='_blank’} were built to be used with the classic/legacy destinations, not Actions. The exception to this is the Amplitude plugin. This is a session plugin meant to be used with Amplitude Actions. If a classic/legacy destinations is in maintenance mode, we will still continue to make updates pertaining to the mobile plugins, but not the server or web components.
+> If you run into any issues setting up your destination, please don't hesitate to reach out to support.
+
 ## Device-mode Vs. Cloud-Mode 
 Analytics Kotlin allows you to choose how you send data to Segment and your connected destinations from your app. There are two ways to send data:
 

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/destination-plugins/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/destination-plugins/index.md
@@ -86,8 +86,8 @@ plugins:
 Analytics Kotlin uses its timeline/plugin architecture to support sending data to bundled SDKs when a Cloud Mode connection is not possible. Destination Plugins are similar to traditional Device Mode integrations available in Analytics Android in that Segment makes calls directly to the destination tool’s API from the device. However, Destination Plugins are more customizable, giving you the ability to control and enrich your data at a much more granular level on the device itself. 
 
 > info "Choosing the right destination"
-> Our device mode destination [plugins](https://segment.com/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-plugin-architecture/){:target='_blank’} were built to be used with the classic/legacy destinations, not Actions. The exception to this is the Amplitude plugin. This is a session plugin meant to be used with Amplitude Actions. If a classic/legacy destinations is in maintenance mode, we will still continue to make updates pertaining to the mobile plugins, but not the server or web components.
-> If you run into any issues setting up your destination, please don't hesitate to reach out to support.
+> Segment built device mode destination [plugins](https://segment.com/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-plugin-architecture/){:target='_blank’} to be used with the classic/legacy destinations, not Actions destinations. The exception to this is the Amplitude plugin. The Amplitude plugin is a session plugin meant to be used with Amplitude Actions. If a classic/legacy destinations is in maintenance mode, Segment continues to make updates pertaining to the mobile plugins, but not the server or web components.
+> If you run into any issues setting up your destination, reach out to support.
 
 ## Device-mode Vs. Cloud-Mode 
 Analytics Kotlin allows you to choose how you send data to Segment and your connected destinations from your app. There are two ways to send data:


### PR DESCRIPTION


### Proposed changes

Added section to Kotlin device mode plugin docs to address using classic/legacy destinations with the plugins and to note that maintenance mode does not apply to these plugins. 

### Merge timing

- ASAP once approved

### Related issues (optional)

n/a
