### PR TITLE
Clearbit Enrichment Destination Not Compatible with EU Segment Worksp…

### DIFF
--- a/src/connections/destinations/catalog/clearbit-enrichment/index.md
+++ b/src/connections/destinations/catalog/clearbit-enrichment/index.md
@@ -7,6 +7,8 @@ id: 576af9ca80412f644ff13b87
 
 ## Getting Started
 
+> warning ""
+> This destination is not supported with EU Workspaces.
 
 
 1. From the Segment web app, click **Catalog**.


### PR DESCRIPTION
…aces

Added a warning to the Clearbit Enrichment docs to alert users that EU workspaces are not compatible with this destination.

### Proposed changes

Updated the docs page with a warning. A customer was unable to get their enriched data to Clearbit from their EU workspace. Tested and confirmed the integration needs to be updated to include EU workspace endpoint. It currently only works with US workspaces.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
