### PR TITLE
Add Troubleshooting note in MailChimp

### DIFF
--- a/src/connections/destinations/catalog/mailchimp/index.md
+++ b/src/connections/destinations/catalog/mailchimp/index.md
@@ -133,6 +133,9 @@ Again, this will **NOT** work for new users. New users will always have their su
 ### Why are my calls with trait arrays not showing up in Mailchimp?
 Mailchimp doesn't support arrays as traits values. This can cause calls to not show up.
 
+### Frequent 404 Bad Requests from Identify events without error message?
+If you are sending concurrent requests for the same userId, MailChimp will block the events due to how MailChimp restricts each API key to a maximum of 10 concurrent requests. 
+
 ## Engage
 
 You can send computed traits and audiences generated using [Engage](/docs/engage/) to Mailchimp as a **user property**. To learn more about Engage, schedule a [demo](https://segment.com/demo/){:target="_blank"}.

--- a/src/connections/destinations/catalog/mailchimp/index.md
+++ b/src/connections/destinations/catalog/mailchimp/index.md
@@ -133,8 +133,8 @@ Again, this will **NOT** work for new users. New users will always have their su
 ### Why are my calls with trait arrays not showing up in Mailchimp?
 Mailchimp doesn't support arrays as traits values. This can cause calls to not show up.
 
-### Frequent 404 Bad Requests from Identify events without error message?
-If you are sending concurrent requests for the same userId, MailChimp will block the events due to how MailChimp restricts each API key to a maximum of 10 concurrent requests. 
+### Why are there frequent 404 Bad Requests from Identify events without an error message?
+If you send concurrent requests for the same userId, MailChimp blocks the events because MailChimp restricts each API key to a maximum of 10 concurrent requests. 
 
 ## Engage
 


### PR DESCRIPTION
### Proposed changes

The note about MailChimp's destination max limit of 10 concurrent events in Step 4 is overlooked. When customer experience dropped events from the same user when trying to update traits, they can refer to MailChimp’s limitation.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
