### PR TITLE
Update doc to clarify Linked Events only support cloud-mode destinations

### DIFF
--- a/src/unify/linked-profiles/linked-events.md
+++ b/src/unify/linked-profiles/linked-events.md
@@ -134,7 +134,7 @@ entity "account-entity" {
 To use Linked Events, you'll need to add an action destination to send enriched events to. Navigate to **Connections > Destinations**. Select an existing action destination, or click **+ Add destination** to add a new action destination.  
 
 > info ""
-> For Linked Events, Segment supports [Destination Actions](/docs/connections/destinations/actions/).
+> For Linked Events, Segment supports [Destination Actions](/docs/connections/destinations/actions/) in cloud-mode only.
 
 
 ## Step 5: Enrich events with entities
@@ -190,7 +190,7 @@ Segment currently syncs once every hour.
 
 #### Which Destinations does Linked Events support? 
 
-For Linked Events, Segment supports all actions-based destinations. 
+For Linked Events, Segment supports all actions-based destinations in cloud-mode. 
 
 #### Why aren't test events working? 
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Just checking with engineers, we currently support [Linked Event](https://segment.com/docs/unify/linked-profiles/linked-events/) for actions-based destinations only in cloud-mode. Web destinations like [Wisepops](https://segment.com/docs/connections/destinations/catalog/actions-wisepops/) and [GA4 Web](https://segment.com/docs/connections/destinations/catalog/actions-google-analytics-4-web/#google-analytics-4-web-destination) are not supported. 

Slack - https://twilio.slack.com/archives/C05BMCB3P2P/p1707979990521649


### Merge timing
ASAP once approved


### Related issues (optional)
https://segment.atlassian.net/browse/KCS-1097
