### PR TITLE
Remove pilot note from Terraform section in Segment for Developers doc

### DIFF
--- a/src/guides/intro-impl.md
+++ b/src/guides/intro-impl.md
@@ -105,8 +105,5 @@ If you're seeing errors thrown by your destinations, you might have an implement
 
 ## Segment Terraform Provider
 
-> info ""
-> Segment Terraform is currently in the pilot phase and is governed by Segment’s [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}.
-
 Segment has a [Terraform](https://www.terraform.io/){:target="_blank"} provider, powered by the Public API, that you can use to manage Segment resources, automate cloud deployments, and change control. Take a look at the [Segment provider documentation](https://registry.terraform.io/providers/segmentio/segment/latest/docs){:target="_blank"} on Terraform to see what's supported.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
See title. Terraform is now GA ([Slack thread for reference](https://twilio.slack.com/archives/C8RQ976RG/p1712686501721949))

### Merge timing
Before Thursday's release

### Related issues (optional)