### PR TITLE
Update the Node version that is supported

### DIFF
--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -15,7 +15,7 @@ All of Segment's server-side libraries are built for high-performance, so you ca
 ## Getting Started
 
 > warning ""
-> Make sure you're using a version of Node that's 14 or higher. 
+> Make sure you're using a version of Node that's 16 or higher. 
 
 1. Run the relevant command to add Segment's Node library module to your `package.json`.
 


### PR DESCRIPTION
### Proposed changes

The node version that is now supported is 16 rather than 14.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
