### PR TITLE
Update limitations for predictive audiences

### DIFF
--- a/src/unify/Traits/predictions/suggested-predictive-audiences.md
+++ b/src/unify/Traits/predictions/suggested-predictive-audiences.md
@@ -80,3 +80,7 @@ Segment builds this Audience with the `Page Viewed` event and Likelihood to Purc
 Choose a **Dormant** Predictive Audience to target inactive customers. 
 
 Segment builds this Audience with the `Page Viewed` event and the Likelihood to Purchase Predictive Trait. Audience members have a low likelihood to purchase and haven't been active on your site in the last 60 days.
+
+### Limits
+
+- Predictive audiences can include up to 1,000 events.


### PR DESCRIPTION
Added the current limitation on included events (1,000).  This number was confirmed in this [slack thread](https://twilio.slack.com/archives/C042BDDE63F/p1703957330628569?thread_ts=1702656186.143529&cid=C042BDDE63F)


### Proposed changes

Added a limitation on the number of events that can be included (1,000).

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
