### PR TITLE
Fix typo in image filename

### DIFF
--- a/src/connections/destinations/catalog/actions-stackadapt/index.md
+++ b/src/connections/destinations/catalog/actions-stackadapt/index.md
@@ -156,7 +156,7 @@ This is necessary when using backend SDKs but not for events sent from the front
 
 When sending past events to StackAdapt using a Reverse ETL tool, the user agent, IP address, event type, and either the page URL (for conversion trackers with URL rules), or the fields the event rules match on, must be included in your mappings. For example, the below mapping for a Snowflake source can be used to match a conversion tracker with an event rule that matches an `action` of `User Registered`:
 
-![Image showing Snowflake mapping to forward User Registered events](images/snowflake-mapping.png)
+![Image showing Snowflake mapping to forward User Registered events](images/snowflake-mappings.png)
 
 Rows forwarded to StackAdapt with this mapping will be matched by the `User Registered` event rule shown below:
 


### PR DESCRIPTION
### Proposed changes

- Fixed typo in image filename that was causing the image not to display. `snowflake-mapping.png` -> `snowflake-mappings.png`.

### Merge timing
ASAP once approved

### Related issues (optional)

Follow-up to https://github.com/segmentio/segment-docs/pull/6502 which introduced the typo.
