### PR TITLE
Amplitude Actions: Update "tracking sessions" for clarity

### DIFF
--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -51,7 +51,9 @@ To manually add the Log Purchases Action:
 
 ### Connection Modes for Amplitude (Actions) destination
 
-The Amplitude (Actions) destination does not offer a device-mode connection mode. Most previous deployments of the Amplitude Segment destination required the device-mode connection to use the `session_id` tracking feature. However, the Amplitude (Actions) destination now includes session ID tracking by default when you use one of Segment's new libraries ([Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/), [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”} or [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}).
+The Amplitude (Actions) destination does not offer a device-mode connection mode. Most previous deployments of the Amplitude Segment destination required the device-mode connection to use the `session_id` tracking feature. However, the Amplitude (Actions) destination now includes session ID tracking by default when you use Segment's ([Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/){:target="_blank”} libaray.
+
+If you're using Segment's [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”}, [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}, or [React Native](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/react-native/){:target="_blank”} library, you will need to include the [desitnation plugin](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/amplitude-react-native/) to enable session tracking. 
 
 ### Track sessions
 

--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -53,13 +53,13 @@ To manually add the Log Purchases Action:
 
 The Amplitude (Actions) destination does not offer a device-mode connection mode. Most previous deployments of the Amplitude Segment destination required the device-mode connection to use the `session_id` tracking feature. However, the Amplitude (Actions) destination now includes session ID tracking by default when you use Segment's ([Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/){:target="_blank”} libaray.
 
-If you're using Segment's [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”}, [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}, or [React Native](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/react-native/){:target="_blank”} library, you will need to include the [desitnation plugin](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/amplitude-react-native/) to enable session tracking. 
-
 ### Track sessions
 
 Session tracking is available with Segment's new libraries: [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/), [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”} or [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}. 
 
 When connected to the Analytics.js 2.0 source, Segment automatically loads a plugin on your website for session tracking and enrichment as an alternative to the Amplitude SDK. This means you don't need to bundle any software to run on the user's device, or write any code. It also means that you can use more of the Segment platform features for data going to Amplitude, such as Protocols filtering and transformations, and Profiles Identity Resolution.
+
+If you're using one of Segment's [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”}, [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}, or [React Native](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/react-native/){:target="_blank”} libraries, you will need to include the [desitnation plugin](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/amplitude-react-native/) to enable session tracking. 
 
 You can read more about Amplitude's [tracking sessions](https://help.amplitude.com/hc/en-us/articles/115002323627-Track-sessions){:target="_blank”} feature in Amplitude's documentation. 
 

--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -51,15 +51,15 @@ To manually add the Log Purchases Action:
 
 ### Connection Modes for Amplitude (Actions) destination
 
-The Amplitude (Actions) destination does not offer a device-mode connection mode. Most previous deployments of the Amplitude Segment destination required the device-mode connection to use the `session_id` tracking feature. However, the Amplitude (Actions) destination now includes session ID tracking by default when you use Segment's ([Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/){:target="_blank”} libaray.
+The Amplitude (Actions) destination does not offer a device-mode connection mode. Previous deployments of the Amplitude Segment destination required the device-mode connection to use the `session_id` tracking feature. However, the Amplitude (Actions) destination now includes session ID tracking by default when you use Segment's ([Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/) library.
 
 ### Track sessions
 
-Session tracking is available with Segment's new libraries: [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/), [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”} or [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}. 
+Session tracking is available with Segment's new libraries: [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/), [Swift](/docs/connections/sources/catalog/libraries/mobile/apple/) or [Kotlin](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/). 
 
-When connected to the Analytics.js 2.0 source, Segment automatically loads a plugin on your website for session tracking and enrichment as an alternative to the Amplitude SDK. This means you don't need to bundle any software to run on the user's device, or write any code. It also means that you can use more of the Segment platform features for data going to Amplitude, such as Protocols filtering and transformations, and Profiles Identity Resolution.
+When connected to the Analytics.js 2.0 source, Segment automatically loads a plugin on your website for session tracking and enrichment as an alternative to the Amplitude SDK. This means you don't need to bundle any software or write any code to run on the user's device, and can use more of the Segment platform features for data going to Amplitude, like [Protocols filtering and transformations](/docs/protocols/) and [Unify Identity Resolution](/unify/identity-resolution/).
 
-If you're using one of Segment's [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”}, [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}, or [React Native](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/react-native/){:target="_blank”} libraries, you will need to include the [desitnation plugin](https://segment-docs.netlify.app/docs/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/amplitude-react-native/) to enable session tracking. 
+If you're using one of Segment's [Swift]((/docs/connections/sources/catalog/libraries/mobile/apple/), [Kotlin](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/), or [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/) libraries, you will need to include the Amplitude destination plugin to enable session tracking. 
 
 You can read more about Amplitude's [tracking sessions](https://help.amplitude.com/hc/en-us/articles/115002323627-Track-sessions){:target="_blank”} feature in Amplitude's documentation. 
 

--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -51,13 +51,15 @@ To manually add the Log Purchases Action:
 
 ### Connection Modes for Amplitude (Actions) destination
 
-The Amplitude (actions) destination does not offer a device-mode connection mode. If you're using one of Segment's new libraries ([Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/), [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”} or [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}) with the Actions-framework version of the destination, you do not need the device-mode connection.
+The Amplitude (Actions) destination does not offer a device-mode connection mode. Most previous deployments of the Amplitude Segment destination required the device-mode connection to use the `session_id` tracking feature. However, the Amplitude (Actions) destination now includes session ID tracking by default when you use one of Segment's new libraries ([Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/), [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”} or [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}).
 
-
-Most previous deployments of the Amplitude Segment destination used the device-mode connection to use the `session_id` tracking feature. The new Actions-framework Amplitude destination includes session ID tracking by default. When connected to the Analytics.js 2.0 source, Segment automatically loads a plugin on your website for session tracking and enrichment as an alternative to the Amplitude SDK. This means you don't need to bundle any software to run on the user's device, or write any code. It also means that you can use more of the Segment platform features on data going to Amplitude, such as Protocols filtering and transformations, and Profiles Identity Resolution.
+### Track sessions
 
 Session tracking is available with Segment's new libraries: [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/), [Swift](https://github.com/segmentio/analytics-swift){:target="_blank”} or [Kotlin](https://github.com/segmentio/analytics-kotlin){:target="_blank”}. 
 
+When connected to the Analytics.js 2.0 source, Segment automatically loads a plugin on your website for session tracking and enrichment as an alternative to the Amplitude SDK. This means you don't need to bundle any software to run on the user's device, or write any code. It also means that you can use more of the Segment platform features for data going to Amplitude, such as Protocols filtering and transformations, and Profiles Identity Resolution.
+
+You can read more about Amplitude's [tracking sessions](https://help.amplitude.com/hc/en-us/articles/115002323627-Track-sessions){:target="_blank”} feature in Amplitude's documentation. 
 
 ### Device ID Mappings
 The Amplitude destination requires that each event include either a Device ID or a User ID. If a User ID isn't present, Amplitude uses a Device ID, and vice versa, if a Device ID isn't present, Amplitude uses the User ID.


### PR DESCRIPTION
### Proposed changes
- Add new subsection for "Track sessions" for ease of reference and clarity
- Re-word paragraph about connection modes for Amplitude Actions for clarity
- Move sentences about session ID to "track sessions" subsection
- Add link to Amplitude's documentation for tracking sessions

### Merge timing
- ASAP once approved
