### PR TITLE
Update facebook-app-events-swift.md

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/facebook-app-events-swift.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/facebook-app-events-swift.md
@@ -121,13 +121,11 @@ You can manually change the Data Processing parameters by adding settings to the
 ## Troubleshooting
 
 ### Not seeing events?
-
-You will have to be sure that the [IDFA](/docs/connections/sources/catalog/libraries/mobile/ios/#idfa) is working within your app, which involves adding the [iAD framework](/docs/connections/sources/catalog/libraries/mobile/ios/#idfa).
+You will have to be sure that the [IDFA](/docs/connections/sources/catalog/libraries/mobile/ios/#idfa) is working within your app, which involves adding the [AdSupport and App Tracking Transparency frameworks](https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#ad-tracking-and-idfa).
 
 Once you've added these, you will start to see the `context.device.advertisingId` populate and the `context.device.adTrackingEnabled` flag set to `true` unless the user has ad tracking limited or is using a mobile ad blocker.
 
-> note ""
-> While the network is deprecated, the relevant iOS [framework](https://developer.apple.com/reference/iad) is not.
+
 
 Facebook requires that payloads include the following:
 - `context.device.id`


### PR DESCRIPTION
Proposed changes
Currently our docs reference an out dated iOS framework. Correct links and reference the appropriate frameworks.

Removed note regarding depreciated framework iAd.

Merge timing
Once approved.

Related issues (optional)
https://twilio.slack.com/archives/GTM41A6G7/p1711488024798749?thread_ts=1711487561.107329&cid=GTM41A6G7

