### PR TITLE
Add reset info for new libraries

### DIFF
--- a/src/_includes/content/reset-mobile.md
+++ b/src/_includes/content/reset-mobile.md
@@ -1,6 +1,6 @@
 <div class="premonition info">
   <div class="fa fa-info-circle"></div>
   <div class="content">
-    <p>The reset method does not clear the userId from connected client side integrations. If you wish to clear the userId from connected client side destination plugins, you would need to call the equivalent reset method for that library.</p>
+    <p>The reset method doesn't clear the `userId` from connected client-side integrations. If you want to clear the `userId` from connected client-side destination plugins, you'll need to call the equivalent reset method for that library.</p>
   </div>
 </div>

--- a/src/_includes/content/reset-mobile.md
+++ b/src/_includes/content/reset-mobile.md
@@ -1,0 +1,6 @@
+<div class="premonition info">
+  <div class="fa fa-info-circle"></div>
+  <div class="content">
+    <p>The reset method does not clear the userId from connected client side integrations. If you wish to clear the userId from connected client side destination plugins, you would need to call the equivalent reset method for that library.</p>
+  </div>
+</div>

--- a/src/connections/sources/catalog/libraries/mobile/apple/implementation.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/implementation.md
@@ -205,6 +205,7 @@ The Analytics Swift utility methods help you work with [plugins](#plugin-archite
 - [Add](#add)
 - [Find](#find)
 - [Remove](#remove)
+- [Reset](#reset)
 
 There's also the [Flush](#flush) method to help you manage the current queue of events.
 
@@ -275,6 +276,25 @@ analytics.flush()
 ```
 {% endcodeexampletab %}
 {% endcodeexample %}
+
+### Reset
+The `reset` method clears the SDK’s internal stores for the current user and group. This is useful for apps where users log in and out with different identities on the same device over time.
+
+{% codeexample %}
+{% codeexampletab Method signature %}
+```swift
+public func reset()
+```
+{% endcodeexampletab %}
+
+{% codeexampletab Example use %}
+```swift
+analytics.reset()
+```
+{% endcodeexampletab %}
+{% endcodeexample %}
+
+{% include content/reset-mobile.md %}
 
 ### OpenURL
 

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/implementation.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/implementation.md
@@ -257,6 +257,7 @@ analytics.reset()
 {% endcodeexampletab %}
 {% endcodeexample %}
 
+{% include content/reset-mobile.md %}
 
 ### OpenURL
 While Analytics Kotlin will automatically track deep links that open your app when the `trackDeepLinks` Configuration property is set to `true`. There are some situations when the app is already open that could cause a deep link open event to be missed.

--- a/src/connections/sources/catalog/libraries/mobile/react-native/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/index.md
@@ -291,6 +291,8 @@ reset();
 {% endcodeexampletab %}
 {% endcodeexample %}
 
+{% include content/reset-mobile.md %}
+
 ### Flush
 By default, the analytics client sends queued events to the API every 30 seconds or when 20 events accumulate, whichever occurs first. This also occurs whenever the app resumes if the user has closed the app with some events unsent. These values can be modified by the `flushAt` and `flushInterval` config options. You can also trigger a flush event manually.
 


### PR DESCRIPTION
### Proposed changes
Adding reset info for our new mobile libraries. Similar content to our ajs docs: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#reset-or-log-out