### PR TITLE
Fixed minor change from 100,000 to 110,000 update user-deletion-and-suppression.md

### DIFF
--- a/src/privacy/user-deletion-and-suppression.md
+++ b/src/privacy/user-deletion-and-suppression.md
@@ -4,7 +4,7 @@ title: "User Deletion and Suppression"
 
 In keeping with Segment's commitment to GDPR and CCPA readiness, Segment offers the ability to delete and suppress data about end-users when they are identifiable by a `userId`, should they revoke or alter consent to data collection. For example, if an end-user invokes the Right to Object or Right to Erasure under the GDPR or CCPA, you can use these features to block ongoing data collection about that user and delete all historical data about them from Segment's systems, connected S3 buckets and warehouses, and supported downstream partners.
 
-[Contact Support](https://segment.com/help/contact/) if you need to process more than 100,000 users within a 30 day period.
+[Contact Support](https://segment.com/help/contact/) if you need to process more than 110,000 users within a 30 day period.
 
 > info "Business Plan Customers"
 > If you use this feature to delete data, you can not Replay the deleted data. For standard Replay requests, you must wait for any pending deletions to complete, and you cannot submit new deletion requests for the period of time that Segment replays data for you.
@@ -50,7 +50,7 @@ Segment deletes messages with this `userId` from connected raw data Destinations
 
 Segment forwards these deletion requests to a [growing list of supported partners](/docs/privacy/faq/#which-destinations-can-i-send-deletion-requests-to).
 
-Note that Segment has a 30-day SLA for submitted deletion requests. Additionally, Segment's deletion manager can only accommodate 100,000 users within a 30-day period and cannot guarantee a 30-day SLA if there are more than 100,000 deletion requests submitted within those 30 days. You can delete up to 5000 `userId`s per call via Public API. [Contact Support](https://segment.com/help/contact/){:target="_blank"} if you need to process more than 100,000 users within a 30 day period.
+Note that Segment has a 30-day SLA for submitted deletion requests. Additionally, Segment's deletion manager can only accommodate 110,000 users within a 30-day period and cannot guarantee a 30-day SLA if there are more than 110,000 deletion requests submitted within those 30 days. You can delete up to 5000 `userId`s per call via Public API. [Contact Support](https://segment.com/help/contact/){:target="_blank"} if you need to process more than 110,000 users within a 30 day period.
  
 **Segment cannot guarantee that data is deleted from your Destinations.**
 


### PR DESCRIPTION



### Proposed changes

Deletion Suppression now defaults to supporting 110,000 deletions per workspace each month. So, fixed minor change from 100,000 to 110,000 update user-deletion-and-suppression.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
