### PR TITLE
Resolving the conversion_date_time that precedes the click error

### DIFF
--- a/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
+++ b/src/connections/destinations/catalog/actions-google-enhanced-conversions/index.md
@@ -127,3 +127,9 @@ This error indicates that the conversion action specified in the upload request 
 
 To resolve this, ensure that the ConversionActionType value in Google Ads is correctly configured.
 
+### Resolving the conversion_date_time that precedes the click error
+
+This error indicates that the conversionDateTime is incorrect in your event, as outlined in [Google's Ads documentation](https://developers.google.com/google-ads/api/rest/reference/rest/v14/Customer#:~:text=CONVERSION_PRECEDES_,correct%20and%20try%20again){:target="_blank”}.
+
+To resolve this issue, ensure that the conversionDateTime in the event payload is accurate and verify that the requirements for uploading click conversions, as outlined in [Google's documentation]([https://developers.google.com/google-ads/api/rest/reference/rest/v14/Customer#:~:text=CONVERSION_PRECEDES_,correct%20and%20try%20again](https://developers.google.com/google-ads/api/docs/conversions/upload-clicks?hl=en#upload_clickconversion)){:target="_blank”}., are met.
+


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Resolving the conversion_date_time that precedes the click error

This error indicates that the conversionDateTime is incorrect in your event, as outlined in [Google's Ads documentation](https://developers.google.com/google-ads/api/rest/reference/rest/v14/Customer#:~:text=CONVERSION_PRECEDES_,correct%20and%20try%20again){:target="_blank”}.

To resolve this issue, ensure that the conversionDateTime in the event payload is accurate and verify that the requirements for uploading click conversions, as outlined in [Google's documentation]([https://developers.google.com/google-ads/api/rest/reference/rest/v14/Customer#:~:text=CONVERSION_PRECEDES_,correct%20and%20try%20again](https://developers.google.com/google-ads/api/docs/conversions/upload-clicks?hl=en#upload_clickconversion)){:target="_blank”}., are met.

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
