### PR TITLE
Update index.md

### DIFF
--- a/src/connections/sources/catalog/cloud-apps/stripe/index.md
+++ b/src/connections/sources/catalog/cloud-apps/stripe/index.md
@@ -11,7 +11,7 @@ id: 1bow82lmk
 1. In Segment go to **Connections** and click **Add Source**.
 2. Choose Stripe.
 3. Give the Source a nickname and click **Add Source**. The nickname is used to designate the source in the Segment interface, and Segment creates a related schema name. The schema name is the namespace you query against in your warehouse. The nickname can be whatever you like, but Segment recommends using a name that reflects the source itself and distinguishes amongst your environments.
-4. Click Connect, and authenticate with Stripe's OAuth.
+4. Click Connect, and authenticate with Stripe's OAuth. To use data from the Stripe test mode, [contact Segment Support](https://segment.com/help/contact/){:target="_blank"} with your test secret key and The support team will configure your source to use Test mode data.
 
 ## Components
 

--- a/src/connections/sources/catalog/cloud-apps/stripe/index.md
+++ b/src/connections/sources/catalog/cloud-apps/stripe/index.md
@@ -11,7 +11,7 @@ id: 1bow82lmk
 1. In Segment go to **Connections** and click **Add Source**.
 2. Choose Stripe.
 3. Give the Source a nickname and click **Add Source**. The nickname is used to designate the source in the Segment interface, and Segment creates a related schema name. The schema name is the namespace you query against in your warehouse. The nickname can be whatever you like, but Segment recommends using a name that reflects the source itself and distinguishes amongst your environments.
-4. Click Connect, and authenticate with Stripe's OAuth. To use data from the Stripe test mode, [contact Segment Support](https://segment.com/help/contact/){:target="_blank"} with your test secret key and The support team will configure your source to use Test mode data.
+4. Click **Connect**, and authenticate with Stripe's OAuth. To use data from Stripe's test mode, [contact Segment Support](https://segment.com/help/contact/){:target="_blank"} with your test Secret Key. Segment's support team can then configure your source to use test mode data.
 
 ## Components
 


### PR DESCRIPTION
addition new content on how to connect Stripe test mode.

### Proposed changes

At the moment, with the native OAuth integration we could only connect live instances of Stripe. To connect Test mode stripe the customer will have to reach out to the Customer Success engineering team with their test secret key.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?


### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
