### PR TITLE
Troubleshoot addition to the FB Customer Audience Destination

### DIFF
--- a/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
+++ b/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
@@ -143,6 +143,10 @@ Segment sends lists of users with identifiers that Facebook supports to Facebook
 
 For example, many B2B SaaS businesses have users that sign up for their products with a work email address, like `jane.doe@segment.com`. However, most Facebook users sign up for Facebook with a personal email only, like `janedoe@gmail.com`. If you only provide the work email address, and no other identifiers, then Facebook can't match your user to the Jane Doe Facebook profile. This is the case for all identifiers - Facebook must have the identifier somewhere in a user's profile, or else they can't match on it.
 
+### Why are all of my audiences connected to Facebook failing with an 'Internal Error' message?
+
+Most likely, this is due to your Facebook needing to be reauthorized, sometimes due to a password change. Please reauthorize the Facebook destination connection. If the error persists, please contact Segment Support.
+
 Please note, emails must be in a plain text format. Facebook also provides these guidelines for the emails that you send to them: trim leading, trail whitespace, and convert all characters to lowercase.
 
 ### Do you support LTV audiences?

--- a/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
+++ b/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
@@ -109,7 +109,7 @@ Once created, the audience should be available in Facebook in ten minutes unless
 > info ""
 > This feature is in Public Preview and usage is subject to the terms contained in the [First Access and Beta Preview Terms](https://segment.com/legal/first-access-beta-preview/){:target="_blank"}{:target="_blank"}. For access, contact your CSM or email Segment at [friends@segment.com](mailto:friends@segment.com).
 
-Previously, Segment only sent email and mobile IDs to Facebook. A new beta feature can send an expanded list of identifiers or traits to Facebook, so that Facebook can try to use these additional data points to match to their user profiles. If you have this feature enabled and implemented any of these traits in your Segment tracking, Engage can send this data to Facebook. Segment can now also sync multiple emails if the profile contains more than one. Additionally as part of this feature, Segment hashes fields before sending them downstream to Facebook, if required. (See the table below for hashing requirements.) Please note that the trait data implemented in your Segment tracking must match the naming convention and format specified in the table below, otherwise Segment can't send it to Facebook.
+Previously, Segment only sent email and mobile IDs to Facebook. A new beta feature can send an expanded list of identifiers or traits to Facebook, so that Facebook can try to use these additional data points to match to their user profiles. If you have this feature enabled and implemented any of these traits in your Segment tracking, Engage can send this data to Facebook. Segment can now also sync multiple emails if the profile contains more than one. Additionally as part of this feature, Segment hashes fields before sending them downstream to Facebook, if required. (See the table below for hashing requirements.) Note that the trait data implemented in your Segment tracking must match the naming convention and format specified in the table below, otherwise Segment can't send it to Facebook.
 
 > success ""
 > Visit Segment's [Trait Enrichment](/docs/engage/trait-activation/trait-enrichment/) to learn more.
@@ -145,9 +145,9 @@ For example, many B2B SaaS businesses have users that sign up for their products
 
 ### Why are all of my audiences connected to Facebook failing with an 'Internal Error' message?
 
-Most likely, this is due to your Facebook needing to be reauthorized, sometimes due to a password change. Please reauthorize the Facebook destination connection. If the error persists, please contact Segment Support.
+Most likely, this is due to your Facebook account needing to be reauthorized, sometimes due to a password change. Reauthorize the Facebook destination connection. If the error persists, contact Segment Support.
 
-Please note, emails must be in a plain text format. Facebook also provides these guidelines for the emails that you send to them: trim leading, trail whitespace, and convert all characters to lowercase.
+Note, emails must be in a plain text format. Facebook also provides these guidelines for the emails that you send to them: trim leading, trail whitespace, and convert all characters to lowercase.
 
 ### Do you support LTV audiences?
 Facebook has a feature called [value-based audiences](https://developers.facebook.com/docs/marketing-api/audiences/guides/value-based-lookalike-audiences/){:target="_blank"} where you can send an additional field like LTV, to tell Facebook how to optimize their advertising based on a customer's value. 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

A common request by customer’s is when they are informed of one of their audiences failing to sync, typically with an ‘Internal Error' message; however, there is nothing else added. Typically, this is due to customer’s needed to re-authorize their FB account.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
