### PR TITLE
Fixed broken external links [DOC-768]

### DIFF
--- a/ignore-links.txt
+++ b/ignore-links.txt
@@ -71,3 +71,10 @@ https://segment.com/docs/connections/sources/catalog/cloud-apps/snowflake/
 https://segment.com/docs/connections/destinations/catalog/adobe-target-cloud-mode/
 https://segment.com/docs/connections/destinations/catalog/adobe-target-web/
 https://segment.com/docs/connections/destinations/catalog/google-ads-remarketing-lists/
+https://compose.aampe.com/configure/integrations
+https://everboarding.trybento.co/data
+https://app.getcorrelated.com/integrations
+https://app.launchdarkly.com/default/production/debugger/goals
+https://www.app.metricstory.ai/account/apikeys
+https://app.unstack.com/login
+https://github.com/fubotv/segment-analytics-android/pull/1

--- a/src/connections/destinations/catalog/actions-absmartly/index.md
+++ b/src/connections/destinations/catalog/actions-absmartly/index.md
@@ -39,7 +39,7 @@ for this purpose.
 > info ""
 > By default, the _Track Calls_ mapping will filter and not send any events with the name `Experiment Viewed` to ABsmartly.
 
-You can [install a custom event logger](https://docs.absmartly.com/docs/sdk%20documentation/getting-started/#using-a-custom-event-logger){:target="_blank"} in ABsmartly and send exposures directly to Segment.
+You can [install a custom event logger](https://docs.absmartly.com/docs/SDK-Documentation/getting-started#using-a-custom-event-logger){:target="_blank"} in ABsmartly and send exposures directly to Segment.
 
 ```javascript
 analytics.ready(function() {

--- a/src/connections/destinations/catalog/actions-snap-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-snap-conversions/index.md
@@ -57,7 +57,7 @@ There are many ways to send conversion data to Snap, including through the Snap 
 The Client Deduplication ID allows for a 48-hour deduplication window. The Transaction ID is only eligible for `PURCHASE` events and allows for a 30-day deduplication window. See Snapchat’s [Marketing API documentation](https://marketingapi.snapchat.com/docs/conversion.html#deduplication){:target="_blank"} and [Business Help Center](https://businesshelp.snapchat.com/s/article/event-deduplication?language=en_US){:target="_blank"} for more information.
 
 > info ""
-> Segment does not have client-side destinations for the Snap Pixel or Snap App Ads Kit (SDK). If you choose to integrate client-side, these must be implemented natively. See Snapchat’s [Install Snap Pixel](https://businesshelp.snapchat.com/s/article/pixel-website-install?language=en_US){:target="_blank"} and [App Ads Kit](https://businesshelp.snapchat.com/s/article/app-ads-kit?language=en_US){:target="_blank"} for implementation details.
+> Segment does not have client-side destinations for the Snap Pixel or Snap App Ads Kit (SDK). If you choose to integrate client-side, these must be implemented natively. See Snapchat’s [Install Snap Pixel](https://businesshelp.snapchat.com/s/article/pixel-website-install?language=en_US){:target="_blank"} and [App Ads Kit](https://businesshelp.snapchat.com/s/topic/0TO0y000000YmidGAC/app-ads-kit?language=en_US){:target="_blank"} for implementation details.
 
 ### Latency
 It may take up to 1-hour for events to appear in the Snapchat [Events Manager](https://businesshelp.snapchat.com/s/article/events-manager?language=en_US){:target="_blank"}.

--- a/src/connections/destinations/catalog/adobe-analytics/best-practices.md
+++ b/src/connections/destinations/catalog/adobe-analytics/best-practices.md
@@ -9,7 +9,7 @@ This page contains best practices and tips for setting up and testing Adobe Anal
 
 The following list contains tools you can use to validate data coming from Segment and going to each different Adobe Analytics component
 
-- **Analytics.js** - [Adobe Experience Cloud Debugger](https://chrome.google.com/webstore/detail/adobe-experience-cloud-de/ocdmogmohccmeicdhlhhgepeaijenapj){:target="_blank”} and Chrome Developer Tools
+- **Analytics.js** - [Adobe Experience Cloud Debugger](https://chromewebstore.google.com/detail/adobe-experience-platform/bfnnokhpnncpkdmbokanobigaccjkpob){:target="_blank”} and Chrome Developer Tools
 - **Other Segment server libraries** - Segment's in-app [Event Tester Tool](/docs/connections/test-connections/)
 - **iOS Device mode** - Charles Proxy, DEBUG mode
 - **Android Device Mode** - Charles Proxy, VERBOSE logging

--- a/src/connections/destinations/catalog/braze/index.md
+++ b/src/connections/destinations/catalog/braze/index.md
@@ -67,7 +67,7 @@ Braze created a sample iOS application that integrates Braze using Segment. See 
 
 #### Device-mode set up for iOS 14 support
 
-Braze updated the Braze iOS Segment SDK to 3.26.1 to prepare for iOS 14. As of version 3.27.0, Braze removed the `ABK_ENABLE_IDFA_COLLECTION` macro. To configure sending ISFA to Braze, see Braze's [Implementing IDFA Collection](https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations/#ios-14-apptrackingtransparency){:target="_blank"}
+Braze updated the Braze iOS Segment SDK to 3.26.1 to prepare for iOS 14. As of version 3.27.0, Braze removed the `ABK_ENABLE_IDFA_COLLECTION` macro. To configure sending ISFA to Braze, see Braze's [Implementing IDFA Collection](https://www.braze.com/docs/developer_guide/platform_integration_guides/legacy_sdks/ios/initial_sdk_setup/other_sdk_customizations/){:target="_blank"}
  documentation.
 
 To use the latest Braze SDK to collect IDFAs you must do the following:
@@ -76,7 +76,7 @@ To use the latest Braze SDK to collect IDFAs you must do the following:
 2. Update the Braze iOS Segment SDK to version 3.3.0 or greater.
 3. Import and add the AppTrackingTransparency (ATT) Framework.
    - Navigate to your project `Info.plist` and add a “Privacy - Tracking Usage Description”. This description appears in a popup when the application initializes in iOS 14. Applications prompt users to select if they want to allow tracking.
-4. Add Braze's `ABKIDFADelegate`. For more information on how to add this see [Braze's IDFA Collection documentation](https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations/#implementing-idfa-collection){:target="_blank"}
+4. Add Braze's `ABKIDFADelegate`. For more information on how to add this see [Braze's IDFA Collection documentation](https://www.braze.com/docs/developer_guide/platform_integration_guides/legacy_sdks/ios/initial_sdk_setup/other_sdk_customizations#implementing-idfa-collectionn){:target="_blank"}
 .
 5. Follow [Segment's guide for collecting IDFA](/docs/connections/sources/catalog/libraries/mobile/ios/#idfa-collection-in-40-beta-and-later)
 
@@ -122,7 +122,7 @@ Segment sends Page calls to Braze as custom events if you have enabled either **
 
 > info "Tip"
 > Add Segment's open-source [Middleware](https://github.com/segmentio/segment-braze-mobile-middleware){:target="_blank"}
- tool to optimize your integration. This tool limits [Data Point](https://www.braze.com/docs/user_guide/onboarding_with_braze/data_points/){:target="_blank"} use by debouncing duplicate identify() calls from Segment. For more information, see the project's [README](https://github.com/segmentio/segment-braze-mobile-middleware/blob/master/README.md#how-does-this-work){:target="_blank"}.
+ tool to optimize your integration. This tool limits [Data Point](https://www.braze.com/docs/user_guide/data_and_analytics/data_points/){:target="_blank"} use by debouncing duplicate identify() calls from Segment. For more information, see the project's [README](https://github.com/segmentio/segment-braze-mobile-middleware/blob/master/README.md#how-does-this-work){:target="_blank"}.
 
 If you're not familiar with the Segment Specs, take a look to understand what the [Identify method](/docs/connections/spec/identify/) does. An example call would look like:
 
@@ -193,7 +193,7 @@ Segment sends all other traits (except Braze's [reserved user profile fields](ht
 ## Track
 
 > info "Tip"
-> To lower [Data Point](https://www.braze.com/docs/user_guide/onboarding_with_braze/data_points/){:target="_blank"} use, limit the events you send to Braze to those that are relevant for campaigns and segmentation to the Braze destination. For more information, see [Schema Controls](/docs/protocols/schema/).
+> To lower [Data Point](https://www.braze.com/docs/user_guide/data_and_analytics/data_points/){:target="_blank"} use, limit the events you send to Braze to those that are relevant for campaigns and segmentation to the Braze destination. For more information, see [Schema Controls](/docs/protocols/schema/).
 
 If you're not familiar with the Segment Specs, take a look to understand what the [Track method](/docs/connections/spec/track/) does. An example call looks like:
 
@@ -325,7 +325,7 @@ The `inAppMessages` parameter will be an array of [`appboy.ab.InAppMessage`](htt
         [[SEGAppboyIntegrationFactory instance] saveRemoteNotification:userInfo];
       }
     ```
-6. If you are using the `UserNotification` framework, follow [Braze's documentation](https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/push_notifications/integration/#using-usernotification-framework-ios-10){:target="_blank"} to register push notifications using the `UserNotification` framework. Then in your application's `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler` method, add the following:
+6. If you are using the `UserNotification` framework, follow [Braze's documentation](https://www.braze.com/docs/developer_guide/platform_integration_guides/legacy_sdks/ios/push_notifications/integration#using-usernotification-framework-ios-10){:target="_blank"} to register push notifications using the `UserNotification` framework. Then in your application's `userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler` method, add the following:
 
     ```objc
     if ([Appboy sharedInstance] == nil) {
@@ -624,4 +624,4 @@ No. Audiences are sent to Braze as either custom attributes or custom events. Yo
 All Braze user profile data (including custom events, custom attributes) is stored for as long as those profiles are active.
 
 #### What happens if I delete a computed trait or audience in Segment?
-When you delete an audience or trait in Segment they are not deleted from Braze. Data sent to Braze is immutable and cannot be deleted or modified once they receive it. However, you can [blocklist](https://www.braze.com/docs/user_guide/administrative/app_settings/manage_app_group/custom_event_and_attribute_management/#blacklisting-custom-attributes-custom-events-and-products){:target="_blank"} custom attributes and events in Braze.
+When you delete an audience or trait in Segment they are not deleted from Braze. Data sent to Braze is immutable and cannot be deleted or modified once they receive it. However, you can [blocklist](https://www.braze.com/docs/user_guide/data_and_analytics/custom_data/managing_custom_data#blocklisting-custom-data){:target="_blank"} custom attributes and events in Braze.

--- a/src/connections/destinations/catalog/cdpresolution/index.md
+++ b/src/connections/destinations/catalog/cdpresolution/index.md
@@ -7,7 +7,7 @@ beta: true
 
 {% include content/plan-grid.md name="actions" %}
 
-[CDP Resolution](https://cdpresolution.com?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank"} helps customers instantly match visitor website traffic to full profiles. It turns your anonymous web traffic into full company and buyer profiles — complete with PII and firmographics data, and much more. You can find a [list of the different attributes](https://cdpresolution.com/theattributes?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank"} you can collect with CDP Resolution.
+[CDP Resolution](https://cdpresolution.com?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank"} helps customers instantly match visitor website traffic to full profiles. It turns your anonymous web traffic into full company and buyer profiles — complete with PII and firmographics data, and much more. You can find a [list of the different attributes](https://www.cdpresolution.com/resources/UPID){:target="_blank"} you can collect with CDP Resolution.
 
 This destination is maintained by CDP Resolution. For any issues with the destination, [contact the CDP Resolution support team](mailto:support@cdpresolution.com).
 
@@ -25,8 +25,6 @@ To set up the CDP Resolution destination:
 2.	Paste your CDP Resolution API key in Segment to generate your Write Key.
 3.	Paste your Write Key into CDP Resolution's connection configuration.
 4.	Click **Upload Key**.
-
-Further documentation can be found on the [CDP documentation site](https://docs.cdpresolution.com?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank"}.
 
 If you have configured your CDP Resolution Destination correctly, and if you've also configured CDP Resolution to send user profile data to a Segment Source, you should start to see user profile data shown in the Segment Source debugger as identify() and group() calls.
 

--- a/src/connections/destinations/catalog/correlated/index.md
+++ b/src/connections/destinations/catalog/correlated/index.md
@@ -8,7 +8,7 @@ id: 60df6d4c038b872f10c54801
 This destination is maintained by Correlated. For any issues with the destination, [contact the Correlated Support team](mailto:support@getcorrelated.com).
 
 > success ""
-> Set up a free account with Correlated by visiting their [website](https://www.getcorrelated.com/get-started){:target="_new"}.
+> Set up a free account with Correlated by visiting their [website](https://docs.getcorrelated.com/docs/setting-up-your-account){:target="_new"}.
 
 ## Getting Started
 

--- a/src/connections/destinations/catalog/courier/index.md
+++ b/src/connections/destinations/catalog/courier/index.md
@@ -81,7 +81,7 @@ Segment Track events are inbound events that might trigger a notification when C
 
 All Inbound Events coming from Segment Track calls appear with a `Segment-TrackEvent` prefix in Courier to help distinguish them from other inbound events.
 
-Courier extracts data from the Segment Track `properties` object, and conditionally triggers a request to the [Courier Send API](https://www.courier.com/docs/reference/send/message/){:target="_blank”} - only if that event is already [mapped](https://help.courier.com/en/articles/4202416-how-to-create-and-map-event-triggers-for-your-notifications){:target="_blank”}.
+Courier extracts data from the Segment Track `properties` object, and conditionally triggers a request to the [Courier Send API](https://www.courier.com/docs/reference/send/message/){:target="_blank”} - only if that event is already [mapped](https://www.courier.com/docs/platform/sending/create-map-events/){:target="_blank”}.
 
 - Segment passes all `properties` from the Track call to the `Send API` as elements in the `data` json objects. You can use these data points as variables in the Notification Template or as input on conditional routing logic.
 - Courier uses the `userId` or `anonymousId` to look up and include the associated `User Profile` with the inbound event. (See the note in the [Identify section](#identify) above.)

--- a/src/connections/destinations/catalog/everflow/index.md
+++ b/src/connections/destinations/catalog/everflow/index.md
@@ -49,6 +49,6 @@ If you aren't familiar with the Segment Spec, take a look at the [Track method d
 The TransactionId (`context.referrer.id`) and `context.referrer.type` are **required** fields. Read more about how to pass the TransactionId in [Everflow's TransactionId Documentation](https://developers.everflow.io/docs/everflow-sdk/click_tracking/){:target="_blank"}
 
 ### Property Mappings
-The data type for Segment properties must match the data type set in Everflow for the corresponding property. Read more about how Everflow maps Segment properties in [Everflow's Properties Mapping documentation](https://helpdesk.everflow.io/en/articles/4785627-integrations-segment){:target="_blank"}.
+The data type for Segment properties must match the data type set in Everflow for the corresponding property. Read more about how Everflow maps Segment properties in [Everflow's Properties Mapping documentation](https://helpdesk.everflow.io/en/articles/6288916-segment-integration){:target="_blank"}.
 
 Custom properties are not supported at this time.

--- a/src/connections/destinations/catalog/everflow/index.md
+++ b/src/connections/destinations/catalog/everflow/index.md
@@ -43,7 +43,7 @@ If you aren't familiar with the Segment Spec, take a look at the [Track method d
 ```
 
 > warning "Map your events"
-> To track the event, go to the Everflow Segment destination settings, and in the Segment event name field, enter the Advertiser ID from your [Offer's Revenue & Payout card](https://helpdesk.everflow.io/en/articles/3673712-offer-revenue-payout){:target="_blank"}.
+> To track the event, go to the Everflow Segment destination settings, and in the Segment event name field, enter the Advertiser ID from your [Offer's Revenue & Payout card](https://helpdesk.everflow.io/en/articles/6125868-offer-revenue-payout){:target="_blank"}.
 
 ### TransactionId
 The TransactionId (`context.referrer.id`) and `context.referrer.type` are **required** fields. Read more about how to pass the TransactionId in [Everflow's TransactionId Documentation](https://developers.everflow.io/docs/everflow-sdk/click_tracking/){:target="_blank"}

--- a/src/connections/destinations/catalog/experiments-by-growthhackers/index.md
+++ b/src/connections/destinations/catalog/experiments-by-growthhackers/index.md
@@ -4,7 +4,7 @@ title: Experiments by Growthhackers Destination
 redirect_from: '/connections/destinations/catalog/northstar-by-growthhackers/'
 id: 5cc205876b9a830001432515
 ---
-[Experiments by Growthhackers](http://growthhackers.com/software){:target="_blank"} provides a project management tool for growth teams, allowing companies to create and prioritize ideas, run experiments and gather data to learn upon!
+[Experiments by Growthhackers](https://growth.software/){:target="_blank"} provides a project management tool for growth teams, allowing companies to create and prioritize ideas, run experiments and gather data to learn upon!
 
 This destination is maintained by Experiments by Growthhackers. For any issues with the destination, [contact the Growthhackers Support team](mailto:tech@growthhackers.com).
 

--- a/src/connections/destinations/catalog/graphjson/index.md
+++ b/src/connections/destinations/catalog/graphjson/index.md
@@ -4,7 +4,7 @@ title: 'GraphJSON Destination'
 beta: true
 id: 61e8726c123c1a81273d00e4
 ---
-[GraphJSON](https://www.graphjson.com/guides/segment){:target="_blank"} provides self-serve analytics to better help you understand your business.
+[GraphJSON](https://www.graphjson.com/){:target="_blank"} provides self-serve analytics to better help you understand your business.
 
 This destination is maintained by GraphJSON. For any issues with the destination, [contact the GraphJSON Support team](mailto:hi@graphjson.com).
 

--- a/src/connections/destinations/catalog/impact-partnership-cloud/index.md
+++ b/src/connections/destinations/catalog/impact-partnership-cloud/index.md
@@ -30,7 +30,7 @@ Segment sends Page calls to Impact Partnership Cloud as a `Clicks` event, if the
 > success ""
 > **Tip!** To accurately track and attribute actions, send a Page call with every page load.
 
-Read [Impact Partnership Cloud's documentation](https://impact-helpdesk.freshdesk.com/en/support/solutions/articles/48001173251){:target="_blank"} to learn more about how Page properties are mapped.
+Read [Impact Partnership Cloud's documentation](https://integrations.impact.com/impact-brand/docs/integrate-with-segment#segment-spec-page-calls){:target="_blank"} to learn more about how Page properties are mapped.
 
 ## Screen
 
@@ -99,4 +99,4 @@ Segment sends Track calls to Impact Partnership Cloud as a `Conversion` or `Page
 
 `Page Load` events appear as `Clicks` on Impact Partnership Cloud's Dashboard if they fit the definition of a unique click.
 
-Read [Impact Partnership Cloud's documentation](https://impact-helpdesk.freshdesk.com/en/support/solutions/articles/48001173251){:target="_blank"} to learn more about how Track properties are mapped.
+Read [Impact Partnership Cloud's documentation](https://integrations.impact.com/impact-brand/docs/integrate-with-segment#track-events-parameter-mapping-reference){:target="_blank"} to learn more about how Track properties are mapped.

--- a/src/connections/destinations/catalog/intercom/index.md
+++ b/src/connections/destinations/catalog/intercom/index.md
@@ -16,7 +16,7 @@ hidden: false
 2.  Search for "Intercom" and select it in the results that appear.
 3.  Choose a Kotlin or Swift Mobile source to connect to Intercom.
 4.  Authorize your Intercom account in Segment and select the Intercom Account to sync with Segment.
-5. [Find your "App ID" in the Intercom UI](https://docs.intercom.com/faqs-and-troubleshooting/getting-set-up/where-can-i-find-my-app-id){:target="_blank"} or by navigating to the Gear Menu and clicking on "App Settings" followed by "API Keys". It should look something like `9iefb489`.
+5. [Find your "App ID" in the Intercom UI](https://developers.intercom.com/installing-intercom/web/installation/#step-3-generate-a-config-file-with-this-command){:target="_blank"} or by navigating to the Gear Menu and clicking on "App Settings" followed by "API Keys". It should look something like `9iefb489`.
 
 
 ### Mobile

--- a/src/connections/destinations/catalog/mammoth/index.md
+++ b/src/connections/destinations/catalog/mammoth/index.md
@@ -3,7 +3,7 @@ rewrite: true
 title: Mammoth Destination
 id: 5cd3f02701645a0001cf49a0
 ---
-[Mammoth](https://mammoth.io/integrations/segment/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank”} provides self-serve analytics for analysts, businesses, and developers who can use Mammoth's data warehousing, data discovery & data preparation abilities to arrive at insights.
+[Mammoth](https://mammoth.io/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank”} provides self-serve analytics for analysts, businesses, and developers who can use Mammoth's data warehousing, data discovery & data preparation abilities to arrive at insights.
 
 Mammoth allows you to blend your data from Segment with other sources of data such as databases and files. Using Mammoth, you can build multiple data pipelines, which are constructed by applying transforms through a no coding interface. Mammoth also allows for the visual discovery of the data and easy exports to databases such as MySQL, Elasticsearch, and PostgreSQL.
 
@@ -14,7 +14,7 @@ This destination is maintained by [Mammoth](https://mammoth.io){:target="_blank"
 
 
 
-There are three steps to get started using Mammoth with Segment. First, [register for an account with Mammoth](https://mammoth.io/register/choose/starter){:target="_blank"}.
+There are three steps to get started using Mammoth with Segment. First, [register for an demo with Mammoth](https://mammoth.io/book-a-demo/){:target="_blank"}.
 
 1. Create a webhook dataset in Mammoth, and copy the API key.
 2. Connect Segment to Mammoth.

--- a/src/connections/destinations/catalog/olark/index.md
+++ b/src/connections/destinations/catalog/olark/index.md
@@ -26,7 +26,7 @@ When you call [`identify`](/docs/connections/spec/identify/) on `analytics.js`, 
 * We call `api.visitor.updatePhoneNumber` with `traits.phone` if you send it.
 * We call `api.visitor.updateCustomFields` with `traits`.
 
-More documentation on the Olark API can be found [in Olark's docs](https://www.olark.com/documentation?r=qhl4tltg){:target="_blank"}.
+More documentation on the Olark API can be found [in Olark's docs](https://www.olark.com/api){:target="_blank"}.
 
 ## Track
 

--- a/src/connections/destinations/catalog/orb/index.md
+++ b/src/connections/destinations/catalog/orb/index.md
@@ -24,7 +24,7 @@ Orb currently supports track calls, as specified in the [Segment Spec](/docs/con
 
 ### Track
 
-Use [Track](/docs/connections/spec/track) calls to automatically send usage events based on your customer's interactions with your application. Any Segment track call will be ingested through [Orb's ingestion pipeline](https://docs.withorb.com/docs/orb-docs/event-ingestion){:target="_blank"} <!---TODO: link machine broke ---> and usage information will be used to calculate billable totals. For example:
+Use [Track](/docs/connections/spec/track) calls to automatically send usage events based on your customer's interactions with your application. Any Segment track call will be ingested through [Orb's ingestion pipeline](https://docs.withorb.com/guides/events-and-metrics/event-ingestion){:target="_blank"} and usage information will be used to calculate billable totals. For example:
 ```js
 analytics.track({
   event: "payment_confirmed",

--- a/src/connections/destinations/catalog/qualaroo/index.md
+++ b/src/connections/destinations/catalog/qualaroo/index.md
@@ -3,7 +3,7 @@ rewrite: true
 title: Qualaroo Destination
 id: 54521fda25e721e32a72eee8
 ---
-[Qualaroo](https://qualaroo.com/home){:target="_blank"} is a user testing tool that lets you add a survey to any page on your site, so you can get targeted user feedback as the user is performing a task. The `analytics.js` Qualaroo Destination is open-source. You can browse the code [on GitHub](https://github.com/segment-integrations/analytics.js-integration-qualaroo){:target="_blank"}.
+[Qualaroo](https://qualaroo.com/){:target="_blank"} is a user testing tool that lets you add a survey to any page on your site, so you can get targeted user feedback as the user is performing a task. The `analytics.js` Qualaroo Destination is open-source. You can browse the code [on GitHub](https://github.com/segment-integrations/analytics.js-integration-qualaroo){:target="_blank"}.
 
 ## Getting Started
 

--- a/src/connections/destinations/catalog/retentive/index.md
+++ b/src/connections/destinations/catalog/retentive/index.md
@@ -1,6 +1,7 @@
 ---
 title: Retentive Destination
 id: 6205293e7095075d8ce71a74
+hidden: true
 ---
 [Retentive](https://retentive.io/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="blank"} makes your help docs searchable in product so go-to-market teams can act on data that each customer struggles with.
 

--- a/src/connections/destinations/catalog/retently/index.md
+++ b/src/connections/destinations/catalog/retently/index.md
@@ -30,7 +30,7 @@ It takes only three steps to set everything up and start surveying your audience
 ### 3. Map survey campaign with Segment events
 
 1. In the Retently destination settings in the Segment app, go to the **Map Retently campaigns with Segment events** section.
-2. In the left input field, enter the ID of the survey campaign. [Learn how to configure the survey campaign.](https://help.retently.com/en/articles/4097690-set-up-segment-transactional-email-surveys){:target="_blank"}
+2. In the left input field, enter the ID of the survey campaign. [Learn how to configure the survey campaign.](hhttps://help.retently.com/en/articles/8217913-trigger-transactional-surveys-via-segment-events){:target="_blank"}
 3. In the right field, list the name of one or more Segment Track events that should trigger the survey in the specified campaign.
    Write the name of the event exactly as it's written in the `analytics.track` method (more details in the section below). You can enter multiple Track events by separating them with a comma symbol (for example Order Placed, Dashboard Visited).
 
@@ -44,7 +44,7 @@ When a Segment Track event fires, Retently performs the following actions:
 1. Identifies the Track event name, and attempts to match it with the campaign ID from the Retently destination settings in Segment. If no campaign ID lists this track event name, then Retently dismisses the event.
 2. If the Track event name matches a campaign ID, Retently looks for the `properties` object passed with the track event, and creates a new customer record in Retently using the properties listed in the object.
 
-The only property that Retently  **requires** is `email`. All other properties can be assigned as optional customer properties in Retently. To learn how to manage customer properties using Segment track events [see the Retently documentation](https://help.retently.com/en/articles/4097690-set-up-segment-transactional-email-surveys){:target="_blank"}.
+The only property that Retently  **requires** is `email`. All other properties can be assigned as optional customer properties in Retently. To learn how to manage customer properties using Segment track events [see the Retently documentation](https://help.retently.com/en/articles/8217913-trigger-transactional-surveys-via-segment-events){:target="_blank"}.
 
 If you aren't familiar with the Segment Spec, take a look at the [Track method documentation](/docs/connections/spec/track/) to learn about what it does. An example call would look like:
 

--- a/src/connections/destinations/catalog/tune/index.md
+++ b/src/connections/destinations/catalog/tune/index.md
@@ -5,7 +5,7 @@ id: 54521fd925e721e32a72eed7
 ---
 [TUNE](https://www.tune.com/){:target="_blank"} helps attribute mobile app events to the advertisements that a customer interacted with. We take care of sending those mobile events to TUNE so that they can be reconciled with ad views. The attributed data can then be [routed](#postbacks) back into other tools that you have enabled in Segment.
 
-This destination is maintained by TUNE. Their code is publicly available for [iOS](https://github.com/TuneOSS/segment-integration-ios){:target="_blank"} and [Android](https://github.com/TuneOSS/segment-integration-android){:target="_blank"}. For any issues with the destination, [contact the TUNE Support team](https://help.tune.com/contact-support/){:target="_blank"}.
+This destination is maintained by TUNE. Their code is publicly available for [iOS](https://github.com/TuneOSS/segment-integration-ios){:target="_blank"} and [Android](https://github.com/TuneOSS/segment-integration-android){:target="_blank"}. For any issues with the destination, [contact the TUNE Support team](https://support.tune.com/hc/en-us/requests/new){:target="_blank"}.
 
 ## Getting Started
 

--- a/src/connections/destinations/catalog/vespucci/index.md
+++ b/src/connections/destinations/catalog/vespucci/index.md
@@ -16,8 +16,8 @@ This destination is maintained by Vespucci. For any issues with the destination,
 1. From the Destinations catalog page in the Segment App, click **Add Destination**.
 2. Search for "Vespucci" in the Destinations Catalog, and select the Vespucci destination.
 3. Choose which Source should send data to the Vespucci destination.
-4. Go to your "Your Active Projects" section on your [Vespucci Dashboard](https://dashboard.vespuccianalytics.com){:target="_blank"}. Click on the **+** button. Enter a name and select "Segment Destination" as the DataPipe.
-5. [Depending on your project configuration](https://www.vespuccianalytics.com/documentation-article/getting-started){:target="_blank"}, select one of the two tracking methods and click "Create" to create your project.
+4. Go to your "Your Active Projects" section on your [Vespucci Dashboard](https://docs.vespuccianalytics.com/vespucci/1_Story_Editor){:target="_blank"}. Click on the **+** button. Enter a name and select "Segment Destination" as the DataPipe.
+5. [Depending on your project configuration](https://docs.vespuccianalytics.com/){:target="_blank"}, select one of the two tracking methods and click "Create" to create your project.
 6. Take note of the API key associated with this project. Back in the Segment App, enter your API key in the Vespucci destination settings.
 
 ## Page

--- a/src/connections/destinations/catalog/willow/index.md
+++ b/src/connections/destinations/catalog/willow/index.md
@@ -2,6 +2,7 @@
 title: Willow Destination
 rewrite: true
 id: 620ebe78b4e75580b6e6b72a
+hidden: true
 ---
 
 [Willow](https://heywillow.io/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank"} is a customer support platform for early stage startups. It focuses on getting your whole team (even engineering) to solve issues together with commenting and tagging, shows you everything in one place from customer messages to in-app actions, and it shows your entire customer's journey in one continuous feed from day one to today.

--- a/src/connections/sources/catalog/cloud-apps/launchdarkly/index.md
+++ b/src/connections/sources/catalog/cloud-apps/launchdarkly/index.md
@@ -88,12 +88,12 @@ Below are tables outlining the properties included in the events listed above.
   </tr>
   <tr>
   <td><code>reasonKind</code></td>
-      <td>The <a href="https://docs.launchdarkly.com/docs/evaluation-reasons">evaluation reason</a> for the flag.</td>
+      <td>The <a href="https://docs.launchdarkly.com/sdk/concepts/evaluation-reasons/?q=evaluation">evaluation reason</a> for the flag.</td>
   </tr>
   <tr>
   <td><code>prereqOf</code></td>
       <td>Set to another flag's key if this flag evaluation was only performed in order to determine
- whether the prerequisite values were met for the indicated flag. See <a href="https://docs.launchdarkly.com/docs/prerequisites">flag prerequisites</a>.</td>
+ whether the prerequisite values were met for the indicated flag. See <a href="https://docs.launchdarkly.com/home/targeting-flags/prerequisites/?q=prerequisites">flag prerequisites</a>.</td>
   </tr>
   <tr>
   <td><code>default</code></td>

--- a/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/braze-swift.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/braze-swift.md
@@ -58,7 +58,7 @@ analytics.add(plugin: BrazeDestination())
 ## Identify
 
 > info "Tip"
-> Add Segment's open-source [Middleware](https://github.com/segmentio/segment-braze-mobile-middleware) tool to optimize your integration. This tool limits [Data Point](https://www.braze.com/docs/user_guide/onboarding_with_braze/data_points/) use by debouncing duplicate identify() calls from Segment. For more information, see the project's [README](https://github.com/segmentio/segment-braze-mobile-middleware/blob/master/README.md#how-does-this-work).
+> Add Segment's open-source [Middleware](https://github.com/segmentio/segment-braze-mobile-middleware) tool to optimize your integration. This tool limits [Data Point](https://www.braze.com/docs/user_guide/data_and_analytics/data_points/) use by debouncing duplicate identify() calls from Segment. For more information, see the project's [README](https://github.com/segmentio/segment-braze-mobile-middleware/blob/master/README.md#how-does-this-work).
 
 If you're not familiar with the Segment Specs, take a look to understand what the [Identify method](/docs/connections/spec/identify/) does. An example call would look like:
 
@@ -126,7 +126,7 @@ Segment sends all other traits (except Braze's [reserved user profile fields](ht
 ## Track
 
 > info "Tip"
-> To lower [Data Point](https://www.braze.com/docs/user_guide/onboarding_with_braze/data_points/) use, limit the events you send to Braze to those that are relevant for campaigns and segmentation to the Braze destination. For more information, see [Schema Controls](/docs/protocols/schema/).
+> To lower [Data Point](https://www.braze.com/docs/user_guide/data_and_analytics/data_points/) use, limit the events you send to Braze to those that are relevant for campaigns and segmentation to the Braze destination. For more information, see [Schema Controls](/docs/protocols/schema/).
 
 The Braze Swift destination plugin currently only supports sending `logPurchase` events, and custom events are not supported in device mode. Please review the [plugin code](https://github.com/braze-inc/analytics-swift-braze/blob/main/Sources/SegmentBraze/BrazeDestination.swift) for more information.
 

--- a/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/intercom-swift.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/intercom-swift.md
@@ -12,7 +12,7 @@ id: 54521fd725e721e32a72eec6
 4.  Authorize your Intercom account in Segment and select the Intercom Account to sync with Segment.
 
     You can choose which account to sync from the drop down menu in the top right. If you are using [server-side sources](/docs/connections/sources#server), Segment starts passing data through once you activate the Destination. For other libraries  continue reading below.
-5. [Find your "App ID" in the Intercom UI](https://docs.intercom.com/faqs-and-troubleshooting/getting-set-up/where-can-i-find-my-app-id){:target="_blank"} or by navigating to the Gear Menu and selecting App Settings > API Keys. It should look something like `9iefb489`.
+5. [Find your "App ID" in the Intercom UI](https://developers.intercom.com/installing-intercom/web/installation/#step-3-generate-a-config-file-with-this-command){:target="_blank"} or by navigating to the Gear Menu and selecting App Settings > API Keys. It should look something like `9iefb489`.
 
 Your changes appear in the Segment CDN in about 45 minutes, and then Analytics.js starts asynchronously loading Intercom's `library.js` onto your page.
 

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/destination-plugins/braze-kotlin-android.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/destination-plugins/braze-kotlin-android.md
@@ -66,7 +66,7 @@ Your events will now begin to flow to Braze in device mode.
 # Identify
 
 > info "Tip"
-> Add Segment's open-source [Middleware](https://github.com/segmentio/segment-braze-mobile-middleware) tool to optimize your integration. This tool limits [Data Point](https://www.braze.com/docs/user_guide/onboarding_with_braze/data_points/) use by debouncing duplicate identify() calls from Segment. For more information, see the project's [README](https://github.com/segmentio/segment-braze-mobile-middleware/blob/master/README.md#how-does-this-work).
+> Add Segment's open-source [Middleware](https://github.com/segmentio/segment-braze-mobile-middleware) tool to optimize your integration. This tool limits [Data Point](https://www.braze.com/docs/user_guide/data_and_analytics/data_points/) use by debouncing duplicate identify() calls from Segment. For more information, see the project's [README](https://github.com/segmentio/segment-braze-mobile-middleware/blob/master/README.md#how-does-this-work).
 
 If you're not familiar with the Segment Specs, take a look to understand what the [Identify method](/docs/connections/spec/identify/) does. An example call would look like:
 
@@ -86,7 +86,7 @@ If you're using a device-mode connection, Braze's SDK assigns a `device_id` and 
 ## Track
 
 > info "Tip"
-> To lower [Data Point](https://www.braze.com/docs/user_guide/onboarding_with_braze/data_points/) use, limit the events you send to Braze to those that are relevant for campaigns and segmentation to the Braze destination. For more information, see [Schema Controls](/docs/protocols/schema/).
+> To lower [Data Point](https://www.braze.com/docs/user_guide/data_and_analytics/data_points/) use, limit the events you send to Braze to those that are relevant for campaigns and segmentation to the Braze destination. For more information, see [Schema Controls](/docs/protocols/schema/).
 
 If you're not familiar with the Segment Specs, take a look to understand what the [Track method](/docs/connections/spec/track/) does. An example call looks like:
 

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/destination-plugins/intercom-kotlin-android.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/destination-plugins/intercom-kotlin-android.md
@@ -10,7 +10,7 @@ id: 54521fd725e721e32a72eec6
 2.  Search for "Intercom" and select it in the results that appear.
 3.  Select a source to connect to your Intercom destination.
 4.  Authorize your Intercom account in Segment and select the Intercom Account to sync with Segment.
-5. [Find your "App ID" in the Intercom UI](https://docs.intercom.com/faqs-and-troubleshooting/getting-set-up/where-can-i-find-my-app-id){:target="_blank"} or by navigating to the Gear Menu and selecting App Settings > API Keys. It should look something like `9iefb489`.
+5. [Find your "App ID" in the Intercom UI](https://developers.intercom.com/installing-intercom/web/installation/#step-3-generate-a-config-file-with-this-command){:target="_blank"} or by navigating to the Gear Menu and selecting App Settings > API Keys. It should look something like `9iefb489`.
 
 ## Adding the dependency
 

--- a/src/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/braze-react-native.md
+++ b/src/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/braze-react-native.md
@@ -68,7 +68,7 @@ Segment sends Page calls to Braze as custom events if you have enabled either **
 ## Identify
 
 > info "Tip"
-> Add Segment's [Enrichment Plugin](/docs/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/braze-middleware-react-native) tool to optimize your integration. This tool limits [Data Point](https://www.braze.com/docs/user_guide/onboarding_with_braze/data_points/){:target="_blank"} use by debouncing duplicate identify() calls from Segment.
+> Add Segment's [Enrichment Plugin](/docs/connections/sources/catalog/libraries/mobile/react-native/destination-plugins/braze-middleware-react-native) tool to optimize your integration. This tool limits [Data Point](https://www.braze.com/docs/user_guide/data_and_analytics/data_points/){:target="_blank"} use by debouncing duplicate identify() calls from Segment.
 
 If you're not familiar with the Segment Specs, take a look to understand what the [Identify method](/docs/connections/spec/identify/) does. An example call would look like:
 
@@ -137,7 +137,7 @@ Except for Braze's [reserved user profile fields](https://www.braze.com/docs/api
 ## Track
 
 > info "Tip"
-> To lower [Data Point](https://www.braze.com/docs/user_guide/onboarding_with_braze/data_points/){:target="_blank"} use, limit the events you send to Braze to those that are relevant for campaigns and segmentation to the Braze destination. For more information, see [Schema Controls](/docs/protocols/schema/).
+> To lower [Data Point](https://www.braze.com/docs/user_guide/data_and_analytics/data_points/){:target="_blank"} use, limit the events you send to Braze to those that are relevant for campaigns and segmentation to the Braze destination. For more information, see [Schema Controls](/docs/protocols/schema/).
 
 If you're not familiar with the Segment Specs, take a look to understand what the [Track method](/docs/connections/spec/track/) does. An example call looks like:
 

--- a/src/connections/sources/catalog/libraries/website/shopify-littledata/index.md
+++ b/src/connections/sources/catalog/libraries/website/shopify-littledata/index.md
@@ -75,7 +75,7 @@ Below is a table of events that **Shopify by Littledata** sends to Segment throu
 
 You can _opt out_ of device-mode pageviews or events by setting `disableClientSideEvents: true` or `disablePageviews: true` in the `LittledataLayer` settings.
 
-The source also respects [GDPR-compliant cookie](https://blog.littledata.io/2021/06/18/shopify-cookie-banner-gdpr-compliance/){:target="\_blank"} consent through Shopify's cookie banner, or popular consent management platforms such as [OneTrust](https://help.littledata.io/help/integrating-onetrust-with-shopify/){:target="\_blank"} and [TrustArc](https://help.littledata.io/posts/integrating-trustarc-with-shopify/){:target="\_blank"}.
+The source also respects [GDPR-compliant cookie](https://blog.littledata.io/2021/06/18/shopify-cookie-banner-gdpr-compliance/){:target="\_blank"} consent through Shopify's cookie banner, or popular consent management platforms such as [OneTrust](https://help.littledata.io/posts/integrating-onetrust-with-shopify/){:target="\_blank"} and [TrustArc](https://help.littledata.io/posts/integrating-trustarc-with-shopify/){:target="\_blank"}.
 
 ## Cloud-mode events
 
@@ -129,13 +129,13 @@ The following traits are included with an Identify call:
 | description                | The customer's notes.                                                                                                                                                           | String        |
 | email                      | The customer's email address.                                                                                                                                                   | String        |
 | email_consent_state        | If the user has consented to email marketing (mapping to [EmailMarketingState](https://shopify.dev/docs/api/customer/unstable/enums/EmailMarketingState){:target="\_blank"})    | String, Null  |
-| email_opt_in_level         | Level of user's opt in email marketing (mapping to [MarketingOptInLevel](https://shopify.dev/docs/api/customer/unstable/enums/MarketingOptInLevel){:target="\_blank"})          | String, Null  |
+| email_opt_in_level         | Level of user's opt in email marketing (mapping to [CustomerMarketingOptInLevel](https://shopify.dev/docs/api/admin-graphql/2024-01/enums/CustomerMarketingOptInLevel){:target="\_blank"})          | String, Null  |
 | firstName                  | The customer's first name.                                                                                                                                                      | String        |
 | lastName                   | The customer's last name.                                                                                                                                                       | String        |
 | phone                      | The customer's phone number.                                                                                                                                                    | String        |
 | purchaseCount              | The number of orders by the customer.                                                                                                                                           | Integer       |
 | sms_consent_state          | If the user has consented to SMS marketing (mapping to [SmsMarketingState](https://shopify.dev/docs/api/customer/unstable/enums/SmsMarketingState){:target="\_blank"})          | String, Null  |
-| sms_opt_in_level           | The level of the user's opt in to SMS marketing (mapping to [MarketingOptInLevel](https://shopify.dev/docs/api/customer/unstable/enums/MarketingOptInLevel){:target="\_blank"}) | String, Null  |
+| sms_opt_in_level           | The level of the user's opt in to SMS marketing (mapping to [CustomerMarketingOptInLevel](https://shopify.dev/docs/api/admin-graphql/2024-01/enums/CustomerMarketingOptInLevel){:target="\_blank"}) | String, Null  |
 | state                      | The Shopify customer state - enabled, disabled, invited to create an account or customer declined.                                                                              | String        |
 | tags                       | The custom tags applied to the customer.                                                                                                                                        | String        |
 | verified_email             | Whether the customer has verified their email.                                                                                                                                  | Boolean       |

--- a/src/connections/storage/catalog/redshift/index.md
+++ b/src/connections/storage/catalog/redshift/index.md
@@ -126,11 +126,10 @@ It's often the case that customers want to combine 1st-party transactional and o
 
 If you're interested in importing data into a Redshift cluster, it's important that you follow these [guidelines](/docs/connections/storage/warehouses/faq/).
 
-Additionally, there a number of tools which provide syncing services between databases (mySQL, SQL Server, Oracle, PostgreSQL). Here is a list of some we've seen used by customers.
+Additionally, there a number of tools which provide syncing services between databases (mySQL, SQL Server, Oracle, PostgreSQL). Here is a list of some that Segment customers use.
 
 - [SymmetricDS (Open Source)](http://www.symmetricds.org/?__hstc=222691652.f2c5ed50a3a9703ac3be5283918044ad.1436399176206.1437192161002.1437244552315.24&__hssc=222691652.12.1437244552315&__hsfp=2203243415)
 - [FlyData](https://www.flydata.com/products/?__hstc=222691652.f2c5ed50a3a9703ac3be5283918044ad.1436399176206.1437192161002.1437244552315.24&__hssc=222691652.12.1437244552315&__hsfp=2203243415)
-- [Attunity](http://www.attunity.com/solutions/cloud/amazon-redshift?__hstc=222691652.f2c5ed50a3a9703ac3be5283918044ad.1436399176206.1437192161002.1437244552315.24&__hssc=222691652.12.1437244552315&__hsfp=2203243415)
 - [Informatica](http://www.informaticacloud.com/infrastructure/synchronize-web-data-amazon-redshift?__hstc=222691652.f2c5ed50a3a9703ac3be5283918044ad.1436399176206.1437192161002.1437244552315.24&__hssc=222691652.12.1437244552315&__hsfp=2203243415)
 
 You can also unload data to a s3 bucket and then load the data into another Redshift instance manually.

--- a/src/connections/storage/warehouses/choose-warehouse.md
+++ b/src/connections/storage/warehouses/choose-warehouse.md
@@ -23,7 +23,7 @@ Redshift performance and storage capacity is a function of cluster size and clus
 
 With BigQuery, you're not constrained by the storage capacity or compute resources of a given cluster. Instead, you can load large amounts of data into BigQuery without running out of memory, and execute complex queries without maxing out CPU.
 
-This is possible because BigQuery takes advantage of distributed storage and networking to separate data storage from compute power. Google's[Colossus distributed file system](https://cloud.google.com/blog/big-data/2016/01/bigquery-under-the-hood) distributes data across many servers in the Google cloud. When you execute a query, the [Dremel query engine](https://cloud.google.com/blog/big-data/2016/01/bigquery-under-the-hood) splits the query into smaller sub-tasks, distributes the sub-tasks to computers across Google data centers, and then re-assembles them into your results.
+This is possible because BigQuery takes advantage of distributed storage and networking to separate data storage from compute power. Google's[Colossus distributed file system](https://cloud.google.com/blog/products/bigquery/bigquery-under-the-hood) distributes data across many servers in the Google cloud. When you execute a query, the [Dremel query engine](https://cloud.google.com/blog/products/bigquery/bigquery-under-the-hood) splits the query into smaller sub-tasks, distributes the sub-tasks to computers across Google data centers, and then re-assembles them into your results.
 
 ## Pricing
 

--- a/src/protocols/tracking-plan/create.md
+++ b/src/protocols/tracking-plan/create.md
@@ -164,7 +164,7 @@ You can filter the Tracking Plan events by keyword or by label. The applied filt
 Protocols Tracking Plans use [JSON Schemas](https://json-schema.org/){:target="_blank”} to validate Segment event payloads. To support a broader range of validation use-cases, Segment lets you to edit your underlying JSON schema.
 
 > warning ""
-> Editing a JSON schema requires technical expertise. The [JSON schema documentation](https://json-schema.org/understanding-json-schema/index.html){:target="_blank”} and [JSON schema validator](https://www.jsonschemavalidator.net/){:target="_blank”} are helpful resources you can use.
+> Editing a JSON schema requires technical expertise. The [JSON schema documentation](https://json-schema.org/understanding-json-schema){:target="_blank”} and [JSON schema validator](https://www.jsonschemavalidator.net/){:target="_blank”} are helpful resources you can use.
 
 You can edit the JSON schema for each Track event listed in the Tracking Plan, and a common JSON schema definition that applies across all events.
 


### PR DESCRIPTION
### Proposed changes
- Found new link for 31/41 broken links
- Added 7/41 broken links (mostly those behind app login walls) to the overrides list
- Found two integrations (retentive.io and williow.io) that went out of business. Thomas removed the integrations from the catalog, and I added `hidden: true` frontmatter attributes for their respective docs
- Found 2/41 broken links (June (Actions) and Clevertap (Actions)) that I'll have to fix with a separate PR in the destination actions repo

### Merge timing
ASAP

### Related issues (optional)
https://segment.atlassian.net/browse/DOC-768 
