### PR TITLE
Add note that new config api tokens cannot be created

### DIFF
--- a/src/api/config-api/index.md
+++ b/src/api/config-api/index.md
@@ -68,6 +68,9 @@ When you create an access token, you'll give it a description, a workspace, and 
 > warning "Secret Token"
 > You can not retrieve the plain-text `token` later, so you should save it in a secret manager. If you lose the `token` you can generate a new one.
 
+> info
+> New Config API tokens cannot be created in the UI as we move towards exclusively supporting the Public API. If you need to create a new Config API token, please reach out to friends@segment.com for support. 
+
 ### API Requests
 
 Now that you have an access token, you can use this token to access the rest of the Config API by setting it in the `Authorization` header of your requests, for example:

--- a/src/api/config-api/index.md
+++ b/src/api/config-api/index.md
@@ -69,7 +69,7 @@ When you create an access token, you'll give it a description, a workspace, and 
 > You can not retrieve the plain-text `token` later, so you should save it in a secret manager. If you lose the `token` you can generate a new one.
 
 > info
-> New Config API tokens cannot be created in the UI as we move towards exclusively supporting the Public API. Please consider migrating your implementation to the Public API to access the latest features and available endpoints as the Config API will continue to become outdated. If you need to create a new Config API token, please reach out to friends@segment.com for support. 
+> As of February 1, 2024, new Config API tokens cannot be created in the app as Segment moves toward exclusive support for the [Public API](/docs/api/public-api/). [Migrate your implementation to the Public API](https://docs.segmentapis.com/tag/Migration){:target="_blank”} to access the latest features and available endpoints. To create a new Config API token, reach out to friends@segment.com for support. 
 
 ### API Requests
 

--- a/src/api/config-api/index.md
+++ b/src/api/config-api/index.md
@@ -69,7 +69,7 @@ When you create an access token, you'll give it a description, a workspace, and 
 > You can not retrieve the plain-text `token` later, so you should save it in a secret manager. If you lose the `token` you can generate a new one.
 
 > info
-> New Config API tokens cannot be created in the UI as we move towards exclusively supporting the Public API. If you need to create a new Config API token, please reach out to friends@segment.com for support. 
+> New Config API tokens cannot be created in the UI as we move towards exclusively supporting the Public API. Please consider migrating your implementation to the Public API to access the latest features and available endpoints as the Config API will continue to become outdated. If you need to create a new Config API token, please reach out to friends@segment.com for support. 
 
 ### API Requests
 


### PR DESCRIPTION

### Proposed changes

Added a note that new Config API tokens cannot be created in the UI at this time and customers should reach out to support for help. 

### Merge timing
- ASAP once approved


### Related issues (optional)

n/a