### PR TITLE
Update audiences/index.md to add specificity that time comparison operators apply only to custom traits

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -60,7 +60,7 @@ You can use the following time comparison operators in your audience definition:
 - `before last`
 - `after next` 
 
-Only ISO timestamps can be used with these operators.
+Only ISO timestamps can be used with these operators. Additionally, these time comparison operators exclusively apply to custom traits.
 If the timestamp is not a valid ISO timestamp (for example, a trailing `Z` is missing), Segment won't process the audience in real-time. Learn more about [real-time compute compared to batch](docs/engage/audiences/#real-time-compute-compared-to-batch)
 
 ### Funnel Audiences


### PR DESCRIPTION
Added specificity that time comparison operators apply **only** to custom traits

### Proposed changes

To add the following line to the 'Time Comparison Operators' section of 'Engage Audiences Overview' Doc:
"Additionally, these time comparison operators exclusively apply to custom traits."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
