### PR TITLE
Add MTU calculation during profile merge content

### DIFF
--- a/src/unify/faqs.md
+++ b/src/unify/faqs.md
@@ -54,6 +54,6 @@ No. As the Identity Graph uses ExternalIDs, they remain for the lifetime of the 
 ### Can I delete specific events from a user profile in Unify? 
 No. Alternatively, you may delete the entire user profile from Segment using a [GDPR deletion request](/docs/privacy/user-deletion-and-suppression/).
 
-### How does profile creation affect MTUs, particularly in scenarios where the profile is not merged with the parent profile due to exceeding the merge limit?
+### How does profile creation affect MTUs, particularly where a profile isn't merged with the parent profile due to exceeding the merge limit?
 Segment determines the Monthly Tracked Users (MTUs) count by the number of unique user IDs and anonymous IDs processed, regardless of how you manage these profiles in Unify and Engage. This count is taken as events are sent to Segment, before they reach Unify and Engage. Therefore, the creation of new profiles or the merging of profiles in Unify doesn't affect the MTU count. The MTU count only increases when you send new unique user or anonymous IDs to Segment.
  

--- a/src/unify/faqs.md
+++ b/src/unify/faqs.md
@@ -55,5 +55,5 @@ No. As the Identity Graph uses ExternalIDs, they remain for the lifetime of the 
 No. Alternatively, you may delete the entire user profile from Segment using a [GDPR deletion request](/docs/privacy/user-deletion-and-suppression/).
 
 ### How does profile creation affect MTUs, particularly in scenarios where the profile is not merged with the parent profile due to exceeding the merge limit?
-The Monthly Tracked Users (MTUs) count is determined by the number of unique user IDs and anonymous IDs that Segment processes, regardless of how these profiles are later managed in Unify & Engage. This count is taken as events are sent to Segment, before they reach Unify & Engage. Therefore, the creation of new profiles or the merging of profiles in Unify does not affect the MTU count. The MTU count would only increase if new unique user IDs or anonymous IDs are sent to Segment.
+Segment determines the Monthly Tracked Users (MTUs) count by the number of unique user IDs and anonymous IDs processed, regardless of how you manage these profiles in Unify and Engage. This count is taken as events are sent to Segment, before they reach Unify and Engage. Therefore, the creation of new profiles or the merging of profiles in Unify doesn't affect the MTU count. The MTU count only increases when you send new unique user or anonymous IDs to Segment.
  

--- a/src/unify/faqs.md
+++ b/src/unify/faqs.md
@@ -53,4 +53,7 @@ No. As the Identity Graph uses ExternalIDs, they remain for the lifetime of the 
 
 ### Can I delete specific events from a user profile in Unify? 
 No. Alternatively, you may delete the entire user profile from Segment using a [GDPR deletion request](/docs/privacy/user-deletion-and-suppression/).
+
+### How does profile creation affect MTUs, particularly in scenarios where the profile is not merged with the parent profile due to exceeding the merge limit?
+The Monthly Tracked Users (MTUs) count is determined by the number of unique user IDs and anonymous IDs that Segment processes, regardless of how these profiles are later managed in Unify & Engage. This count is taken as events are sent to Segment, before they reach Unify & Engage. Therefore, the creation of new profiles or the merging of profiles in Unify does not affect the MTU count. The MTU count would only increase if new unique user IDs or anonymous IDs are sent to Segment.
  


### PR DESCRIPTION
… is exceeded.


### Proposed changes

### How does profile creation affect MTUs, particularly in scenarios where the profile is not merged with the parent profile due to exceeding the merge limit? 

The Monthly Tracked Users (MTUs) count is determined by the number of unique user IDs and anonymous IDs that Segment processes, regardless of how these profiles are later managed in Unify & Engage. This count is taken as events are sent to Segment, before they reach Unify & Engage. Therefore, the creation of new profiles or the merging of profiles in Unify does not affect the MTU count. The MTU count would only increase if new unique user IDs or anonymous IDs are sent to Segment.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
