### PR TITLE
Add note about “Search for user” in Journeys

### DIFF
--- a/src/engage/journeys/journeys-analytics.md
+++ b/src/engage/journeys/journeys-analytics.md
@@ -35,7 +35,7 @@ The following table shows the statistics available for a Journey:
 | Exits       | The total number of users who have exited the Journey                         |
 
 > info ""
-> Completed and exits are mutually exclusive.
+> Completed and exits are mutually exclusive. The "Search for a user" search box excludes users who have exited the Journey. 
 
 Use the date picker to view a Journey's analytics over a specific time frame in any 180 day period.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
To clarify that the “Search for user” search box in Journeys only pulls users who are currently in the journey (just like the Preview tab). We are unable to search for those users who have already exited the journey.

### Merge timing
ASAP once approved

### Related issues (optional)
- https://segment.atlassian.net/browse/KCS-1337
