### PR TITLE
Ajs collects timezone by default 

### DIFF
--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -200,7 +200,7 @@ Other libraries only collect `context.library`, any other context variables must
 | traits                   |              | ✅             | ✅                 |
 | userAgent                | ✅            |               | ✅                 |
 | userAgentData*           | ✅           |                |                    |
-| timezone                 |              | ✅             | ✅                 |
+| timezone                 | ✅            | ✅             | ✅                 |
 
 - IP Address isn't collected by Segment's libraries, but is instead filled in by Segment's servers when it receives a message for **client side events only**.
 > info "IPv6 Addresses are not Supported"


### PR DESCRIPTION
<!--Tell us what you did and why-->
Update the context field chart to reflect that Ajs now collects timezone by default 

<!-- When should this get merged/published?
ASAP once approved

### Related issues (optional)

Slack: https://twilio.slack.com/archives/C9Z93GW76/p1713203633234209?thread_ts=1713203458.879349&cid=C9Z93GW76