### PR TITLE
Update v2.md

### DIFF
--- a/src/connections/spec/ecommerce/v2.md
+++ b/src/connections/spec/ecommerce/v2.md
@@ -817,7 +817,7 @@ This event supports the following semantic properties:
 | affiliation           | String   | Store or affiliation from which this transaction occurred (for example, Google Store)               |
 | subtotal              | Number   | Order total after discounts but before taxes and shipping       |
 | total                 | Number   | Revenue ($) with discounts and coupons added in. Note that our Google Analytics Ecommerce destination accepts `total` *or* `revenue`, but not both. For better flexibility and total control over tracking, we let you decide how to calculate how coupons and discounts are applied |
-| revenue               | Number   | Revenue ($) associated with the transaction (excluding shipping and tax)        |
+| revenue               | Number   | Revenue ($) associated with the transaction (including discounts, but excluding shipping and taxes)        |
 | shipping              | Number   | Shipping cost associated with the transaction                  |
 | tax                   | Number   | Total tax associated with the transaction                      |
 | discount              | Number   | Total discount associated with the transaction                 |
@@ -847,7 +847,7 @@ analytics.track('Order Completed', {
   affiliation: 'Google Store',
   total: 27.50,
   subtotal: 22.50,
-  revenue: 25.00,
+  revenue: 22.50,
   shipping: 3,
   tax: 2,
   discount: 2.5,

--- a/src/connections/spec/ecommerce/v2.md
+++ b/src/connections/spec/ecommerce/v2.md
@@ -816,7 +816,7 @@ This event supports the following semantic properties:
 | order_id              | String   | Order/transaction ID                   |
 | affiliation           | String   | Store or affiliation from which this transaction occurred (for example, Google Store)               |
 | subtotal              | Number   | Order total after discounts but before taxes and shipping       |
-| total                 | Number   | Revenue ($) with discounts and coupons added in. Note that our Google Analytics Ecommerce destination accepts `total` *or* `revenue`, but not both. For better flexibility and total control over tracking, we let you decide how to calculate how coupons and discounts are applied |
+| total                 | Number   | Subtotal ($) with shipping and taxes added in. Note that our Google Analytics Ecommerce destination accepts `total` *or* `revenue`, but not both. For better flexibility and total control over tracking, we let you decide how to calculate how coupons and discounts are applied |
 | revenue               | Number   | Revenue ($) associated with the transaction (including discounts, but excluding shipping and taxes)        |
 | shipping              | Number   | Shipping cost associated with the transaction                  |
 | tax                   | Number   | Total tax associated with the transaction                      |


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

According to our [eComm docs](https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed) for `Order Completed`, "subtotal" and "revenue" do vary slightly, in that subtotal is intended to be used for order total after discounts but before taxes and shipping, while revenue is total [before discounts] and also before taxes and shipping.
| **Property**          | **Type** | **Description** |
|-----------------------|----------|---------------- |
| subtotal              | Number   | Order total after discounts but before taxes and shipping       |
| revenue               | Number   | Revenue ($) associated with the transaction (excluding shipping and tax)        |

However, we have received feedback from customers indicating they expected "revenue" to be the **actual amount received**, not the price before discounts.


### Merge timing
ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/KCS-1302
