### PR TITLE
HTTP API Troubleshooting Topic: Retries to Iterable

### DIFF
--- a/src/connections/destinations/catalog/iterable/index.md
+++ b/src/connections/destinations/catalog/iterable/index.md
@@ -128,6 +128,12 @@ Iterable supports sending push notification events to Segment. These events are 
 They support the following events:
 `Push Delivered`, `Push Bounced`, `Mobile App Uninstalled`, `Push Opened`
 
+## High Retry Rate
+
+If you are experiencing a large amount of retries within your destinations that are connected to your HTTP API source, this could be due to a related Etimedout errors. The errors seem to be Etimedout errors, in general, these are relatively normal intermittent problems that can come about when HTTP requests are made from server to server. 
+
+The Etimedout error is the result of an HTTP response not being received in a specific timeframe. Read more about how Segment retries events to destinations [here](/docs/connections/destinations/#retries-between-segment-and-destinations).
+
 
 ## Using Iterable with Engage
 

--- a/src/connections/destinations/catalog/iterable/index.md
+++ b/src/connections/destinations/catalog/iterable/index.md
@@ -128,11 +128,11 @@ Iterable supports sending push notification events to Segment. These events are 
 They support the following events:
 `Push Delivered`, `Push Bounced`, `Mobile App Uninstalled`, `Push Opened`
 
-## High Retry Rate
+## High retry rate
 
-If you are experiencing a large amount of retries within your destinations that are connected to your HTTP API source, this could be due to a related Etimedout errors. The errors seem to be Etimedout errors, in general, these are relatively normal intermittent problems that can come about when HTTP requests are made from server to server. 
+If you're experiencing a large amount of retries within your destinations that are connected to your HTTP API source, this could be due to Etimedout errors. Etimedout errors are intermittent problems that can come about when HTTP requests are made from server to server. 
 
-The Etimedout error is the result of an HTTP response not being received in a specific timeframe. Read more about how Segment retries events to destinations [here](/docs/connections/destinations/#retries-between-segment-and-destinations).
+The Etimedout error is the result of an HTTP response not being received in a specific timeframe. [Learn more](/docs/connections/destinations/#retries-between-segment-and-destinations) about how Segment retries events to destinations.
 
 
 ## Using Iterable with Engage


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Customers will write in regarding a large amount of retires from a HTTP Source 

The errors seem to be Etimedout errors, in general, these are relatively normal intermittent problems that can come about when HTTP requests are made from server to server. The Etimedout error is the result of an HTTP response not being received in a specific timeframe.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
