### PR TITLE
Add FAQ bullet on supported destination types

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -488,6 +488,10 @@ Yes, you can have both destination filters and destination insert functions in t
 
 Segment's data pipeline applies destination filters before invoking insert functions. 
 
+##### What destination types support Insert Functions?
+
+Only cloud-mode [Event destinations](/docs/engage/using-engage-data/#engage-destination-types-event-vs-list) support destination Insert Functions. [List destinations](/docs/engage/using-engage-data/#list-destinations) are not compatible. 
+
 {% comment %}
 
 ## Using Segment's Public API


### PR DESCRIPTION
### Proposed changes

Added a FAQ bullet point mentioning Insert Function compatibility with destination types.

Only [Event-type destinations](https://segment.com/docs/engage/using-engage-data/#engage-destination-types-event-vs-list) are currently supported, and [List destinations](/docs/engage/using-engage-data/#list-destinations) are not compatible. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
