### PR TITLE
Workspace Owners can now delete alerts

### DIFF
--- a/src/connections/alerting.md
+++ b/src/connections/alerting.md
@@ -28,9 +28,12 @@ To create a source volume alert:
   - **In-app**: Select this to receive notifications in the Segment app. To view your notifications, select the bell next to your user icon in the Segment app. 
 5. Click **Save**.
 
-To make changes to a source volume alert that you created, select the icon in the Actions column for the alert and click **Edit**. 
+To make changes to a source volume alert, select the icon in the Actions column for the alert and click **Edit**. 
 
-To delete a source volume alert that you created, select the icon in the Actions column for the alert and click **Delete**. 
+To delete a source volume alert, select the icon in the Actions column for the alert and click **Delete**.
+
+> info "Deleting alerts created by other users requires Workspace Owner permissions"
+> All users can delete source volume alerts that they created, but only those with Workspace Owner permissions can delete alerts created by other users. 
 
 ## Successful delivery rate alerts
 
@@ -48,6 +51,9 @@ To create a successful delivery rate alert:
   - **In-app**: Select this to receive notifications in the Segment app. To view your notifications, select the bell next to your user icon in the Segment app. 
 5. Click **Save**.
 
-To make changes to a successful delivery rate alert that you created, select the icon in the Actions column for the alert and click **Edit**. 
+To make changes to a successful delivery rate alert, select the icon in the Actions column for the alert and click **Edit**. 
 
-To delete a successful delivery rate alert that you created, select the icon in the Actions column for the alert and click **Delete**. 
+To delete a successful delivery rate alert, select the icon in the Actions column for the alert and click **Delete**. 
+
+> info "Deleting alerts created by other users requires Workspace Owner permissions"
+> All users can delete successful delivery alerts that they created, but only those with Workspace Owner permissions can delete alerts created by other users. 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Updated specific language around only the people that created alerts can delete them, as workspace owners can now delete alerts created by other users

### Merge timing
ASAP

### Related issues (optional)
[OBS-1562](https://segment.atlassian.net/browse/OBS-1562)
