### PR TITLE
Add info note about no toggle option for server-side sources

### DIFF
--- a/src/connections/sources/schema/destination-data-control.md
+++ b/src/connections/sources/schema/destination-data-control.md
@@ -42,6 +42,9 @@ If you no longer want to track an event, you can either remove it from your code
 
 Once you block an event in Segment, Segment stops forwarding it to all of your destinations, including your warehouses. You can remove it from your code at your leisure. In addition to blocking track calls, Business plan customers can block all Page and Screen calls, as well as Identify traits and Group properties. 
 
+> info "Blocking events server-side"
+> The toggle option is not availble for server-side sources.
+
 ## Add a new event using the **New Event** button
 
 The **New Event** button in your source schema adds the event to the source schema only. It does not add any events to your tracking code. If you want to track an event, you still need to manually add it to your source code. 


### PR DESCRIPTION
### Proposed changes

A customer recently asked if there was a toggle option to block an event on their Java source, like their other client sources and it may be helpful to add a note in a public doc.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
