### PR TITLE
Removed 'contact support' link

### DIFF
--- a/src/unify/Traits/sql-traits.md
+++ b/src/unify/Traits/sql-traits.md
@@ -165,7 +165,6 @@ Click **Create Computed Trait** to save the Trait.
 Check **Compute without destinations** if you only want to send to Engage.
 
 When you create a SQL Trait, Segment runs the query on the warehouse twice a day by default. You can customize the time at which Segment queries the data warehouse and  the frequency, up to once per hour, from the SQL Trait's settings.
-(If you're interested in a more frequent schedule, [contact Segment Support](https://segment.com/help/contact/){:target="_blank"}.)
 
 For each row (user or account) in the query result, Engage sends an identify or group call with all the columns that were returned as Traits. For example, if you write a query that returns `user_id, has_open_ticket, num_tickets_90_days, avg_zendesk_rating_90days` Segment sends an identify call with the following payload:
 


### PR DESCRIPTION
### Proposed changes

Removed 'contact support' link from "You can customize the time at which Segment queries the data warehouse and the frequency, up to once per hour, from the SQL Trait’s settings" - Support team cannot update SQL Trait compute schedule, it has to be done by the customer in UI.

### Merge timing

ASAP once approved
