### PR TITLE
Remove `email` from Profiles Sync example

### DIFF
--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -48,7 +48,6 @@ email: jane.kim@segment.com
 anonymous_id: b50e18a5-1b8d-451c
 context.url: twilio.com/education
 timestamp: June 22, 10:47:15
-email: jane.kim@segment.com
 
 // Segment generates Profile 2, with a single known ID: b50e18a5-1b8d-451c.
 ```


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->
- Remove `email` from an example Page call in the Profiles Sync docs 
### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->
- Once approved
### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
Closes #5820 