### PR TITLE
Add note about change in sentat in new mobile libraries

### DIFF
--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -276,6 +276,9 @@ The `sentAt` timestamp specifies the clock time for the client's device when the
 
 **Note:** The `sentAt` timestamp is not useful for any analysis since it's tainted by user's clock skew.
 
+> warning ""
+> When `sentAt` is added to a payload has been changed in the Swift, Kotlin, and C# mobile libraries. The `sentAt` value is now added when the batch is complete and initially tried to the Segment API. This changes the value of the Segment calculated `timestamp` to align closer with the `receivedAt` value rather than the `originalTimestamp` value. For most users who are online when events are sent, this will not impact the data in any significant way. However, if your application utilizes an offline mode where events are queued up for any period of time, the `timestamp` value will more closely reflect when the events were received by Segment, rather than the time they occurred on the users device. 
+
 
 ### receivedAt
 

--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -276,8 +276,8 @@ The `sentAt` timestamp specifies the clock time for the client's device when the
 
 **Note:** The `sentAt` timestamp is not useful for any analysis since it's tainted by user's clock skew.
 
-> warning ""
-> When `sentAt` is added to a payload has been changed in the Swift, Kotlin, and C# mobile libraries. The `sentAt` value is now added when the batch is complete and initially tried to the Segment API. This changes the value of the Segment calculated `timestamp` to align closer with the `receivedAt` value rather than the `originalTimestamp` value. For most users who are online when events are sent, this will not impact the data in any significant way. However, if your application utilizes an offline mode where events are queued up for any period of time, the `timestamp` value will more closely reflect when the events were received by Segment, rather than the time they occurred on the users device. 
+> warning "Segment now adds `sentAt` to a payload when the batch is complete and initially tried to the Segment API for the Swift, Kotlin, and C# mobile libraries"
+> This update changes the value of the Segment-calculated `timestamp` to align closer with the `receivedAt` value rather than the `originalTimestamp` value. For most users who are online when events are sent, this does not significantly impact their data. However, if your application utilizes an offline mode where events are queued up for any period of time, the `timestamp` value for those users now more closely reflects when Segment received the events rather than the time they occurred on the users' devices. 
 
 
 ### receivedAt


### PR DESCRIPTION

### Proposed changes

The mobile team has changed when the `sentAt` timestamp is added to the event payload causing a skew in the Segment calculated timestamp. This has not been documented but could impact the timestamps of events received in downstream destinations. 

### Merge timing
- ASAP once approved


### Related issues (optional)

n/a