### PR TITLE
Updating Information on GCLID

### DIFF
--- a/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
@@ -81,7 +81,7 @@ Conversions tracked by other means, such as importing goals from Google Analytic
 
 ### Enhanced conversions for leads
 
-[Enhanced conversions for leads](https://developers.google.com/google-ads/api/docs/conversions/upload-identifiers){:target="_blank"} allows you to use hashed, first-party user-provided data from your website lead forms for offline lead measurement. When you upload your leads, the provided hashed information is used to attribute back to the Google Ad campaign. In order to send enhanced conversions for leads, you can use the "Upload Click Conversion" action. If available, include both GCLID and send an email address and phone number of the user for Segment to hash and send to Google Ads. 
+[Enhanced conversions for leads](https://developers.google.com/google-ads/api/docs/conversions/upload-identifiers){:target="_blank"} allows you to use hashed, first-party user-provided data from your website lead forms for offline lead measurement. When you upload your leads, the provided hashed information is used to attribute back to the Google Ad campaign. In order to send enhanced conversions for leads, you can use the "Upload Click Conversion" action. According to Goggle, if you do not have GCLID at your source payload, you have to pass user identifiers, at least email or phone number in your mappings, for Google to make the match. A conversion must be addressed to an existing profile. If there's not a match, Google responds with a failure.
 
 ### Refreshing access tokens
 


### PR DESCRIPTION
### Proposed changes

Frequent response to gclid error in Google Ads destination. I end up saying this statement for this type of error and it’s helpful to include google’s doc as well. 

Current: Instead of sending GCLID, send an email address or phone number of the user for Segment to hash and send to Google Ads.

Updated: According to Goggle's  docs, if you do not have GCLID at your source payload, you have to pass user identifiers, at least email or phone number in your mappings, for Google to make the match. A conversion must be addressed to an existing profile. If there's not a match, Google responds with a failure.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
