### PR TITLE
Fix broken email editor link

### DIFF
--- a/src/engage/content/email/editor.md
+++ b/src/engage/content/email/editor.md
@@ -161,7 +161,7 @@ After you design the email, click **Create Email Template**.
 
 ## Next steps
 
-- Learn more about [building email templates](/docs/engage/content/template/) to include in your Engage campaigns. 
+- Learn more about [building email templates](/docs/engage/content/email/template/) to include in your Engage campaigns. 
 
 - You can learn about the [HTML Editor](/docs/engage/content/email/html-editor) for both code and visual editing capabilities from a single view.
 


### PR DESCRIPTION
### Proposed changes

Fix dead link. Link currently goes to: https://segment.com/docs/engage/content/template/, which gives a 404 Error

Updated to: https://segment.com/docs/engage/content/**email**/template/

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
