### PR TITLE
Add clarity around Predictive Audiences limit

### DIFF
--- a/src/unify/Traits/predictions/using-predictions.md
+++ b/src/unify/Traits/predictions/using-predictions.md
@@ -108,6 +108,8 @@ Every seven days.
 
 You get five predictions as part of Engage Foundations or Unify Plus. To purchase more predictions, reach out to your CSM.
 
+Predictive Audiences contribute to the Engage limit of 100 audiences. Regardless of whether an audience is manually crafted or generated via predictive modeling, each one is counted as a single audience within this limit.
+
 #### Is Predictions HIPAA-compliant?
 
 No, Predictions isn't HIPAA-compliant. Avoid using Predictions for health and life science applications.

--- a/src/unify/Traits/predictions/using-predictions.md
+++ b/src/unify/Traits/predictions/using-predictions.md
@@ -108,7 +108,7 @@ Every seven days.
 
 You get five predictions as part of Engage Foundations or Unify Plus. To purchase more predictions, reach out to your CSM.
 
-Predictive Audiences contribute to the Engage limit of 100 audiences. Regardless of whether an audience is manually crafted or generated via predictive modeling, each one is counted as a single audience within this limit.
+Predictive Audiences contribute to the Engage limit of 100 audiences. Whether you create the audience manually or with predictive modeling, the audience counts towards the 100-audience limit.
 
 #### Is Predictions HIPAA-compliant?
 


### PR DESCRIPTION
### Proposed changes

Clarify that Predictive Audiences contribute to the Engage limit of 100 audiences. Regardless of whether an audience is manually crafted or generated via predictive modeling, each one is counted as a single audience within this limit.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
