### PR TITLE
Update index.md - Slack (Classic) Link broken

### DIFF
--- a/src/connections/destinations/catalog/actions-slack/index.md
+++ b/src/connections/destinations/catalog/actions-slack/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - '/connections/destinations/catalog/vendor-slack'
 versions:
   - name: Slack (Classic)
-    link: /docs/connections/destinations/slack
+    link: /docs/connections/destinations/catalog/slack/
 ---
 {% include content/plan-grid.md name="actions" %}
 


### PR DESCRIPTION
### Proposed changes

The Slack (Classic) Link was broken
was : /docs/connections/destinations/slack/
changed to : /docs/connections/destinations/catalog/slack/

### Merge timing
- ASAP once approved?
