### PR TITLE
How to override data being sent to Engage via Consent Manager

### DIFF
--- a/src/privacy/consent-management/consent-in-unify.md
+++ b/src/privacy/consent-management/consent-in-unify.md
@@ -56,4 +56,13 @@ In addition to enforcing consent in Connections, you may want these preferences 
 If you use Destination Actions to send consent information to your destinations, the Segment Consent Preference Updated event should **only** include information about a user's consent preferences because this event is sent regardless of an end-user's consent preferences. 
 
 > info "Sharing consent with Classic Destinations is not available"
-> Segment only supports sharing consent with Actions Destinations. 
+> Segment only supports sharing consent with Actions Destinations.
+
+### FAQ
+
+**Q. How can your override data being sent to an Engage space?**
+
+A. By default Personas is set to true in the consent manager, but this can be overridden by passing Personas false in the integrations object in all events.
+```analytics.identify(71661,{favoriteFood:"cheese burgers"},{"integrations":{"Personas":false}})``` 
+
+


### PR DESCRIPTION
If customers would like to override data being sent to an Engage space, via consent manager, you can do this via the integrations object.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
