### PR TITLE
Add FAQ to Kotlin Sidenav

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -199,6 +199,8 @@ sections:
     title: Typewriter for Kotlin
   - path: /connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-destination-filters
     title: Destination Filters for Kotlin
+  - path: /connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-faq
+    title: FAQs
 
 - slug: swift
   section_title: Analytics-Swift Documentation


### PR DESCRIPTION
### Proposed changes
Add FAQ to Kotlin Sidenav. The FAQ file already exists: src/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-faq.md