### PR TITLE
Update Public API link

### DIFF
--- a/src/engage/user-subscriptions/set-user-subscriptions.md
+++ b/src/engage/user-subscriptions/set-user-subscriptions.md
@@ -55,7 +55,7 @@ With Segment's APIs, you can manage user subscriptions programmatically on a rea
 
 ### Choosing between the Identify call and the Public API
 
-To update Engage user subscriptions with Segment's APIs, first choose between [the Identify call](/docs/connections/spec/identify/), for non-critical subscription updates, or the [Public API](https://api.segmentapis.com/docs/spaces/#replace-messaging-subscriptions-in-spaces){:target="_blank"}, for critical updates that require immediate confirmation, like unsubscribes.
+To update Engage user subscriptions with Segment's APIs, first choose between [the Identify call](/docs/connections/spec/identify/), for non-critical subscription updates, or the [Public API](https://docs.segmentapis.com/tag/Spaces#operation/replaceMessagingSubscriptionsInSpaces){:target="_blank"}, for critical updates that require immediate confirmation, like unsubscribes.
 
 When you use the Identify call, Segment replies with a standard HTTP `200 OK` status response code if it successfully received the request. Because the Identify call updates user traits asynchronously, though, the `200 OK` code indicates that Segment has received, but not yet processed, the request. As a result, use the Identify call for non-critical subscription updates, like form signups on your website or adding a subscription from within the user's notification center.
 


### PR DESCRIPTION
### Proposed changes

Current link does not point to correct Public API documentation to Replace Messaging Subscriptions in Spaces: https://docs.segmentapis.com/tag/Spaces#operation/replaceMessagingSubscriptionsInSpaces

Updated docs with working link

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
