### PR TITLE
clear up common Actions misconception

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -270,3 +270,7 @@ Access Tokens that were generated from initial authorization, for example, when 
 
 The underlying systems for these flows have their own copy of the token, which can expire at different points in time.
 Threfore, if you see a 401 error in a sample response, it is likely that you’ll also see another request was made after it, to ask the downstream destination for a new token. Then one more request was made to actually send the data in your payload to the downstream destination.
+
+### Is it possible to map a field from one event to another?
+
+Segment integrations process events through mappings individially. This means that no context is held that would allow you to map a value from one event to the field of a subsequent event. Each event itself must contain all of the data you'd like to send downstream in regards to it. For example, you cannot send `email` in on an Identify call and then access that same `email` field on a Track call that comes in later if that Track call doesn't also have `email` set on it. 


### PR DESCRIPTION
### Proposed changes

Customers often have a misconception that Actions destinations allow for mapping fields from one event to another. This change clarifies that.

### Merge timing

ASAP is fine