### PR TITLE
Hide outfunnel destination docs

### DIFF
--- a/src/connections/destinations/catalog/actions-outfunnel/index.md
+++ b/src/connections/destinations/catalog/actions-outfunnel/index.md
@@ -3,8 +3,8 @@ title: Outfunnel Destination
 hide-boilerplate: true
 hide-dossier: true
 id: 63ff8bae963d5cb4fc79f097
-private: false
-hidden: false
+private: true
+hidden: true
 
 ---
 {% include content/plan-grid.md name="actions" %}


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Destination is being deprecated so hiding docs

### Merge timing
asap
