### PR TITLE
Update Destination Filters device-mode support

### DIFF
--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -31,7 +31,8 @@ Keep the following limitations in mind when you use destination filters:
 - *(For device-mode)* Destination filters don't filter some fields that are collected by the destination SDK outside of Segment such as `page.url` and `page.referrer`.
 - *(For web device-mode)* Destination filters for web device-mode only supports the Analytics.js 2.0 source. You need to enable device mode destination filters for your Analytics.js source. To do this, go to your Javascript source and navigate to **Settings > Analytics.js** and turn the toggle on for **Destination Filters**.
 - *(For web device-mode)* Destination filters for device-mode only supports the Analytics.js 2.0 source.
-- *(For mobile device-mode)* Destination filters for mobile device-mode is currenlty not supported.
+(Change here)
+- *(For mobile device-mode)* Destination filters for mobile device-mode is currenlty not supported. - (Change should be: *(For IOS and Android mobile device-mode)* Destination filters are currenlty not supported. Our newer libraries Swift and Kotlin are supported)
 - Destination Filters don't apply to events that send through the destination Event Tester.
 - Destination Filters within the UI and [FQL]([url](https://segment.com/docs/api/public-api/fql/)) do not currently support matching on event fields containing '.$' or '.$.', which references fields with an array type. 
 

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -31,7 +31,7 @@ Keep the following limitations in mind when you use destination filters:
 - *(For device-mode)* Destination filters don't filter some fields that are collected by the destination SDK outside of Segment such as `page.url` and `page.referrer`.
 - *(For web device-mode)* Destination filters for web device-mode only supports the Analytics.js 2.0 source. You need to enable device mode destination filters for your Analytics.js source. To do this, go to your Javascript source and navigate to **Settings > Analytics.js** and turn the toggle on for **Destination Filters**.
 - *(For web device-mode)* Destination filters for device-mode only supports the Analytics.js 2.0 source.
-- *(For IOS and Android mobile device-mode)* Destination filters are currenlty not supported. Our newer libraries Swift and Kotlin are supported)
+- - *(For IOS and Android mobile device-mode)* Destination filters are currently not supported. Our Swift, Kotlin and React Native libraries do support device-mode destination filters.
 - Destination Filters don't apply to events that send through the destination Event Tester.
 - Destination Filters within the UI and [FQL]([url](https://segment.com/docs/api/public-api/fql/)) do not currently support matching on event fields containing '.$' or '.$.', which references fields with an array type. 
 

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -31,8 +31,7 @@ Keep the following limitations in mind when you use destination filters:
 - *(For device-mode)* Destination filters don't filter some fields that are collected by the destination SDK outside of Segment such as `page.url` and `page.referrer`.
 - *(For web device-mode)* Destination filters for web device-mode only supports the Analytics.js 2.0 source. You need to enable device mode destination filters for your Analytics.js source. To do this, go to your Javascript source and navigate to **Settings > Analytics.js** and turn the toggle on for **Destination Filters**.
 - *(For web device-mode)* Destination filters for device-mode only supports the Analytics.js 2.0 source.
-(Change here)
-- *(For mobile device-mode)* Destination filters for mobile device-mode is currenlty not supported. - (Change should be: *(For IOS and Android mobile device-mode)* Destination filters are currenlty not supported. Our newer libraries Swift and Kotlin are supported)
+- *(For IOS and Android mobile device-mode)* Destination filters are currenlty not supported. Our newer libraries Swift and Kotlin are supported)
 - Destination Filters don't apply to events that send through the destination Event Tester.
 - Destination Filters within the UI and [FQL]([url](https://segment.com/docs/api/public-api/fql/)) do not currently support matching on event fields containing '.$' or '.$.', which references fields with an array type. 
 

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -31,7 +31,7 @@ Keep the following limitations in mind when you use destination filters:
 - *(For device-mode)* Destination filters don't filter some fields that are collected by the destination SDK outside of Segment such as `page.url` and `page.referrer`.
 - *(For web device-mode)* Destination filters for web device-mode only supports the Analytics.js 2.0 source. You need to enable device mode destination filters for your Analytics.js source. To do this, go to your Javascript source and navigate to **Settings > Analytics.js** and turn the toggle on for **Destination Filters**.
 - *(For web device-mode)* Destination filters for device-mode only supports the Analytics.js 2.0 source.
-- - *(For IOS and Android mobile device-mode)* Destination filters are currently not supported. Our Swift, Kotlin and React Native libraries do support device-mode destination filters.
+- - *(For iOS and Android mobile device-mode)* Destination filters aren't supported. Segment's Swift, Kotlin and React Native libraries do support device-mode destination filters.
 - Destination Filters don't apply to events that send through the destination Event Tester.
 - Destination Filters within the UI and [FQL]([url](https://segment.com/docs/api/public-api/fql/)) do not currently support matching on event fields containing '.$' or '.$.', which references fields with an array type. 
 


### PR DESCRIPTION
### Proposed changes

Adjusting the line for mobile device mode libraries. The older libraries such as IOS and Android don't have support for destination filters. 

Swift and Kotlin do have destination filter support.

### Merge timing

- ASAP once approved
