### PR TITLE
Update Context Spec Code for GroupId

### DIFF
--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -215,9 +215,11 @@ Other libraries only collect `context.library`, any other context variables must
 To pass the context variables which are not automatically collected by Segment's libraries, you must manually include them in the event payload. The following code shows how to pass `groupId` as the context field of Analytics.js's `.track()` event:
 
 ```js
-analytics.track("Report Submitted", {},
-    {"groupId": "1234"}
-);
+analytics.track("Report Submitted", {}, {
+  context: {
+    groupId: "1234"
+  }
+});
 ```
 
 To add fields to the context object in the new mobile libraries, you must utilize a custom plugin. Documentation for creating plugins for each library can be found here:


### PR DESCRIPTION
### Proposed changes

The clarification needed regarding the placement of groupId in the context of a track call, the corrected code snippet should ensure that groupId is properly included within the context object, as this is the standard way to associate a tracking event with a specific group without making a direct group call. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
