### PR TITLE
Fix support type param for library tiers

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/android/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/android/index.md
@@ -2,7 +2,7 @@
 title: 'Analytics for Android'
 strat: android
 repo: analytics-android
-support_type: legacy
+support_type: maintenance
 id: wXNairW5xX
 ---
   Analytics for Android makes it easier for you to send data to any tool without having to learn, test or implement a new API every time.

--- a/src/connections/sources/catalog/libraries/mobile/ios/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/index.md
@@ -2,7 +2,7 @@
 title: Analytics for iOS
 strat: ios
 repo: analytics-ios
-support_type: legacy
+support_type: maintenance
 id: UBrsG9RVzw
 ---
 With Analytics for iOS, you can send your data to analytics or marketing tool, without needing to learn, test, or implement a new API with each update or addition.


### PR DESCRIPTION
### Proposed changes
Incorrect `support_type` set for the older android and iOS library:
https://github.com/segmentio/segment-docs/commit/5ac3ec3fea10dbb4883af9c49cfb8eb07d5e1023
https://github.com/segmentio/segment-docs/pull/6039