### PR TITLE
Add FAQ about loading multiple writeKeys for iOS

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/ios/ios-faqs.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/ios-faqs.md
@@ -28,6 +28,14 @@ Once you install the framework, import the header file and install as described 
 If you choose not to use a dependency manager, you must manually keep files up-to-date with regularly scheduled, manual updates.
 
 
+## Can I initiate multiple `writeKey`s for a single iOS project?
+No, we don't support sending events to multiple `writeKey`s for a single iOS project post-initialization. You can conditionally set the `writeKey` based on an environment variable. For example:
+```objc
+let writeKey
+ENV == 'production' ? (writeKey = 'A') : (writeKey = 'B')
+```
+
+
 ## Should I include each destination's native SDK in my project?
 
 No. Don't include destination-native SDKs manually for a service Segment supports. Instead, bundle the destination's Segment-integration SDK.

--- a/src/connections/sources/catalog/libraries/mobile/ios/ios-faqs.md
+++ b/src/connections/sources/catalog/libraries/mobile/ios/ios-faqs.md
@@ -29,7 +29,7 @@ If you choose not to use a dependency manager, you must manually keep files up-t
 
 
 ## Can I initiate multiple `writeKey`s for a single iOS project?
-No, we don't support sending events to multiple `writeKey`s for a single iOS project post-initialization. You can conditionally set the `writeKey` based on an environment variable. For example:
+No, Segment doesn't support sending events to multiple `writeKey`s for a single iOS project post-initialization. You can conditionally set the `writeKey` based on an environment variable. For example:
 ```objc
 let writeKey
 ENV == 'production' ? (writeKey = 'A') : (writeKey = 'B')


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
We are receiving tickets from time to time about loading multiple `writeKey`s for mobile sources. 

However, for both our iOS and Android libraries, our public documentation does not explicitly state that multiple `writeKey`s are not permitted for a single project.

### Merge timing
ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/KCS-1141