### PR TITLE
Update Privacy Portal Inbox time period

### DIFF
--- a/src/privacy/portal.md
+++ b/src/privacy/portal.md
@@ -25,7 +25,7 @@ The Inbox helps you keep track of new restricted data types as they are captured
 
 Segment detects these fields by scanning data from your Web, Mobile, Server, and Cloud Event Sources to detect PII based on the [default PII matchers](#default-pii-matchers). New properties sent into Segment appear in the Inbox in realtime.
 
-When you view the Inbox for the first time, it displays every property that was sent into Segment from Web, Mobile, Server, and Cloud Event Sources for the past 7 days. ([Object Cloud Sources](/docs/connections/sources/#object-cloud-sources) and [Reverse ETL Sources](/docs/connections/sources/#reverse-etl-sources) do not appear in the Inbox at this time.)
+When you view the Inbox, it displays every property that was sent into Segment from Web, Mobile, Server, and Cloud Event Sources for the past 7 days. ([Object Cloud Sources](/docs/connections/sources/#object-cloud-sources) and [Reverse ETL Sources](/docs/connections/sources/#reverse-etl-sources) do not appear in the Inbox at this time.)
 
 You can click a row in the Inbox to learn more about a field and where it was collected. The expanded view shows:
 

--- a/src/privacy/portal.md
+++ b/src/privacy/portal.md
@@ -25,7 +25,7 @@ The Inbox helps you keep track of new restricted data types as they are captured
 
 Segment detects these fields by scanning data from your Web, Mobile, Server, and Cloud Event Sources to detect PII based on the [default PII matchers](#default-pii-matchers). New properties sent into Segment appear in the Inbox in realtime.
 
-When you view the Inbox for the first time, it displays every property that was sent into Segment from Web, Mobile, Server, and Cloud Event Sources dating back to August 9, 2019. ([Object Cloud Sources](/docs/connections/sources/#object-cloud-sources) and [Reverse ETL Sources](/docs/connections/sources/#reverse-etl-sources) do not appear in the Inbox at this time.)
+When you view the Inbox for the first time, it displays every property that was sent into Segment from Web, Mobile, Server, and Cloud Event Sources for the past 7 days. ([Object Cloud Sources](/docs/connections/sources/#object-cloud-sources) and [Reverse ETL Sources](/docs/connections/sources/#reverse-etl-sources) do not appear in the Inbox at this time.)
 
 You can click a row in the Inbox to learn more about a field and where it was collected. The expanded view shows:
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->
Jira: https://segment.atlassian.net/browse/PROT-5075

### Proposed changes
There is an inconsistency between what's happening and what's reflected on our public doc for Privacy Portal Inbox. There's a cron job running that deletes inbox items older than 7 days, but the current doc here actually implies that we store the data indefinitely. This is not true and we want to fix the doc.

<!--Tell us what you did and why-->
Fix the doc on how long we store privacy inbox items.
### Merge timing
ASAP once approved
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
