### PR TITLE
rETL - Add FAQ for Syntax errors

### DIFF
--- a/src/connections/reverse-etl/index.md
+++ b/src/connections/reverse-etl/index.md
@@ -321,3 +321,6 @@ To receive Reverse ETL sync notifications:
 3. Enable the toggle for **Reverse ETL Sync Failed**.
 
 In case of consecutive failures, Segment sends notifications for every sync failure. Segment doesn't send notifications for partial failures.
+
+#### Can I have multiple queries in the Query Builder?
+No. In Reverse ETL, we execute queries in a [common table expression](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#with_clause), which can only bind the results from one single subquery. If there are multiple semicolons `;` in the query, they'll also be treated as several subqueries (even if the second part is only an inline comment), and cause the syntax error.

--- a/src/connections/reverse-etl/index.md
+++ b/src/connections/reverse-etl/index.md
@@ -323,4 +323,4 @@ To receive Reverse ETL sync notifications:
 In case of consecutive failures, Segment sends notifications for every sync failure. Segment doesn't send notifications for partial failures.
 
 #### Can I have multiple queries in the Query Builder?
-No. In Reverse ETL, we execute queries in a [common table expression](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#with_clause), which can only bind the results from one single subquery. If there are multiple semicolons `;` in the query, they'll also be treated as several subqueries (even if the second part is only an inline comment), and cause the syntax error.
+No. In Reverse ETL, we execute queries in a [common table expression](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#with_clause), which can only bind the results from **one single** subquery. If there are multiple semicolons `;` in the query, they'll be treated as several subqueries (even if the second part is only an inline comment), and cause syntax errors.

--- a/src/connections/reverse-etl/index.md
+++ b/src/connections/reverse-etl/index.md
@@ -323,4 +323,4 @@ To receive Reverse ETL sync notifications:
 In case of consecutive failures, Segment sends notifications for every sync failure. Segment doesn't send notifications for partial failures.
 
 #### Can I have multiple queries in the Query Builder?
-No. In Reverse ETL, we execute queries in a [common table expression](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#with_clause), which can only bind the results from **one single** subquery. If there are multiple semicolons `;` in the query, they'll be treated as several subqueries (even if the second part is only an inline comment), and cause syntax errors.
+No. In Reverse ETL, Segment executes queries in a [common table expression](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#with_clause){:target="_blank”}, which can only bind the results from **one single** subquery. If there are multiple semicolons `;` in the query, they'll be treated as several subqueries (even if the second part is only an inline comment) and cause syntax errors.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Customer reported seeing errors when adding inline comments to the end of the query for rETL:
`googleapi: Error 400: Syntax error: Expected ")" but got ";"`

Engineers have confirmed in this [Jira](https://segment.atlassian.net/browse/RETL-1228) that this is expected:
> Hi team, this is not a bug. In RETL, we execute customer’s queries in a common table expression, which can only bind the results from one single subquery ([link to Google doc](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#with_clause:~:text=Each%20CTE%20binds%20the%20results%20of%20a%20subquery%20to%20a%20table%20name)). If there are multiple ; in the customer query, they'll be treated as several subqueries (even if the 2nd part is only an inline comment), and thus caused this syntax error.
> 
> As pointed out in the ticket body, a simple solution is just to remove the ;.

### Merge timing
ASAP once approved

### Related issues (optional)
- https://segment.atlassian.net/browse/KCS-1140
- https://segment.atlassian.net/browse/RETL-1228
