### PR TITLE
Fix slug override for AppFit

### DIFF
--- a/src/_data/catalog/slugs.yml
+++ b/src/_data/catalog/slugs.yml
@@ -211,7 +211,7 @@ destinations:
     override: "klayvio-actions"
   - original: "google-analytics-4-cloud"
     override: "actions-google-analytics-4"
-  - original: "app-fit"
+  - original: "appfit"
     override: "actions-app-fit"
   - original: "the-trade-desk-crm"
     override: "actions-the-trade-desk-crm"


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

App fit is not currently showing [in the docs catalog](https://segment.com/docs/connections/destinations/catalog/). This fixes that: 

verified locally: 
![Screenshot 2024-02-28 at 12 39 24 PM](https://github.com/segmentio/segment-docs/assets/64277654/6824fa10-5f29-4bc5-9600-cb585ec52185)


### Merge timing
asap