### PR TITLE
Fixed sidebar buffer [DOC-764]

### DIFF
--- a/src/_sass/components/_sidebar.scss
+++ b/src/_sass/components/_sidebar.scss
@@ -53,6 +53,7 @@
       & > * + * {
         margin-top: 20px;
         padding-top: 20px;
+        padding-bottom: 20px;
         position: relative;
 
         &::before {


### PR DESCRIPTION
### Proposed changes
Added 20px of padding to the source/destination/warehouse/stratconn/glossary sidebars to prevent the sidebar from running into the footer. 

#### Before
![before-doc-764](https://github.com/segmentio/segment-docs/assets/92472883/da1b3c9c-ee9c-49f7-b993-83bda2f4eb79)

#### After
![Screenshot 2024-01-22 at 12 42 58 PM](https://github.com/segmentio/segment-docs/assets/92472883/af4017ba-84a8-4fe0-93ac-7228149a065f)


### Merge timing
no rush

### Related issues (optional)
