### PR TITLE
Update index.md

### DIFF
--- a/src/connections/storage/catalog/aws-s3/index.md
+++ b/src/connections/storage/catalog/aws-s3/index.md
@@ -488,4 +488,11 @@ For user-property destinations, Segment sends an [identify](/docs/connections/sp
 
 When you first create an audience, Engage sends an Identify call for every user in that audience. Later audience syncs send updates for users whose membership has changed since the last sync.
 
+##**FAQ**
+
+**AWS S3 destination connection error “Multiple instance of AWS S3 are not allowed for this source"
+**
+
+Before inspecting the AWS S3 configurations (i.e.: IAM role and trust policy), it’s worth checking if you already have an S3 destination connected to the source in question. Segment only supports one AWS S3 destination per source.
+
 {% include content/destination-footer.md %}

--- a/src/connections/storage/catalog/aws-s3/index.md
+++ b/src/connections/storage/catalog/aws-s3/index.md
@@ -490,8 +490,7 @@ When you first create an audience, Engage sends an Identify call for every user 
 
 ##**FAQ**
 
-**AWS S3 destination connection error “Multiple instance of AWS S3 are not allowed for this source"
-**
+### AWS S3 destination connection error “Multiple instance of AWS S3 are not allowed for this source"
 
 You might encounter this error if you already have a S3 destination connected to the source in question. Segment only supports one AWS S3 destination per source.
 

--- a/src/connections/storage/catalog/aws-s3/index.md
+++ b/src/connections/storage/catalog/aws-s3/index.md
@@ -493,6 +493,6 @@ When you first create an audience, Engage sends an Identify call for every user 
 **AWS S3 destination connection error “Multiple instance of AWS S3 are not allowed for this source"
 **
 
-Before inspecting the AWS S3 configurations (i.e.: IAM role and trust policy), it’s worth checking if you already have an S3 destination connected to the source in question. Segment only supports one AWS S3 destination per source.
+You might encounter this error if you already have a S3 destination connected to the source in question. Segment only supports one AWS S3 destination per source.
 
 {% include content/destination-footer.md %}

--- a/src/connections/storage/catalog/aws-s3/index.md
+++ b/src/connections/storage/catalog/aws-s3/index.md
@@ -488,7 +488,7 @@ For user-property destinations, Segment sends an [identify](/docs/connections/sp
 
 When you first create an audience, Engage sends an Identify call for every user in that audience. Later audience syncs send updates for users whose membership has changed since the last sync.
 
-##**FAQ**
+## FAQ
 
 ### AWS S3 destination connection error “Multiple instance of AWS S3 are not allowed for this source"
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

###
**What**: In the public doc, added new section as [FAQ](https://segment.com/docs/connections/storage/catalog/aws-s3/#create-a-new-destination)

**AWS S3 destination connection error “Multiple instance of AWS S3 are not allowed for this source"**

Before inspecting the AWS S3 configurations (i.e.: IAM role and trust policy), it’s worth checking if you already have an S3 destination connected to the source in question. Segment only supports one AWS S3 destination per source.

**Why**: The customer wanted to add multiple instance of the AWS S3 for the same source, which is not possible. 

Zendesk: 

https://segment.zendesk.com/agent/tickets/533718

https://segment.zendesk.com/agent/tickets/510242

Slack: https://twilio.slack.com/archives/C8AA794FN/p1706136425243499

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
