### PR TITLE
Update HTTP API rate limits

### DIFF
--- a/src/connections/rate-limits.md
+++ b/src/connections/rate-limits.md
@@ -1,7 +1,7 @@
 ---
 title: Product Limits
 ---
-These limits were updated on February 22, 2023.
+These limits were updated on January 25, 2024.
 
 ## Event properties ingestion limit
 
@@ -9,7 +9,7 @@ Events ingested by Segment have a limit of **10,000** properties per individual 
 
 ## Inbound data ingestion API rate limit
 
-If any sources send more than 20,000 events per second in a workspace without prior arrangement, Segment reserves the right to queue any additional events and process those at a rate that doesn't exceed this limit. To request a higher limit, contact [Segment](mailto:friends@segment.com). 
+If any sources send more than 1,000 events per second in a workspace without prior arrangement, Segment reserves the right to queue any additional events and process those at a rate that doesn't exceed this limit. To request a higher limit, contact [Segment](mailto:friends@segment.com). 
 
 > warning "Engage rate limit"
 > Engage has a limit of 1,000 events per second for inbound data. Visit the [Engage Default Limits documentation](/docs/engage/product-limits/) to learn more.

--- a/src/connections/sources/catalog/libraries/server/http-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/http-api/index.md
@@ -38,7 +38,7 @@ Segment welcomes feedback on API responses and error messages. [Reach out to sup
 
 ## Rate limits
 
-For each workspace, Segment recommends you to not exceed 20,000 requests per second with the HTTP API. If you exceed this, Segment reserves the right to queue any additional events and process those at a rate that doesn't exceed the limit. To request a higher limit, contact [Segment](mailto:friends@segment.com).
+For each workspace, Segment recommends you to not exceed 1,000 requests per second with the HTTP API. If you exceed this, Segment reserves the right to queue any additional events and process those at a rate that doesn't exceed the limit. To request a higher limit, contact [Segment](mailto:friends@segment.com).
 
 For [`batch` requests](#batch), there's a limit of 500 KB per request. 
 


### PR DESCRIPTION
### Proposed changes
Updated the inbound HTTP API limit from 20,000 events/second to 1,000 events/second, as requested by a PM on the platform services team

### Merge timing
ASAP
