### PR TITLE
Add plan slug to Consent Management docs

### DIFF
--- a/src/_data/products.yml
+++ b/src/_data/products.yml
@@ -173,3 +173,12 @@ items:
     team: false
     business: true
     addon: true
+
+- product_display_name: Consent Management
+  slug: consent-management
+  plan-note: "Consent Management is available to customers on the Business Tier Plan"
+  plans:
+    free: false
+    team: false
+    business: true
+    addon: false

--- a/src/privacy/consent-management/configure-consent-management.md
+++ b/src/privacy/consent-management/configure-consent-management.md
@@ -1,5 +1,6 @@
 ---
 title: Configure Consent Management
+plan: consent-management
 related:
   - "/privacy/consent-management/"
   - "/privacy/consent-management/consent-in-segment-connections/"

--- a/src/privacy/consent-management/consent-in-segment-connections.md
+++ b/src/privacy/consent-management/consent-in-segment-connections.md
@@ -1,5 +1,6 @@
 ---
 title: Consent in Segment Connections
+plan: consent-management
 related:
   - "/privacy/consent-management/"
   - "/privacy/consent-management/configure-consent-management/"

--- a/src/privacy/consent-management/consent-in-unify.md
+++ b/src/privacy/consent-management/consent-in-unify.md
@@ -1,5 +1,6 @@
 ---
 title: Consent in Unify
+plan: consent-management
 related:
   - "/privacy/consent-management/"
   - "/privacy/consent-management/configure-consent-management/"

--- a/src/privacy/consent-management/index.md
+++ b/src/privacy/consent-management/index.md
@@ -1,12 +1,10 @@
 ---
 title: Consent Management Overview
+plan: consent-management
 related:
   - "/privacy/consent-management/configure-consent-management/"
   - "/privacy/consent-management/consent-in-segment-connections/"
 ---
-
-(Add: a tag for 'Available for BT customers' as seen on many of our other pages placed just under the title: https://segment.com/docs/protocols/ - This product is availble for all business customers and not an add-on)
-
 
 When an end user visits your web or mobile app, they set **consent preferences**, or make decisions about the types of data they want you to collect, use, and share. These consent preferences are typically presented as a set list of categories that describe how your company intends to use that data. Some common categories include personalization, advertising, and site performance.
 

--- a/src/privacy/consent-management/index.md
+++ b/src/privacy/consent-management/index.md
@@ -5,6 +5,9 @@ related:
   - "/privacy/consent-management/consent-in-segment-connections/"
 ---
 
+(Add: a tag for 'Available for BT customers' as seen on many of our other pages placed just under the title: https://segment.com/docs/protocols/ - This product is availble for all business customers and not an add-on)
+
+
 When an end user visits your web or mobile app, they set **consent preferences**, or make decisions about the types of data they want you to collect, use, and share. These consent preferences are typically presented as a set list of categories that describe how your company intends to use that data. Some common categories include personalization, advertising, and site performance.
 
 Segment integrates with your commercial third-party or bespoke consent management platform (CMP) that captures an end user's consent preferences and enforces those preferences by only routing events to the categories consented to by an end user.


### PR DESCRIPTION
Place a tag to mention that it's available for business customers, not part of the free and team plans.

![Screenshot 2024-02-22 at 13 46 29](https://github.com/segmentio/segment-docs/assets/113425933/e542e0d1-2aff-42f7-9d57-41d2da611bc2)


### Proposed changes

It might not be clear to all customers which paying tier can use this product.

### Merge timing

- ASAP once approved



