### PR TITLE
Remove beta tag from Avo destination docs

### DIFF
--- a/src/connections/destinations/catalog/avo/index.md
+++ b/src/connections/destinations/catalog/avo/index.md
@@ -1,7 +1,6 @@
 ---
 title: Avo Destination
 id: 65c2465d0d7d550aa8e7e5c6
-beta: true
 redirect_from: "/connections/destinations/catalog/actions-avo/"
 ---
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Integration is now out of beta. Remove beta tag from Avo destination docs

### Merge timing
asap

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
