### PR TITLE
Adding required event fields when using ensure method for insert functions

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -164,6 +164,27 @@ If you don't supply a function for an event type, Segment throws an `EventNotSup
 
 You can read more about [error handling](#destination-insert-functions-logs-and-errors) below.
 
+## Required Event Fields for .ensure() method
+
+If an incoming payload meets the `.ensure()` specifications for a particular destination then it will be sent through the Insert Function, otherwise it will not. The required event fields are the following: 
+
+```
+"supportedEventTypes": {
+            "track": {}
+        },
+        "requiredSettings": {},
+        "requiredEventFields": {
+            "context.device.type": {},
+            "context.app.version": {},
+            "context.os.version": {}
+        },
+        "supportedChannels": [
+            "server"
+        ]
+```
+> info ""
+> These are only the required fields for Classic destination types.
+
 ## Runtime and dependencies
 
 {% include content/functions/runtime.md %}


### PR DESCRIPTION

### Proposed changes

Currently, when customers are using an insert function connected to a classic destination they are attempting to use the .ensure() method however the events are being dropped due to missing required fields. The piping of these events is out of order and is in the works of being fixed. The workaround is for customers to include the required event fields in the meantime.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
