### PR TITLE
Updating unique list to reflect the last 50 received 

### DIFF
--- a/src/unify/Traits/computed-traits.md
+++ b/src/unify/Traits/computed-traits.md
@@ -107,7 +107,7 @@ Account-level examples:
 
 ### Unique List
 
-Unique list computed traits will output a **list of unique values** in alphabetical order for an **event property**. This is helpful to understand the different types of products or content that a customer or users in an account have interacted with or purchased. Customers are creating traits like `unique_product_categories_viewed` and sending them to email marketing tools and accessing them through the Profiles API for in-app personalization.
+Unique list computed traits will output a **list of the 50 last received unique values** in alphabetical order for an **event property**. This is helpful to understand the different types of products or content that a customer or users in an account have interacted with or purchased. Customers are creating traits like `unique_product_categories_viewed` and sending them to email marketing tools and accessing them through the Profiles API for in-app personalization.
 
 Example use cases:
 - Unique products purchased


### PR DESCRIPTION

### Proposed changes
Since unique lists only return 50 values, there can sometimes be confusion as to if these were the first 50 or last 50 received.  This change clarifies that.
Here is the proposed change:

Unique list computed traits will output a **list of the 50 last received unique values** in alphabetical order for an **event property**.


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
