### PR TITLE
Klaviyo - Add note about 'Enforce email as primary identifier' setting

### DIFF
--- a/src/connections/destinations/catalog/klaviyo/index.md
+++ b/src/connections/destinations/catalog/klaviyo/index.md
@@ -85,6 +85,8 @@ If your `userId` is an email, or you provide an email in `traits.email`, Segment
 #### Enforce email as primary identifier
 
 This option is enabled by default to ensure duplicate profiles are not being created inside of Klaviyo. When enabled, Segment will never set the $id field to your `userId` when you call `.identify()` or `.track()`. Instead, Segment will only set $email as the primary identifier with your `traits.email` or `properties.email`. Please note that if you have this setting toggled on, you must send `email` in on your payloads or your events will not go through to Klaviyo.
+> info ""
+> For the Web Device-mode connection, this option applies **only** to the `.identify()` call.
 
 #### Fallback on Anonymous ID
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Checking the integration code for Web>Klaviyo (Device mode), the Enforce email as primary identifier setting applies only to Identify calls (unlike the Cloud mode connection, this option will be used by both Identify and Track).

### Merge timing
ASAP once approved

### Related issues (optional)
- https://segment.atlassian.net/browse/KCS-1331