### PR TITLE
Add note on returning event object in handler

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -100,8 +100,7 @@ async function onTrack(event) {
 
 To change which event type the handler listens to, you can rename it to the name of the message type. For example, if you rename this function `onIdentify`, it listens for "Identify" events instead.
 
-> info ""
-> To ensure the Destination processes an event payload modified by the Function, return the `event` object at the handler's end.
+To ensure the Destination processes an event payload modified by the function, return the `event` object at the handler's end.
 
 > info ""
 > Functions' runtime includes a `fetch()` polyfill using a `node-fetch` package. Check out the [node-fetch documentation](https://www.npmjs.com/package/node-fetch){:target="_blank"} for usage examples.

--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -101,6 +101,9 @@ async function onTrack(event) {
 To change which event type the handler listens to, you can rename it to the name of the message type. For example, if you rename this function `onIdentify`, it listens for "Identify" events instead.
 
 > info ""
+> To ensure the Destination processes an event payload modified by the Function, return the `event` object at the handler's end.
+
+> info ""
 > Functions' runtime includes a `fetch()` polyfill using a `node-fetch` package. Check out the [node-fetch documentation](https://www.npmjs.com/package/node-fetch){:target="_blank"} for usage examples.
 
 ### Errors and error handling


### PR DESCRIPTION
### Proposed changes

Docs don't currently call out that the event object needs to be returned at the end of a method handler in order for the connected destination to proceed with processing the Function-modified event payload. 

Added a note under the section to code the insert function that mentions this. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
