### PR TITLE
hidden duplication causing page to display

### DIFF
--- a/src/engage/audiences/linked-audiences-use-cases.md
+++ b/src/engage/audiences/linked-audiences-use-cases.md
@@ -5,7 +5,6 @@ beta: true
 hidden: true
 redirect_from: 
     - '/unify/linked-profiles/linked-audiences-use-cases'
-hidden: false
 ---
 
 Below are some example use cases to help you learn more about Linked Audiences.


### PR DESCRIPTION
The page header had a duplicate 'hidden' indicator, causing it to still show up in search. 