### PR TITLE
Removing messaging services

### DIFF
--- a/src/engage/campaigns/mobile-push/index.md
+++ b/src/engage/campaigns/mobile-push/index.md
@@ -354,8 +354,8 @@ Follow these steps to set up mobile push in Twilio Engage.
 12. Click **Verify**, then select the messaging services you want to use in your space.
 13. Click **Save Twilio Account.**
 
-> info ""
-> After creating the messaging service, it cannot be directly removed from the space. To remove the messaging service, you have to edit the Twilio account credentials by clicking the pencil icon. Enter the account credentials (use the API key secret if you remember or create a new API key). Once you've selected the desired services, they will override the existing ones, effectively removing the ones you no longer need.
+> info "Removing messaging services"
+> To remove a messaging service, navigate to Engage > Engage settings > Channels and click the pencil icon under **Twilio messaging service**. Enter the account credentials by either using the API key secret or creating a new API key. Once you've selected the desired services, they will override the existing ones, effectively removing the ones you no longer need.
 
 ### 5b. Create a new push service
 

--- a/src/engage/campaigns/mobile-push/index.md
+++ b/src/engage/campaigns/mobile-push/index.md
@@ -354,6 +354,9 @@ Follow these steps to set up mobile push in Twilio Engage.
 12. Click **Verify**, then select the messaging services you want to use in your space.
 13. Click **Save Twilio Account.**
 
+> info ""
+> After creating the messaging service, it cannot be directly removed from the space. As a workaround, you can edit the Twilio account credentials by clicking the pencil icon. Enter the account credentials (use the API key secret if you remember or create a new API key). Once you've selected the desired services, they will override the existing ones, effectively removing the ones you no longer need.
+
 ### 5b. Create a new push service
 
 Complete mobile push onboarding by creating a new push service:

--- a/src/engage/campaigns/mobile-push/index.md
+++ b/src/engage/campaigns/mobile-push/index.md
@@ -355,7 +355,7 @@ Follow these steps to set up mobile push in Twilio Engage.
 13. Click **Save Twilio Account.**
 
 > info ""
-> After creating the messaging service, it cannot be directly removed from the space. As a workaround, you can edit the Twilio account credentials by clicking the pencil icon. Enter the account credentials (use the API key secret if you remember or create a new API key). Once you've selected the desired services, they will override the existing ones, effectively removing the ones you no longer need.
+> After creating the messaging service, it cannot be directly removed from the space. To remove the messaging service, you have to edit the Twilio account credentials by clicking the pencil icon. Enter the account credentials (use the API key secret if you remember or create a new API key). Once you've selected the desired services, they will override the existing ones, effectively removing the ones you no longer need.
 
 ### 5b. Create a new push service
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

> info ""
> After creating the messaging service, it cannot be directly removed from the space. To remove the messaging service, you have to edit the Twilio account credentials by clicking the pencil icon. Enter the account credentials (use the API key secret if you remember or create a new API key). Once you've selected the desired services, they will override the existing ones, effectively removing the ones you no longer need.

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
