### PR TITLE
Update CSV Upload Guidelines

### DIFF
--- a/src/engage/profiles/csv-upload.md
+++ b/src/engage/profiles/csv-upload.md
@@ -11,7 +11,6 @@ Keep the following guidelines in mind as you upload CSV files to Twilio Engage:
 - You can only upload `.csv` files.
 - Files can't be empty and must have at least one header and one row.
 - You can't have multiple columns with the same header.
-- CSV files can't contain extraneous column headers.
 - CSV files cannot exceed 1 million rows (plus one header row), 299 columns, or 100 MB in file size.
 - You can only upload one file at a time.
 - Add an identifier column or `anonymous_id` in your identity resolution configuration.

--- a/src/engage/user-subscriptions/csv-upload.md
+++ b/src/engage/user-subscriptions/csv-upload.md
@@ -121,7 +121,6 @@ Please note the following limits as you upload CSV files to Twilio Engage:
 - You can only upload .csv files.
 - Files can't be empty and must have at least one header and one row.
 - You can't have multiple columns with the same header.
-- CSV files can't contain extraneous column headers.
 - Upload CSV files with up to 1 million rows (plus one header row).
 - You can only upload one file at a time.
 - The CSV file size can't exceed 100 MB.


### PR DESCRIPTION
### Proposed changes

- Removed `CSV files can’t contain extraneous column headers.` from CSV upload pages.  Segment now supports this.

### Merge timing

- ASAP once approved.