### PR TITLE
Remove no settings text from actions-fields.html

### DIFF
--- a/src/_includes/components/actions-fields.html
+++ b/src/_includes/components/actions-fields.html
@@ -39,10 +39,6 @@
 </tbody>
 </table>
 
-{% else %}
-<em>No settings available. The destination may not be publicly visible.</em>
-
-
 {% endif %}
 
 


### PR DESCRIPTION
### Proposed changes

This PR removes the generated line of text "No settings available. The destination may not be publicly visible." when no settings are detected for a destination. A growing number of destinations intentionally do not have top-level settings. This is resulting in an incorrect warning on a growing number of docs pages that could lead to confusion for customers. See a sample Google search here: https://www.google.com/search?q=site:segment.com/docs+%22No+settings+available.+The+destination+may+not+be+publicly+visible.%22&rlz=1C5GCCM_en&sca_esv=9009150f6e709f7a&cs=0&filter=0&biw=1258&bih=934&dpr=2#ip=1

### Merge timing
- ASAP once approved.

### Related issues (optional)
- n/a
