### PR TITLE
Prediction failure

### DIFF
--- a/src/unify/Traits/predictions/index.md
+++ b/src/unify/Traits/predictions/index.md
@@ -99,6 +99,10 @@ Segment would then build the prediction from this criteria and create specific p
 
 Predicted LTV has strict data requirements. Segment can only make predictions for customers that have purchased two or more times. Segment also requires a year of purchase data to perform LTV calculations.
 
+> info "Prediction is failing with error "We weren't able to create this prediction because your requested prediction event is not being tracked anymore. Please choose a different prediction event and try again.""
+> Predictions are computed based on the available data and the conditions specified for the trait. A gap in tracking events for seven continuous days could potentially affect the computation of the prediction.
+Nevertheless, once data tracking resumes and there is enough data, the prediction should be recomputed.
+
 ## Use cases
 
 For use cases and information on how Segment builds prediction, read [Using Predictions](/docs/unify/traits/predictions/using-predictions/).

--- a/src/unify/Traits/predictions/index.md
+++ b/src/unify/Traits/predictions/index.md
@@ -5,7 +5,7 @@ redirect_from:
   - "/engage/audiences/predictive-traits"
 ---
 
-Predictions, Segment's artificial intelligence and machine learning feature, lets you predict the likelihood that users will perform any event tracked in Segment. 
+Predictions, Segment's artificial intelligence and machine learning feature, lets you predict the likelihood that users will perform any event tracked in Segment.
 
 With Predictions, you can identify users with, for example, a high propensity to purchase, refer a friend, or use a promo code. Predictions also lets you predict a user's lifetime value (LTV).
 
@@ -98,10 +98,6 @@ Segment would then build the prediction from this criteria and create specific p
 #### Data requirements
 
 Predicted LTV has strict data requirements. Segment can only make predictions for customers that have purchased two or more times. Segment also requires a year of purchase data to perform LTV calculations.
-
-> info "Prediction is failing with error "We weren't able to create this prediction because your requested prediction event is not being tracked anymore. Please choose a different prediction event and try again.""
-> Predictions are computed based on the available data and the conditions specified for the trait. A gap in tracking events for seven continuous days could potentially affect the computation of the prediction.
-Nevertheless, once data tracking resumes and there is enough data, the prediction should be recomputed.
 
 ## Use cases
 

--- a/src/unify/Traits/predictions/using-predictions.md
+++ b/src/unify/Traits/predictions/using-predictions.md
@@ -114,3 +114,5 @@ Yes. Keep the following in mind when you work with Predictions:
 
 - **Predictions made for more than 100 million users will fail.** Segment recommends making predictions only for non-anonymous users, or, as an alternative, use the Starting Cohort to narrow down the audience for which you want to make a prediction.
 - **Predictions may not work as intended if you track more than a thousand unique events in your workspace.** If this applies to your use case, [contact Segment Support](https://segment.com/help/contact/){:target="_blank"} for help with removing unused events, which will allow you to create predictions.
+- **Prediction is failing with error "We weren't able to create this prediction because your requested prediction event is not being tracked anymore. Please choose a different prediction event and try again."** Predictions are computed based on the available data and the conditions specified for the trait. A gap in tracking events for seven continuous days could potentially affect the computation of the prediction.
+Nevertheless, once data tracking resumes and there is enough data, the prediction should be recomputed.


### PR DESCRIPTION

### Proposed changes

> info "Prediction is failing with error "We weren't able to create this prediction because your requested prediction event is not being tracked anymore. Please choose a different prediction event and try again.""
> Predictions are computed based on the available data and the conditions specified for the trait. A gap in tracking events for seven continuous days could potentially affect the computation of the prediction.
Nevertheless, once data tracking resumes and there is enough data, the prediction should be recomputed.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
