### PR TITLE
Add note about config options for downstream sdks

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/index.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/index.md
@@ -360,7 +360,7 @@ analytics.identify("hello world")
 
 ### Ready
 
-The `ready` method allows you to pass in a method that is called once Analytics.js finishes initializing, and once all enabled device-mode destinations load. It's like [jQuery's `ready` method](https://api.jquery.com/ready/){:target="_blank"}, except for Destinations. Because it does not fire until all enabled device-mode destinations are loaded, it cannot be used to change configuration options for downstream SDKs. That can only be done if the SDK is loaded natively. 
+The `ready` method lets you pass in a method that gets called after Analytics.js finishes initializing and after all enabled device-mode destinations load. It's like [jQuery's `ready` method](https://api.jquery.com/ready/){:target="_blank"}, except for Destinations. Because it doesn't fire until all enabled device-mode destinations are loaded, it can't be used to change configuration options for downstream SDKs. That can only be done if the SDK is loaded natively. 
 
 The `ready` method isn't invoked if any Destination throws an error (for example, for an expired API key, incorrect settings configuration, or when a Destination is blocked by the browser) during initialization.
 

--- a/src/connections/sources/catalog/libraries/website/javascript/index.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/index.md
@@ -360,11 +360,11 @@ analytics.identify("hello world")
 
 ### Ready
 
-The `ready` method allows you to pass in a method that is called once Analytics.js finishes initializing, and once all enabled device-mode destinations load. It's like [jQuery's `ready` method](https://api.jquery.com/ready/){:target="_blank"}, except for Destinations.
+The `ready` method allows you to pass in a method that is called once Analytics.js finishes initializing, and once all enabled device-mode destinations load. It's like [jQuery's `ready` method](https://api.jquery.com/ready/){:target="_blank"}, except for Destinations. Because it does not fire until all enabled device-mode destinations are loaded, it cannot be used to change configuration options for downstream SDKs. That can only be done if the SDK is loaded natively. 
 
 The `ready` method isn't invoked if any Destination throws an error (for example, for an expired API key, incorrect settings configuration, or when a Destination is blocked by the browser) during initialization.
 
-The code in the `ready` function only executes after `ready` is emitted.
+The code in the `ready` function only executes after `ready` is emitted. 
 
 If you want to access end-tool library methods that do not match any Analytics.js methods, like adding an extra setting to Mixpanel, you can use a `ready` callback so that you're guaranteed to have access to the Mixpanel object, like so:
 


### PR DESCRIPTION

### Proposed changes

We ocassionally get questions from customers about changing a config option on a downstream SDK. this cannot be done as config options need to be set before initialization and the ready method does not fire until after everything is loaded and initialized. 

### Merge timing
- ASAP once approved

### Related issues (optional)

n/a
