### PR TITLE
Add Proxy info for mobile libraries

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/apple/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/index.md
@@ -160,7 +160,7 @@ Analytics for Swift is built with extensibility in mind. Use the tools list belo
 - [Code samples](/docs/connections/sources/catalog/libraries/mobile/swift/swift-samples)
 
 ## Proxying events
-If you proxy your events through the `apiHost` config option, you must forward the batched events to the following Segment endpoint `https://api.segment.io/v1/b`. The `https://api.segment.io/v1/batch` endpoint is reserved for events arriving from server side sending, and proxying to that endpoint for your mobile events may result in unexpected behavior.
+If you proxy your events through the `apiHost` config option, you must forward the batched events to `https://api.segment.io/v1/b`. The `https://api.segment.io/v1/batch` endpoint is reserved for events arriving from server-side sending, and proxying to that endpoint for your mobile events may result in unexpected behavior.
 
 > warning ""
 > If you are using the Analytics iOS (Classic) SDK, you can find [the documentation here](/docs/connections/sources/catalog/libraries/mobile/ios). Many of the features available in the Analytics-Swift SDK are not available in the Analytics iOS (Classic) SDK. 

--- a/src/connections/sources/catalog/libraries/mobile/apple/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/index.md
@@ -159,6 +159,9 @@ Analytics for Swift is built with extensibility in mind. Use the tools list belo
 - [Destination Filters](/docs/connections/sources/catalog/libraries/mobile/swift/swift-destination-filters)
 - [Code samples](/docs/connections/sources/catalog/libraries/mobile/swift/swift-samples)
 
+## Proxying events
+If you proxy your events through the `apiHost` config option, you must forward the batched events to the following Segment endpoint `https://api.segment.io/v1/b`. The `https://api.segment.io/v1/batch` endpoint is reserved for events arriving from server side sending, and proxying to that endpoint for your mobile events may result in unexpected behavior.
+
 > warning ""
 > If you are using the Analytics iOS (Classic) SDK, you can find [the documentation here](/docs/connections/sources/catalog/libraries/mobile/ios). Many of the features available in the Analytics-Swift SDK are not available in the Analytics iOS (Classic) SDK. 
 

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-faq.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-faq.md
@@ -82,3 +82,6 @@ When you successfully package a plugin in device-mode, you will no longer see th
 
 ## What is the instanceId set in context?
 The instanceId was introduced in [V 1.10.1](https://github.com/segmentio/analytics-kotlin/releases/tag/1.10.1){:target="_blank"} and correlates events to a particular instance of the client in a scenario when you might have multiple instances on a single app.
+
+## If I use a proxy, what Segment endpoint should I send to?
+If you proxy your events through the `apiHost` config option, you must forward the batched events to the following Segment endpoint `https://api.segment.io/v1/b`. The `https://api.segment.io/v1/batch` endpoint is reserved for events arriving from server side sending, and proxying to that endpoint for your mobile events may result in unexpected behavior.

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-faq.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-faq.md
@@ -84,4 +84,4 @@ When you successfully package a plugin in device-mode, you will no longer see th
 The instanceId was introduced in [V 1.10.1](https://github.com/segmentio/analytics-kotlin/releases/tag/1.10.1){:target="_blank"} and correlates events to a particular instance of the client in a scenario when you might have multiple instances on a single app.
 
 ## If I use a proxy, what Segment endpoint should I send to?
-If you proxy your events through the `apiHost` config option, you must forward the batched events to the following Segment endpoint `https://api.segment.io/v1/b`. The `https://api.segment.io/v1/batch` endpoint is reserved for events arriving from server side sending, and proxying to that endpoint for your mobile events may result in unexpected behavior.
+If you proxy your events through the `apiHost` config option, you must forward the batched events to `https://api.segment.io/v1/b`. The `https://api.segment.io/v1/batch` endpoint is reserved for events arriving from server side sending, and proxying to that endpoint for your mobile events may result in unexpected behavior.

--- a/src/connections/sources/catalog/libraries/mobile/react-native/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/index.md
@@ -751,5 +751,9 @@ segmentClient.userInfo.set((currentUserInfo) => {
   });
 ```
 
+### If I use a proxy, what Segment endpoint should I send to?
+If you proxy your events through the `proxy` config option, you must forward the batched events to the following Segment endpoint `https://api.segment.io/v1/b`. The `https://api.segment.io/v1/batch` endpoint is reserved for events arriving from server side sending, and proxying to that endpoint for your mobile events may result in unexpected behavior.
+
+
 ## Changelog
 [View the Analytics React Native changelog on GitHub](https://github.com/segmentio/analytics-react-native/releases){:target="_blank"}.

--- a/src/connections/sources/catalog/libraries/mobile/react-native/index.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/index.md
@@ -752,7 +752,7 @@ segmentClient.userInfo.set((currentUserInfo) => {
 ```
 
 ### If I use a proxy, what Segment endpoint should I send to?
-If you proxy your events through the `proxy` config option, you must forward the batched events to the following Segment endpoint `https://api.segment.io/v1/b`. The `https://api.segment.io/v1/batch` endpoint is reserved for events arriving from server side sending, and proxying to that endpoint for your mobile events may result in unexpected behavior.
+If you proxy your events through the `proxy` config option, you must forward the batched events to `https://api.segment.io/v1/b`. The `https://api.segment.io/v1/batch` endpoint is reserved for events arriving from server side sending, and proxying to that endpoint for your mobile events may result in unexpected behavior.
 
 
 ## Changelog


### PR DESCRIPTION
### Proposed changes
Batched client side events should always send to /b endpoint. We have logic on the segment server side to mark these events that arrive at  /b as sending from the client side. 
Sending to /batch can cause issues with the data.