### PR TITLE
Clarify Segment timestamps are in UTC

### DIFF
--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -248,7 +248,7 @@ Sending data to the rest of Segment's destinations is opt-out so if you don't sp
 
 Every API call has four timestamps, `originalTimestamp`, `timestamp`, `sentAt`, and `receivedAt.`  They're used for very different purposes.
 
-**All timestamps are [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601){:target="_blank"} date strings.**
+**All timestamps are [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601){:target="_blank"} date strings, and are in the UTC timezone.**
 
 > info ""
 > You must use ISO-8601 date strings that include timezones when you use timestamps with [Engage](/docs/engage/). If you send custom traits without a timezone, Segment doesn't save the timestamp value.

--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -248,7 +248,7 @@ Sending data to the rest of Segment's destinations is opt-out so if you don't sp
 
 Every API call has four timestamps, `originalTimestamp`, `timestamp`, `sentAt`, and `receivedAt.`  They're used for very different purposes.
 
-**All timestamps are [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601){:target="_blank"} date strings, and are in the UTC timezone.** To see the user's timezone information, please check the `timezone` field that's automatically collected by client-side libraries listed [here](/docs/connections/spec/common/#context-fields-automatically-collected).
+**All timestamps are [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601){:target="_blank"} date strings, and are in the UTC timezone.** To see the user's timezone information, check the `timezone` field that's automatically collected by [client-side libraries](/docs/connections/spec/common/#context-fields-automatically-collected).
 
 > info ""
 > You must use ISO-8601 date strings that include timezones when you use timestamps with [Engage](/docs/engage/). If you send custom traits without a timezone, Segment doesn't save the timestamp value.

--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -248,7 +248,7 @@ Sending data to the rest of Segment's destinations is opt-out so if you don't sp
 
 Every API call has four timestamps, `originalTimestamp`, `timestamp`, `sentAt`, and `receivedAt.`  They're used for very different purposes.
 
-**All timestamps are [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601){:target="_blank"} date strings, and are in the UTC timezone.**
+**All timestamps are [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601){:target="_blank"} date strings, and are in the UTC timezone.** To see the user's timezone information, please check the `timezone` field that's automatically collected by client-side libraries listed [here](/docs/connections/spec/common/#context-fields-automatically-collected).
 
 > info ""
 > You must use ISO-8601 date strings that include timezones when you use timestamps with [Engage](/docs/engage/). If you send custom traits without a timezone, Segment doesn't save the timestamp value.


### PR DESCRIPTION
### Proposed changes
It is not indicated in our documentation where the timezone of the Segment’s timestamps falls. We receive tickets from time to time requesting this information.

### Merge timing
ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/KCS-1314