### PR TITLE
Add faq about trait values set to null when user no longer returned by SQL Trait

### DIFF
--- a/src/unify/Traits/sql-traits.md
+++ b/src/unify/Traits/sql-traits.md
@@ -268,3 +268,8 @@ Ensure that the name given to the SQL trait is not the same name as the identifi
 
 ### Why can't I see error messages in SQL traits while other users can?
 To see error messages in SQL traits, you will need to have PII Access.
+
+### What will happen to the traits values of a user who is no longer returned in the latest update for a SQL trait?
+By default, if a user previously showed up in SQL Trait results but no longer does, the SQL Trait will detect this difference and send null values for all that user’s trait values that were previously set by this SQL trait.
+
+To disable this default behaviour, the SQL Trait can be updated to become what we call "additive". For the SQL Traits with type 'Additive SQL', this default behaviour will not happen. So in that same scenario, when user was present in previous computation but is no longer present in the following one, the traits values in the SQL Trait for the user will remain. To update an SQL Trait to type ‘Additive SQL’, please reach out to friends@segment.com. 


### PR DESCRIPTION
### Proposed changes
<!--Tell us what you did and why-->
There have been several tickets regarding trait values of user set to null when user no longer returned by the SQL trait and customers are not aware of this default behavior.

Add the following faq about default behavior where traits values are set to null when user no longer returned by SQL Trait.

"What will happen to the traits values of a user who is no longer returned in the latest update for a SQL trait?

By default, if a user previously showed up in SQL Trait results but no longer does, the SQL Trait will detect this difference and send null values for all that user’s trait values that were previously set by this SQL trait.

To disable this default behaviour, the SQL Trait can be updated to become what we call "additive". For the SQL Traits with type 'Additive SQL', this default behaviour will not happen. So in that same scenario, when user was present in previous computation but is no longer present in the following one, the traits values in the SQL Trait for the user will remain. To update an SQL Trait to type ‘Additive SQL’, please reach out to friends@segment.com.  "

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
Same sample tickets:
https://segment.zendesk.com/agent/tickets/530251
https://segment.zendesk.com/agent/tickets/526371
https://segment.zendesk.com/agent/tickets/506886

