### PR TITLE
Upgrade Broken Link

### DIFF
--- a/src/connections/sources/catalog/libraries/server/node/migration.md
+++ b/src/connections/sources/catalog/libraries/server/node/migration.md
@@ -4,7 +4,7 @@ repo: analytics-next
 strat: node-js
 ---
 
-If you're using the [classic version of Analytics Node.js](/docs/connections/sources/catalog/libraries/server/node/classic) (named `analytics-node` on npm), [upgrade to the latest version of Analytics Node.js](/connections/sources/catalog/libraries/server/node/) (named `@segment/analytics-node` on npm). 
+If you're using the [classic version of Analytics Node.js](/docs/connections/sources/catalog/libraries/server/node/classic) (named `analytics-node` on npm), [upgrade to the latest version of Analytics Node.js](/docs/connections/sources/catalog/libraries/server/node/) (named `@segment/analytics-node` on npm). 
 
 1. Change the named imports.
 


### PR DESCRIPTION
### Proposed changes

The link in [this doc](https://segment.com/docs/connections/sources/catalog/libraries/server/node/migration/), specifically, this sentence, “[upgrade to the latest version of Analytics Node.js](https://segment.com/connections/sources/catalog/libraries/server/node/) (named @segment/analytics-node on npm)” is broken and needs updating.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
