### PR TITLE
Update index.md - clarify audience behavior when new destination is connected

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -110,7 +110,7 @@ For account-level audiences, you can send either a [Group](/docs/connections/spe
 Because most marketing tools are still based at the user level, it is often important to map this account-level trait onto each user within an account. See [Account-level Audiences](/docs/engage/audiences/account-audiences) for more information.
 
 > info ""
-> When you connect a new Destination to an existing Audience, Engage will backfill historical data for that Audience to the new Destination.
+> When you connect a new Destination with an existing Audience, Engage will backfill historical data for that Audience to the new Destination if the 'Include Historical Data' option is enabled in the Audience Settings. For Audience's that do not have this setting enabled, only new data will be sent. If you'd like to sync all Audience data to the newly connected Destination, please reach out to [Support](friends@segment.com) to request a Resync.
 
 ## Understanding compute times
 


### PR DESCRIPTION
### Proposed changes

Update Audience Sync to Destination's section to clarify expected behavior when connecting a new destination to an existing Audience.

If 'include historical data' is enabled, the entire audience will be sent when a new destination is connected, otherwise, only new data is sent.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
