### PR TITLE
Update PHP 3rd-party Libraries section 

### DIFF
--- a/src/connections/sources/catalog/libraries/server/php/index.md
+++ b/src/connections/sources/catalog/libraries/server/php/index.md
@@ -529,4 +529,4 @@ $ sudo service cron reload    # reload the cron daemon
 
 If you only need support for PHP5, the team at Underground Elephant has released a [3rd-party library](https://github.com/uecode/segment-io-php) based on Guzzle.
 
-If you're using Laravel 4 our friends at Catchet have written a wrapper for you! Docs and GitHub repo can be found here: https://github.com/cachethq/Laravel-Segment
+Alt Three Segment is a Segment bridge for Laravel and the GitHub repo can be found here: ALTTHREE/SEGMENT


### PR DESCRIPTION
### Proposed changes

It looks like the previous wrapper to assist with integrating the 3rd party library, Laravel, has deprecated and now the setup is through [ALTTHREE/SEGMENT](https://github.com/AltThree/Segment).

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
