### PR TITLE
Add information about traits and adding to context for new mobile lib…

### DIFF
--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -210,7 +210,7 @@ Other libraries only collect `context.library`, any other context variables must
 
 - userAgentData is only collected if the [Client Hints API](https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API){:target="_blank"} is available on the browser.
 
-- Traits are no longer collected and appended to the context of subsequent calls in the new mobile libraries (Swift, Kotlin, and React Native). 
+- Segment doesn't collect or append to the context of subsequent calls in the new mobile libraries (Swift, Kotlin, and React Native). 
 
 To pass the context variables which are not automatically collected by Segment's libraries, you must manually include them in the event payload. The following code shows how to pass `groupId` as the context field of Analytics.js's `.track()` event:
 
@@ -220,10 +220,10 @@ analytics.track("Report Submitted", {},
 );
 ```
 
-In order to add fields to the context object in the new mobile libraries, you must utilize a custom plugin. Documentation for creating plugins for each library can be found here:
-- [React Native](https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/#plugin-architecture){:target="_blank"}
-- [Swift](https://segment.com/docs/connections/sources/catalog/libraries/mobile/apple/swift-plugin-architecture/){:target="_blank"}
-- [Kotlin](https://segment.com/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-plugin-architecture/){:target="_blank"}
+To add fields to the context object in the new mobile libraries, you must utilize a custom plugin. Documentation for creating plugins for each library can be found here:
+- [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/#plugin-architecture)
+- [Swift](/docs/connections/sources/catalog/libraries/mobile/apple/swift-plugin-architecture/)
+- [Kotlin](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-plugin-architecture/)
 
 
 ## Integrations

--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -210,6 +210,8 @@ Other libraries only collect `context.library`, any other context variables must
 
 - userAgentData is only collected if the [Client Hints API](https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API){:target="_blank"} is available on the browser.
 
+- Traits are no longer collected and appended to the context of subsequent calls in the new mobile libraries (Swift, Kotlin, and React Native). 
+
 To pass the context variables which are not automatically collected by Segment's libraries, you must manually include them in the event payload. The following code shows how to pass `groupId` as the context field of Analytics.js's `.track()` event:
 
 ```js
@@ -217,6 +219,11 @@ analytics.track("Report Submitted", {},
     {"groupId": "1234"}
 );
 ```
+
+In order to add fields to the context object in the new mobile libraries, you must utilize a custom plugin. Documentation for creating plugins for each library can be found here:
+- [React Native](https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/#plugin-architecture){:target="_blank"}
+- [Swift](https://segment.com/docs/connections/sources/catalog/libraries/mobile/apple/swift-plugin-architecture/){:target="_blank"}
+- [Kotlin](https://segment.com/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-plugin-architecture/){:target="_blank"}
 
 
 ## Integrations


### PR DESCRIPTION
### Proposed changes

We frequently get questions about why traits aren't in the context object of new libraries. Added a note that traits are not longer collected and appended to context for new mobile libraries. Also added a section to note that if you want to add to the context object for these libraries, customers must use a custom plugin. 

### Merge timing
- ASAP once approved

### Related issues (optional)

n/a
