### PR TITLE
Add Bucket Web (Actions) documentation

### DIFF
--- a/src/connections/destinations/catalog/bucket-web/index.md
+++ b/src/connections/destinations/catalog/bucket-web/index.md
@@ -48,7 +48,7 @@ If you are running with strict Content Security Policies active on your website,
 | script-src-elem | https://cdn.jsdelivr.net        | bootstrap         | Loads the Bucket tracking SDK from a CDN                                                                                                 |
 | connect-src     | https://tracking.bucket.co      | tracking          | Used for all tracking methods: `analytics.identify()`, `analytics.group()` and `analytics.track()`                                       |
 | connect-src     | https://livemessaging.bucket.co | live satisfaction | Server sent events from the Bucket Live Feedback service, which allows for automatically collecting feedback when a user used a feature. |
-| style-src       | 'unsafe-inline'                 | feedback UI       | The feedback UI is styled with inline script tags. Not having this directive results unstyled HTML elements.                             |
+| style-src       | 'unsafe-inline'                 | feedback UI       | The feedback UI is styled with inline styles. Not having this directive results unstyled HTML elements.                                  |
 
 As HTTP-header:
 

--- a/src/connections/destinations/catalog/bucket-web/index.md
+++ b/src/connections/destinations/catalog/bucket-web/index.md
@@ -1,0 +1,60 @@
+---
+title: 'Bucket Web (Actions) Destination'
+hidden: true
+id: 656dc9330d1863a8870bacd1
+published: true
+beta: true
+---
+
+{% include content/plan-grid.md name="actions" %}
+
+[Bucket](https://bucket.co/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="blank"} is feature-focused analytics. Bucket empowers software teams with a repeatable approach to shipping features that satisfy customers.
+
+This destination is maintained by Bucket. For any issues with the destination, [contact the Bucket Support team](mailto:support@bucket.co).
+
+{% include content/ajs-upgrade.md %}
+
+> warning ""
+> If you are using both the "Bucket Web (Actions)"-destination and the server side ["Bucket"-destination](/docs/connections/destinations/catalog/bucket/) on the same source, avoid duplicate event tracking by disabling the "Track Event"-mapping in "Bucket Web (Actions)".
+
+
+## Benefits of Bucket Web (Actions) vs Bucket Classic
+
+Bucket Web (Actions) provides the following benefits over the classic Bucket destination:
+
+- **Clearer mapping of data**. Actions-based destinations enable you to define the mapping between the data Segment receives from your source, and the data Segment sends to the destination.
+- Automatically enables [Live Satisfaction](https://bucket.co/live-satisfaction) prompts in your app, giving you fully automated customer satisfaction scores and feedback on your features.
+
+
+## Getting Started
+
+1. From the Destinations catalog page in the Segment App, click **Add Destination**.
+2. Search for `"Bucket Web"` in the Destinations Catalog, and select the `Bucket Web (Actions)` destination.
+3. Choose which Source should send data to the Bucket destination.
+4. Go to [Bucket's Settings](https://app.bucket.co){:target="blank"} and find and copy the "Tracking Key" on the "Tracking" page.
+5. Enter the "Tracking Key" as "Tracking Key" in the "Bucket Web (Actions)" destination settings in Segment.
+
+{% include components/actions-fields.html %}
+
+## Content Security Policies (CSP)
+
+If you are running with strict Content Security Policies active on your website, you will need to enable these directives in order to use this destination:
+
+| Directive       | Values                          | Module            | Reason                                                                                                                                   |
+| --------------- | ------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| script-src-elem | https://cdn.jsdelivr.net        | bootstrap         | Loads the Bucket tracking SDK from a CDN                                                                                                 |
+| connect-src     | https://tracking.bucket.co      | tracking          | Used for all tracking methods: `analytics.identify()`, `analytics.group()` and `analytics.track()`                                       |
+| connect-src     | https://livemessaging.bucket.co | live satisfaction | Server sent events from the Bucket Live Feedback service, which allows for automatically collecting feedback when a user used a feature. |
+| style-src       | 'unsafe-inline'                 | feedback UI       | The feedback UI is styled with inline script tags. Not having this directive results unstyled HTML elements.                             |
+
+As HTTP-header:
+
+```http
+Content-Security-Policy: script-src-elem https://cdn.jsdelivr.net; connect-src https://livemessaging.bucket.co https://tracking.bucket.co; style-src 'unsafe-inline'
+```
+
+As `<meta>`-tag:
+
+```html
+<meta http-equiv="Content-Security-Policy" content="script-src-elem https://cdn.jsdelivr.net; connect-src https://livemessaging.bucket.co https://tracking.bucket.co; style-src 'unsafe-inline'">
+```

--- a/src/connections/destinations/catalog/bucket-web/index.md
+++ b/src/connections/destinations/catalog/bucket-web/index.md
@@ -15,7 +15,6 @@ versions:
 
 This destination is maintained by Bucket. For any issues with the destination, [contact the Bucket Support team](mailto:support@bucket.co).
 
-{% include content/ajs-upgrade.md %}
 
 > warning ""
 > If you are using both the "Bucket Web (Actions)"-destination and the server side ["Bucket"-destination](/docs/connections/destinations/catalog/bucket/) on the same source, avoid duplicate event tracking by disabling the "Track Event"-mapping in "Bucket Web (Actions)".

--- a/src/connections/destinations/catalog/bucket-web/index.md
+++ b/src/connections/destinations/catalog/bucket-web/index.md
@@ -4,6 +4,9 @@ hidden: true
 id: 656dc9330d1863a8870bacd1
 published: true
 beta: true
+versions:
+  - name: "Bucket (Classic)"
+    link: '/docs/connections/destinations/catalog/bucket'
 ---
 
 {% include content/plan-grid.md name="actions" %}

--- a/src/connections/destinations/catalog/bucket-web/index.md
+++ b/src/connections/destinations/catalog/bucket-web/index.md
@@ -25,7 +25,7 @@ This destination is maintained by Bucket. For any issues with the destination, [
 Bucket Web (Actions) provides the following benefits over the classic Bucket destination:
 
 - **Clearer mapping of data**. Actions-based destinations enable you to define the mapping between the data Segment receives from your source, and the data Segment sends to the destination.
-- Automatically enables [Live Satisfaction](https://bucket.co/live-satisfaction) prompts in your app, giving you fully automated customer satisfaction scores and feedback on your features.
+- Automatically enables [Live Satisfaction](https://bucket.co/live-satisfaction){:target="_blank"} prompts in your app, giving you fully automated customer satisfaction scores and feedback on your features.
 
 
 ## Getting Started

--- a/src/connections/destinations/catalog/bucket/index.md
+++ b/src/connections/destinations/catalog/bucket/index.md
@@ -18,7 +18,7 @@ This destination is maintained by Bucket. For any issues with the destination, [
 1. From the Destinations catalog page in the Segment App, click **Add Destination**.
 2. Search for "Bucket" in the Destinations Catalog, and select the Bucket destination.
 3. Choose which Source should send data to the Bucket destination.
-4. Go to [Bucket's Settings](https://bucket.co){:target="blank"} and find and copy the "Tracking Key" under Settings.
+4. Go to [Bucket's Settings](https://app.bucket.co){:target="blank"} and find and copy the "Tracking Key" under Settings.
 5. Enter the "Tracking Key" as "API Key" in the "Bucket" destination settings in Segment.
 
 ## Identify

--- a/src/connections/destinations/catalog/bucket/index.md
+++ b/src/connections/destinations/catalog/bucket/index.md
@@ -2,6 +2,9 @@
 title: Bucket Destination
 rewrite: true
 id: 5fabc0b00f88248bbce4db48
+versions:
+  - name: "Bucket Web (Actions)"
+    link: '/docs/connections/destinations/catalog/bucket-web'
 ---
 
 [Bucket](https://bucket.co/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="blank"} is feature-focused analytics. Bucket empowers software teams with a repeatable approach to shipping features that customers crave.


### PR DESCRIPTION
### Proposed changes

Add documentation for the new Bucket Web (Actions) destination.
I also made some minor updates to the previous Bucket destination, so the two can refer to each other as alternatives.

### Merge timing

ASAP, once approved, to move the Bucket Web (Actions) closer to public release

### Notes

I was unable to fetch catalog information for Bucket Web (Actions), so I have been unable to verify a correct rendering of the destination info and `components/actions-fields.html` includes. Please advise if I am supposed to do any more on my end in order to get the correct metadata into the collection

![localhost_4000_docs_connections_destinations_catalog_bucket-web_](https://github.com/segmentio/segment-docs/assets/331790/41b6f521-3a32-4232-9020-26a3ee57ff7c)

