### PR TITLE
Revert "Bump commonmarker from 0.23.9 to 0.23.10"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     colorator (1.1.0)
-    commonmarker (0.23.10)
+    commonmarker (0.23.9)
     concurrent-ruby (1.2.2)
     dotenv (2.8.1)
     em-websocket (0.5.3)
@@ -46,7 +46,6 @@ GEM
     filesize (0.2.0)
     forwardable-extended (2.6.0)
     google-protobuf (3.23.2-x86_64-darwin)
-    google-protobuf (3.23.2-x86_64-linux)
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
     i18n (1.13.0)
@@ -90,8 +89,6 @@ GEM
     mercenary (0.4.0)
     nokogiri (1.15.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.2-x86_64-linux)
-      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
@@ -109,8 +106,6 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.62.1-x86_64-darwin)
       google-protobuf (~> 3.21)
-    sass-embedded (1.62.1-x86_64-linux-gnu)
-      google-protobuf (~> 3.21)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thread_safe (0.3.6)
@@ -124,9 +119,9 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
-  x86_64-linux
 
 DEPENDENCIES
   dotenv


### PR DESCRIPTION
Reverts segmentio/segment-docs#5150

taking this back out as it broke stuff. :( 