### PR TITLE
Update LiveRamp Integration doc to remove Public Beta instructions

### DIFF
--- a/src/connections/destinations/catalog/actions-liveramp-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-liveramp-audiences/index.md
@@ -41,12 +41,6 @@ The LiveRamp Audiences destination can be connected to **Twilio Engage sources o
 
 {% include components/actions-fields.html settings="false"%}
 
-## Public Beta instructions 
-
-* The Segment team will need to enable the feature for your Engage spaces.
-* Once you agree to join the public beta, Segment will enable all Engage spaces that are part of your Segment workspace.
-* New Engage spaces you create won't automatically be enrolled. Contact your Account Team/CSM to get these spaces enrolled.
-
 ## Limitations 
 
 * Audience must have at least 25 unique members, otherwise the destination will fail and the data will not be synced.


### PR DESCRIPTION
The Public Beta instructions for LiveRamp Audiences Destination are no longer applicable to this destination. Customers can now independently add the destination to their workspace.

### Proposed changes

I've removed the Public Beta section from the LiveRamp Audiences Destination since those instructions are no longer relevant. Customers can now autonomously add the destination to their workspace, and there's no need for our team to take any action to enable this for them.
<img width="704" alt="image" src="https://github.com/segmentio/segment-docs/assets/100810716/93205151-150e-429a-8a3f-33db72fe47e9">


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
