### PR TITLE
Identify Spec Note for Traits Identify Spec

### DIFF
--- a/src/connections/spec/identify.md
+++ b/src/connections/spec/identify.md
@@ -135,6 +135,8 @@ Traits are pieces of information you know about a user that are included in an I
 
 Segment has reserved some traits that have semantic meanings for users, and will handle them in special ways. For example, Segment always expects `email` to be a string of the user's email address. Segment sends this on to destinations like _Mailchimp_ that require an email address for their tracking.
 
+The “Select Object” option will send the entire object from the event; whereas, the “Edit Object” option allows you to map each individual property.  
+
 You should **only use reserved traits for their intended meaning**.
 
 Reserved traits Segment has standardized:


### PR DESCRIPTION
### Proposed changes

I recently assisted a customer with mapping a specific trait in an Identify call who needed a reminder of the difference between selecting the ‘Select Object' vs 'Edit Object’. Explaining the difference and showing an example was a quick fix. I checked the public docs and it might be helpful to include in both the Identify and Track spec when mapping properties/traits.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
