### PR TITLE
Update Listrak Destination Documentation

### DIFF
--- a/src/connections/destinations/catalog/actions-listrak/index.md
+++ b/src/connections/destinations/catalog/actions-listrak/index.md
@@ -42,17 +42,18 @@ To sync an Engage audience with your Listrak (Actions) destination:
 9. In the **Mappings** tab, click **New Mapping** and select **Update Email Contact Profile Fields**.
 10. Under **Select events to map and send**, select **Track** for the **Event Type**.  
 11. Click **Add Condition** and add this condition: **Event Name** is `Audience Entered`.
-12. Under **Select mappings**, enter the list ID and map the email address if `context.traits.email` is not desired.
-13. Still under **Select mappings**, in the section for mapping the `Profile Field Values`, enter the profile field ID for the `Enter Key Name` textbox on the right and `on` in the textbox for its value to the left. Click **Save**.
-14. Repeat steps 9 through 13 using `Audience Exited` instead of `Audience Entered` in step 11 and `off` instead of `on` in step 13.
-15. **Enable** both mappings.
-16. Go to the **Settings** tab for the destination and **Enable** the destination. Click **Save Changes**.
-17. Select the Engage space and navigate to **Engage > Audiences**. Select the source audience to send to the Listrak destination.
-18. Click **Add Destination** and select the Listrak Audience destination. 
-19. In the settings that appear on the right-hand side, toggle the **Send Track** option on and disable **Send Identify**.
-20. Click **Save**.
-21. To filter email sends in Listrak using the new audience profile field, see this [help article](https://help.listrak.com/en/articles/3951597-introduction-to-building-filter-2-0-segments){:target="_blank”}.
-22. If you want to sync another audience, repeat steps 1 through 20.
+12. Click **Add Condition** and add this condition: **Event Property** `audience_key` is `my_audience` (where `my_audience` is the Audience Key found on the Audience settings page).
+13. Under **Select mappings**, enter the list ID and map the email address if `context.traits.email` is not desired.
+14. Still under **Select mappings**, in the section for mapping the `Profile Field Values`, enter the profile field ID for the `Enter Key Name` textbox on the right and `on` in the textbox for its value to the left. Click **Save**.
+15. Repeat steps 9 through 13 using `Audience Exited` instead of `Audience Entered` in step 11 and `off` instead of `on` in step 13.
+16. **Enable** both mappings.
+17. Go to the **Settings** tab for the destination and **Enable** the destination. Click **Save Changes**.
+18. Select the Engage space and navigate to **Engage > Audiences**. Select the source audience to send to the Listrak destination.
+19. Click **Add Destination** and select the Listrak Audience destination. 
+20. In the settings that appear on the right-hand side, toggle the **Send Track** option on and disable **Send Identify**.
+21. Click **Save**.
+22. To filter email sends in Listrak using the new audience profile field, see this [help article](https://help.listrak.com/en/articles/3951597-introduction-to-building-filter-2-0-segments){:target="_blank”}.
+23. If you want to sync another audience, repeat steps 1 through 20.
 
 {% include components/actions-fields.html %}
 


### PR DESCRIPTION
### Proposed changes

Adds a step for an `audience_key` condition. The `audience_key` condition is necessary in order to allow multiple audiences to be synced with Listrak from a single destination instance.

### Merge timing

ASAP once approved
