### PR TITLE
Add warning that Impact/Segment OAuth must be done by workspace owner

### DIFF
--- a/src/connections/destinations/catalog/impact-partnership-cloud/index.md
+++ b/src/connections/destinations/catalog/impact-partnership-cloud/index.md
@@ -17,8 +17,8 @@ This destination is maintained by Impact. For any issues with the destination, c
 4. Go to the [Impact Partnership Cloud Settings](https://app.impact.com){:target="_blank"}, find and copy the "Account SID", "Auth Token", and "Campaign ID".
 5. Back in the Impact Partnership Cloud destination settings in Segment, enter the "Account SID", "Auth Token", and "Campaign ID".
 
-> warning ""
-> To enable OAuth between Impact and Segment, a Segment workspace owner must complete the process. If you encounter any issues, verify your workspace settings to confirm your authorization as a workspace owner.
+> warning "Workspace owner required for OAuth setup"
+> Only a Segment workspace owner can enable OAuth between Impact and Segment. If you run into during setup, check your workspace settings to verify you have the required permissions.
 
 ## Page
 

--- a/src/connections/destinations/catalog/impact-partnership-cloud/index.md
+++ b/src/connections/destinations/catalog/impact-partnership-cloud/index.md
@@ -17,6 +17,9 @@ This destination is maintained by Impact. For any issues with the destination, c
 4. Go to the [Impact Partnership Cloud Settings](https://app.impact.com){:target="_blank"}, find and copy the "Account SID", "Auth Token", and "Campaign ID".
 5. Back in the Impact Partnership Cloud destination settings in Segment, enter the "Account SID", "Auth Token", and "Campaign ID".
 
+> warning ""
+> To enable OAuth between Impact and Segment, a Segment workspace owner must complete the process. If you encounter any issues, verify your workspace settings to confirm your authorization as a workspace owner.
+
 ## Page
 
 If you aren't familiar with the Segment Spec, take a look at the [Page method documentation](/docs/connections/spec/page/) to learn about what it does. An example call would look like:


### PR DESCRIPTION

### Proposed changes

Added a warning in the setup that OAuth for this destination must be completed by workspace owners. A customer ran into issues with this and the UI and console did not surface any significant warnings to explain why. 

### Merge timing
- ASAP once approved

### Related issues (optional)
 n/a
