### PR TITLE
Vero destination does not support group calls

### DIFF
--- a/src/connections/destinations/catalog/vero/index.md
+++ b/src/connections/destinations/catalog/vero/index.md
@@ -4,6 +4,8 @@ id: 54521fdc25e721e32a72ef03
 ---
 Our Vero destination code is all open-source on GitHub if you want to check it out: [JavaScript](https://github.com/segmentio/analytics.js-integrations/tree/master/integrations/vero){:target="_blank"}, [Server](https://github.com/segmentio/integration-vero){:target="_blank"}.
 
+**Group calls are not supported by the Vero Destination. Please remove 'Group' from the list of supported calls in the Destination Info Table on the docs page by setting the flag to 'false' in the src/_data/catalog/destinations.yml file.**
+
 ## Getting Started
 
 Vero helps you send targeted emails to customers based on their behavior.


### PR DESCRIPTION
DO NOT PUBLISH. Please follow commit details to remove 'group' from the list of events supported by the Vero destination.

(Per Segment's Vero integration code, there is a group mapping configured, but the endpoint does not exist in Vero's API docs.)

### Proposed changes

After some testing, I confirmed the Vero destination does not support 'group' calls.

I was unable to edit the file that displays the "Destination Info" details on the public doc page. Instead, I added details on where/how to update the destination to remove 'group' from the "Destination Info" section.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
