### PR TITLE
Add Email Alert Steps for Failed Events/Syncs

### DIFF
--- a/src/connections/event-delivery.md
+++ b/src/connections/event-delivery.md
@@ -111,3 +111,9 @@ When debugging, it's helpful to see when issues start, stop, and trend over time
 #### Latency
 
 How P95 latency has trended over the time period you selected.
+
+#### Email Alerts
+
+You can opt in to receive email alerts regarding failed events/syncs by going to your workspaace Settings > User Preferences > Activity Notifications > Destiantions. Then you can select the option to be alerted by Email and/or In-app. 
+
+

--- a/src/connections/event-delivery.md
+++ b/src/connections/event-delivery.md
@@ -92,7 +92,11 @@ To help you debug, Segment provides sample payloads from every step of the data'
 
 - **Request to Destination** - the request Segment made to the Partner API. This payload will likely be different from what you sent it because Segment is mapping your event to the partner's spec to ensure the message is successfully delivered. 
 
-- **Response from Destination** - the response Segment received from the Partner API. This will have the raw partner error. If you need to troubleshoot an issue with a Partner's Success team, this is usually something they'll want to see. 
+- **Response from Destination** - the response Segment received from the Partner API. This will have the raw partner error. If you need to troubleshoot an issue with a Partner's Success team, this is usually something they'll want to see.
+
+#### Email Alerts
+
+You can opt in to receive email alerts regarding failed events/syncs by going to your workspaace Settings > User Preferences > Activity Notifications > Destiantions. Then you can select the option to be alerted by Email and/or In-app. 
 
 
 ## 4. Trends
@@ -112,8 +116,5 @@ When debugging, it's helpful to see when issues start, stop, and trend over time
 
 How P95 latency has trended over the time period you selected.
 
-#### Email Alerts
-
-You can opt in to receive email alerts regarding failed events/syncs by going to your workspaace Settings > User Preferences > Activity Notifications > Destiantions. Then you can select the option to be alerted by Email and/or In-app. 
 
 


### PR DESCRIPTION
### Proposed changes

There have been a few inquiries regarding sending email alerts for failed events/syncs. I added a step-by-step process for how to add admin/users to be notified

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
