### PR TITLE
Add warning on realtime computations connected to List destinations

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -180,6 +180,9 @@ While Engage is computing, use the Audience Explorer to see users or accounts th
 > warning ""
 > [Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/), [Marketo Lists](/docs/connections/destinations/catalog/marketo-static-lists/), and [Adwords Remarking Lists](/docs/connections/destinations/catalog/adwords-remarketing-lists) impose rate limits on how quickly Segment can update an Audience. Segment syncs at the highest frequency allowed by the tool, which is between one and six hours.
 
+> warning ""
+> Real-time computations connected to List destinations utilize a separate sync process that can take 12-15 hours to send changes present in the most recent computation.
+
 ### Editing Realtime Audiences and Traits
 
 Engage supports the editing of realtime Audiences and Traits, which allows you to make nuanced changes to existing Traits and Audiences in situations where cloning or building from scratch may not suit your use case.

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -181,7 +181,7 @@ While Engage is computing, use the Audience Explorer to see users or accounts th
 > [Facebook Custom Audiences](/docs/connections/destinations/catalog/personas-facebook-custom-audiences/), [Marketo Lists](/docs/connections/destinations/catalog/marketo-static-lists/), and [Adwords Remarking Lists](/docs/connections/destinations/catalog/adwords-remarketing-lists) impose rate limits on how quickly Segment can update an Audience. Segment syncs at the highest frequency allowed by the tool, which is between one and six hours.
 
 > warning ""
-> Real-time computations connected to List destinations utilize a separate sync process that can take 12-15 hours to send changes present in the most recent computation.
+> Real-time computations connected to List destinations use a separate sync process that can take 12-15 hours to send changes present in the most recent computation.
 
 ### Editing Realtime Audiences and Traits
 


### PR DESCRIPTION
### Proposed changes

Per [this Slack thread](https://twilio.slack.com/archives/CTA527410/p1701798342233869?thread_ts=1701722029.486749&cid=CTA527410), realtime audiences connected to list destinations are processed through ROW 2.0, which take 12–15 hours to process the syncs to a connected destination. 

Added mention of this in our public documentation per customer request. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
