### PR TITLE
feat(content): remove `onBatch` limitation as no longer valid

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -61,9 +61,6 @@ The default source code template includes handlers for all event types. You don'
 
 Insert functions can define handlers for each message type in the [Segment spec](/docs/connections/spec/):
 
-> info "onBatch handler"
-> At this time, Destination Insert Functions do not support the onBatch handler. 
-
 - `onIdentify`
 - `onTrack`
 - `onPage`
@@ -71,6 +68,7 @@ Insert functions can define handlers for each message type in the [Segment spec]
 - `onGroup`
 - `onAlias`
 - `onDelete`
+- `onBatch`
 
 Each of the functions above accepts two arguments:
 


### PR DESCRIPTION
### Proposed changes
- remove `onBatch` limitation for Destination Insert Functions as `onBatch` is available as mentioned below

### Merge timing
- ASAP once approved?
