### PR TITLE
Add faq that insert function is not supported for storage destination

### DIFF
--- a/src/connections/functions/insert-functions.md
+++ b/src/connections/functions/insert-functions.md
@@ -476,6 +476,10 @@ However, if your function aims to enrich event data by fetching additional infor
 
 No, Destination Insert Functions are currently available for use with Cloud Mode (server-side) destinations only. Segment is in the early phases of exploration and discovery for supporting customer web plugins for custom Device Mode destinations and other use cases, but this is unsupported today.
 
+##### Can I use Insert Functions with Storage destinations?
+
+No, Destination Insert Functions are currently available for use with Cloud Mode (server-side) destinations only. Using of insert function with Storage destination is unsupported today.
+
 ##### Can I connect an insert function to multiple destinations?
 
 Yes, an insert function can be connected to multiple destinations. 


### PR DESCRIPTION
### Proposed changes
Customer asked if insert function can be used for Storage destination.

Added the following faq:
"Can I use Insert Functions with Storage destinations?

No, Destination Insert Functions are currently available for use with Cloud Mode (server-side) destinations only. Using of insert function with Storage destination is unsupported today."


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)
<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
https://segment.zendesk.com/agent/tickets/539705