### PR TITLE
Updated Node Hidden Value to False

### DIFF
--- a/src/_data/catalog/sources.yml
+++ b/src/_data/catalog/sources.yml
@@ -1337,7 +1337,7 @@ items:
     isCloudEventSource: false
     slug: node-js
     url: connections/sources/catalog/libraries/server/node-js
-    hidden: true
+    hidden: false
     regions:
       - us
       - eu


### PR DESCRIPTION
The Node server source was missing from the list of sources in the public docs due to the value of the 'hidden' attribute being set to 'true'.  Updated the `hidden` value from 'true' to 'false'.

### Proposed changes

Updated the 'hidden' flag for the Node source for it to appear in the list of server-side sources in the public docs.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
