### PR TITLE
Indicate time on audience builder’s UI is based on local timezone

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -66,6 +66,9 @@ You can use the following time comparison operators in your audience definition:
 Only ISO timestamps can be used with these operators. Additionally, these time comparison operators exclusively apply to custom traits.
 If the timestamp is not a valid ISO timestamp (for example, a trailing `Z` is missing), Segment won't process the audience in real-time. Learn more about [real-time compute compared to batch](/docs/engage/audiences/#real-time-compute-compared-to-batch).
 
+While in the audience builder, the time you see on the UI will be based on your local timezone but it is converted to UTC on the backend. Please take note of this while you are setting time on the audience builder UI.
+
+
 ### Funnel Audiences
 
 Funnel audiences allow you to specify strict ordering between two events. This might be the case if you want an event to happen or not happen within a specific time window, as in the following example:

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -64,10 +64,9 @@ You can use the following time comparison operators in your audience definition:
 - `after next` 
 
 Only ISO timestamps can be used with these operators. Additionally, these time comparison operators exclusively apply to custom traits.
-If the timestamp is not a valid ISO timestamp (for example, a trailing `Z` is missing), Segment won't process the audience in real-time. Learn more about [real-time compute compared to batch](/docs/engage/audiences/#real-time-compute-compared-to-batch).
+If the timestamp is not a valid ISO timestamp (for example, a trailing `Z` is missing), Segment won't process the audience in real-time. Learn more about [real-time compute compared to batch](/docs/engage/audiences/#real-time-compute-compared-to-batch). 
 
-While in the audience builder, the time you see on the UI will be based on your local timezone but it is converted to UTC on the backend. Please take note of this while you are setting time on the audience builder UI.
-
+**Note**: Timezones seen in the UI are based on your local timezone, but are converted to UTC on the backend.
 
 ### Funnel Audiences
 


### PR DESCRIPTION
### Proposed changes

<!--Tell us what you did and why-->
Information is added as there were tickets where customers are unaware of this and cause confusion when they set time in audience builder.

Added the following info in Time Comparison section: 
 -----------------------------------------------------  
While in the audience builder, the time you see on the UI will be based on your local timezone but it is converted to UTC on the backend. Please take note of this while you are setting time on the audience builder UI.


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
https://segment.zendesk.com/agent/tickets/537225
https://segment.zendesk.com/agent/tickets/496305
https://segment.zendesk.com/agent/tickets/526263

