### PR TITLE
Adding warning about device mode sources and multi-instances of destinationsUpdate add-destination.md

### DIFF
--- a/src/connections/destinations/add-destination.md
+++ b/src/connections/destinations/add-destination.md
@@ -101,6 +101,8 @@ For example, you might set up a single Segment source to send data both to separ
 
 You can also connect multiple instances of a destination to help you smoothly migrate from one configuration to another. By sending each version the same data, you can check and validate the new configuration without interrupting use of the old one.
 
+> warning ""
+> Non-mobile sources can only connect to one device-mode instance of a destination and you cannot connect a source to more than one instance of a destination that operates in device-mode only. read more [here](/docs/connections/destinations/add-destination/#connecting-one-source-to-multiple-instances-of-a-destination:~:text=Multi%2Dinstance%20destinations-,and,-Device%2Dmode).
 
 > success ""
 > If your organization is on a Segment Business tier plan, you can use [Replay](/docs/guides/what-is-replay/) to send historical data to new instances of a destination.

--- a/src/connections/destinations/add-destination.md
+++ b/src/connections/destinations/add-destination.md
@@ -101,8 +101,8 @@ For example, you might set up a single Segment source to send data both to separ
 
 You can also connect multiple instances of a destination to help you smoothly migrate from one configuration to another. By sending each version the same data, you can check and validate the new configuration without interrupting use of the old one.
 
-> warning ""
-> Non-mobile sources can only connect to one device-mode instance of a destination and you cannot connect a source to more than one instance of a destination that operates in device-mode only. read more [here](/docs/connections/destinations/add-destination/#connecting-one-source-to-multiple-instances-of-a-destination:~:text=Multi%2Dinstance%20destinations-,and,-Device%2Dmode).
+> warning "Non-mobile sources can only connect to _one_ device-mode instance of a destination"
+> You cannot connect a source to more than one instance of a destination that operates only in device-mode. For more information about device-mode restrictions, see the [Sending Segment data to Destinations](/docs/connections/destinations/add-destination/#connecting-one-source-to-multiple-instances-of-a-destination:~:text=Multi%2Dinstance%20destinations-,and,-Device%2Dmode) documentation.
 
 > success ""
 > If your organization is on a Segment Business tier plan, you can use [Replay](/docs/guides/what-is-replay/) to send historical data to new instances of a destination.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Non-mobile sources can only connect to one device-mode instance of a destination and you cannot connect a source to more than one instance of a destination that operates in device-mode only. read more [here](/docs/connections/destinations/add-destination/#connecting-one-source-to-multiple-instances-of-a-destination:~:text=Multi%2Dinstance%20destinations-,and,-Device%2Dmode).

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
