### PR TITLE
Provide information on sending email data to Iterable destination

### DIFF
--- a/src/connections/destinations/catalog/iterable/index.md
+++ b/src/connections/destinations/catalog/iterable/index.md
@@ -226,3 +226,9 @@ When you delete an audience or trait in Segment it is not deleted from Iterable.
 #### If a user has multiple email addresses as external ids in Segment, what happens when they enter an audience or have a computed trait?
 
 Segment sends an `identify` or `track` call for each email address on the user's account. For example, if a user has three email addresses, this creates three separate users in Iterable.
+
+### Are you able to update a user's email through Iterable?
+
+Updating a user's email in Iterable is currently not possible via Segment. You will have to call updateEmail outside of Segment if you want to be able to do so: Updating a user's email address cannot be achieved with the standard Segment identify call alone. It requires sending an Update Email Request directly to the Iterable API from outside the Segment platform.
+
+The API request outlined [here](https://api.iterable.com/api/docs#users_updateEmail). This needs to be followed in order to ensure Iterable has the correct email address for any users who have updated their email address. A workaround to update an email in Iterable from Segment would be to hit that API endpoint using a destination function.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

I’ve had a recent ticket inquire if Segment is able to update a user’s email address in real-time via identify call to Iterable (which is currently not possible retroactively).

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
