### PR TITLE
Add information on deduplication

### DIFF
--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -219,6 +219,6 @@ Because [Google's Measurement Protocol API](https://developers.google.com/analyt
 
 The Google Analytics 4 Cloud destination does not support Google Optimize. This destination operates in cloud-mode (sending events from Segment servers to Google Analytics using the Measurement Protocol API), which prevents the required [Optimize SDK](https://support.google.com/optimize/answer/11287798?visit_id=637903946258690719-978290187&rd=1){:target="_blank"} snippet from loading on the page.
 
-### Client/Server-side Event Deduplication 
-Google doesn't offer guidence around how to deduplicate the same event coming in server and client-side. As that is the case, Segment advises that you not send the same event into Google Analytics 4 from two different locations such that you would expect Google to deduplicate one of the events out of their pipeline. You can [deduplicate user counts]([url](https://support.google.com/analytics/answer/9355949?hl=en)) using the `User ID` field, but you cannot deduplicate whole events in the Google platform as far as Segment is aware.
+### Client/server-side event deduplication 
+Google doesn't offer guidance around how to deduplicate the same event coming in server and client side. As a result, Segment recommends that you not send the same event into Google Analytics 4 from two different locations such that you would expect Google to deduplicate one of the events out of their pipeline. You can [deduplicate user counts](https://support.google.com/analytics/answer/9355949?hl=en){:target="_blank"} using the `User ID` field, but you cannot deduplicate whole events in the Google platform as far as Segment is aware.
 

--- a/src/connections/destinations/catalog/actions-google-analytics-4/index.md
+++ b/src/connections/destinations/catalog/actions-google-analytics-4/index.md
@@ -219,3 +219,6 @@ Because [Google's Measurement Protocol API](https://developers.google.com/analyt
 
 The Google Analytics 4 Cloud destination does not support Google Optimize. This destination operates in cloud-mode (sending events from Segment servers to Google Analytics using the Measurement Protocol API), which prevents the required [Optimize SDK](https://support.google.com/optimize/answer/11287798?visit_id=637903946258690719-978290187&rd=1){:target="_blank"} snippet from loading on the page.
 
+### Client/Server-side Event Deduplication 
+Google doesn't offer guidence around how to deduplicate the same event coming in server and client-side. As that is the case, Segment advises that you not send the same event into Google Analytics 4 from two different locations such that you would expect Google to deduplicate one of the events out of their pipeline. You can [deduplicate user counts]([url](https://support.google.com/analytics/answer/9355949?hl=en)) using the `User ID` field, but you cannot deduplicate whole events in the Google platform as far as Segment is aware.
+


### PR DESCRIPTION
### Proposed changes

Google doesn't provide any guidance on how to deduplicate events which likely means that their platform doesn't handle that. This update clarifies that for Segment users.

### Merge timing

ASAP is fine