### PR TITLE
Add info about mobile device mode destination filters

### DIFF
--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -31,7 +31,11 @@ Keep the following limitations in mind when you use destination filters:
 - *(For device-mode)* Destination filters don't filter some fields that are collected by the destination SDK outside of Segment such as `page.url` and `page.referrer`.
 - *(For web device-mode)* Destination filters for web device-mode only supports the Analytics.js 2.0 source. You need to enable device mode destination filters for your Analytics.js source. To do this, go to your Javascript source and navigate to **Settings > Analytics.js** and turn the toggle on for **Destination Filters**.
 - *(For web device-mode)* Destination filters for device-mode only supports the Analytics.js 2.0 source.
-- - *(For iOS and Android mobile device-mode)* Destination filters aren't supported. Segment's Swift, Kotlin and React Native libraries do support device-mode destination filters.
+- *(For iOS and Android mobile device-mode)* Destination filters aren't supported. Segment's Swift, Kotlin and React Native libraries do support device-mode destination filters.
+- *(For Kotlin, Swift, and React Native device-mode)* You must enable the filters for your source. To do this, go to your source and navigate to **Settings >> Advanced** and turn on the toggle for **Destination Filters**. Once this is done, you still need to add the Destination Filters plugin to your application. Instructions for this can be found here:
+  - [Kotlin](https://segment.com/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-destination-filters/#destination-filters){:target="_blank"}
+  - [Swift](https://segment.com/docs/connections/sources/catalog/libraries/mobile/apple/swift-destination-filters/){:target="_blank"}
+  - [React Native](https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/react-native-destination-filters/){:target="_blank"}
 - Destination Filters don't apply to events that send through the destination Event Tester.
 - Destination Filters within the UI and [FQL]([url](https://segment.com/docs/api/public-api/fql/)) do not currently support matching on event fields containing '.$' or '.$.', which references fields with an array type. 
 

--- a/src/connections/destinations/destination-filters.md
+++ b/src/connections/destinations/destination-filters.md
@@ -32,12 +32,12 @@ Keep the following limitations in mind when you use destination filters:
 - *(For web device-mode)* Destination filters for web device-mode only supports the Analytics.js 2.0 source. You need to enable device mode destination filters for your Analytics.js source. To do this, go to your Javascript source and navigate to **Settings > Analytics.js** and turn the toggle on for **Destination Filters**.
 - *(For web device-mode)* Destination filters for device-mode only supports the Analytics.js 2.0 source.
 - *(For iOS and Android mobile device-mode)* Destination filters aren't supported. Segment's Swift, Kotlin and React Native libraries do support device-mode destination filters.
-- *(For Kotlin, Swift, and React Native device-mode)* You must enable the filters for your source. To do this, go to your source and navigate to **Settings >> Advanced** and turn on the toggle for **Destination Filters**. Once this is done, you still need to add the Destination Filters plugin to your application. Instructions for this can be found here:
-  - [Kotlin](https://segment.com/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-destination-filters/#destination-filters){:target="_blank"}
-  - [Swift](https://segment.com/docs/connections/sources/catalog/libraries/mobile/apple/swift-destination-filters/){:target="_blank"}
-  - [React Native](https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/react-native-destination-filters/){:target="_blank"}
+- *(For Kotlin, Swift, and React Native device-mode)* You must enable the filters for your source. To do this, go to your source and navigate to **Settings >> Advanced** and turn on the toggle for **Destination Filters**. After you've done that, you'll still need to add the Destination Filters plugin to your application. Instructions for this can be found here:
+  - [Kotlin](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-destination-filters/#destination-filters){:target="_blank"}
+  - [Swift](/docs/connections/sources/catalog/libraries/mobile/apple/swift-destination-filters/){:target="_blank"}
+  - [React Native](/docs/connections/sources/catalog/libraries/mobile/react-native/react-native-destination-filters/){:target="_blank"}
 - Destination Filters don't apply to events that send through the destination Event Tester.
-- Destination Filters within the UI and [FQL]([url](https://segment.com/docs/api/public-api/fql/)) do not currently support matching on event fields containing '.$' or '.$.', which references fields with an array type. 
+- Destination Filters within the UI and [FQL](/docs/api/public-api/fql/) do not currently support matching on event fields containing '.$' or '.$.', which references fields with an array type. 
 
 [Contact Segment](https://segment.com/help/contact/){:target="_blank"} if these limitations impact your use case.
 


### PR DESCRIPTION

### Proposed changes

Customers will either not enable the setting in the source for these, or they will enable it but not include the plugin. This adds more clarity that both are needed for device mode destination filters to work for mobile.

### Merge timing
- ASAP once approved


### Related issues (optional)

n/a
