### PR TITLE
Generative Audiences GA

### DIFF
--- a/src/engage/audiences/generative-audiences.md
+++ b/src/engage/audiences/generative-audiences.md
@@ -3,9 +3,6 @@ title: Generative Audiences
 beta: true
 plan: engage-foundations
 ---
- 
-> info "Generative Audiences is in private beta"
-> Generative Audiences is in private beta, and Segment is actively working on this feature. Some functionality may change before it becomes generally available. [Contact Segment](https://segment.com/help/contact/){:target="_blank"} with any feedback or questions.
 
 With Generative Audiences, part of Segment's CustomerAI, use generative AI to create Engage Audiences with natural language prompts. 
 


### PR DESCRIPTION
### Proposed changes

- Removed beta callout for Generative Audiences.  It went GA on 3 May 2024.

### Merge timing

- 3 May 2024.
