### PR TITLE
Remove Twilio Notify link

### DIFF
--- a/src/engage/campaigns/mobile-push/index.md
+++ b/src/engage/campaigns/mobile-push/index.md
@@ -317,8 +317,6 @@ To do so, you'll need to configure your Service instance to use the Credential t
 
 If you're just getting started, set up the APN credential first, then create your Service by clicking the blue plus button on the [Services Console](https://console.twilio.com/us1/develop/notify/services?frameUrl=%2Fconsole%2Fnotify%2Fservices%3Fx-target-region%3Dus1&_ga=2.170545120.1341805708.1700099403-1979911827.1631664239&_gl=1*1msrgrt*_ga*MTk3OTkxMTgyNy4xNjMxNjY0MjM5*_ga_RRP8K4M4F3*MTcwMDEwNTYwOC45Ny4xLjE3MDAxMDU2MjAuMC4wLjA.){:target="_blank"} page.
 
-For more information, view Twilio's [How to Configure iOS Push Notifications documentation](https://www.twilio.com/docs/notify/configure-ios-push-notifications){:target="_blank"}.
-
 ## 4. Configure Android push notifications 
 
 Follow the steps in Twilio's [Configuring Android Push Notifications](https://www.twilio.com/docs/notify/configure-android-push-notifications){:target="_blank"}.


### PR DESCRIPTION
### Proposed changes

- Removed a link to the Twilio Notify documentation.  Those docs will be deprecated, and it was confusing customers.

### Merge timing

- ASAP once approved.