### PR TITLE
Clarify ipv6 docs

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/identity.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/identity.md
@@ -218,7 +218,10 @@ analytics.ready(function() {
 
 Segment automatically collects the user's IP address for device-based (iOS, Android, Analytics.js and Xamarin) events.
 
-You can pass a value for `options.context.ip` to prevent the Segment systems from recording the IP address for the request, as in the example below.
+> info "IPv6"
+> At the moment, Segment doesn't support automatically collecting IPv6 addresses.
+
+You can manually set the IP by passing a value for `options.context.ip` to prevent the Segment systems from recording the IP address for the request, as in the example below.
 
 ```js
   analytics.track("Order Completed", {}, { context: { ip: "0.0.0.0" }});
@@ -226,5 +229,3 @@ You can pass a value for `options.context.ip` to prevent the Segment systems fro
 
 You must add this override to _every_ Track call to explicitly override IP collection. If you reset this trait in the context object, Segment defaults to the normal IP collection behavior.
 
-> info "IPv6"
-> Segment doesn't support collecting IPv6 addresses.


### PR DESCRIPTION
The current call out at the bottom makes it sound a bit like if you pass an ipv6 address in context, we just ignore it.

Added some detail.