### PR TITLE
Update set-user-subscriptions.md - update to include RETL option

### DIFF
--- a/src/engage/user-subscriptions/set-user-subscriptions.md
+++ b/src/engage/user-subscriptions/set-user-subscriptions.md
@@ -5,7 +5,7 @@ plan: engage-premier
 
 Segment associates a [user subscription state](/docs/engage/user-subscriptions/subscription-states/) with each email address and phone number in your Engage audiences. Subscription states give you insight into the level of consent a user has given you to receive your Engage campaigns.
 
-You can set a user’s subscription state using a CSV file or, programmatically, using Segment’s APIs. On this page, you’ll learn how and when to use both processes.
+You can set a user’s subscription state using a CSV file or, programmatically, using Reverse ETL or Segment’s APIs. On this page, you’ll learn how and when to use these processes.
 
 ## Setting user subscriptions with a CSV file upload
 
@@ -109,3 +109,9 @@ For successful requests, Segment instantly updates subscription states in your w
 
 > success ""
 > While SMS and WhatsApp share the same number, you must add a separate subscription state for both of them.
+
+## Setting user subscriptions with Reverse ETL
+
+[Engage Premier Subscriptions users](/docs/engage/user-subscriptions/) can use Reverse ETL to sync subscription data from warehouses to destinations.
+
+To get started with using Reverse ETL for managing subscriptions, please refer to our guide available [here](https://segment.com/docs/connections/reverse-etl/#reverse-etl-for-engage-premier-subscriptions).


### PR DESCRIPTION
### Proposed changes
As of October 2023, there is a new generally available feature for managing user subscriptions, via rETL & the Segment Profiles Destination.

I've made a slight modification to the verbiage in the intro of this documentation, as well as included a reference to the RETL method, which links to the set up instructions already detailed within the Reverse ETL Documentation.
https://segment.com/docs/connections/reverse-etl/#reverse-etl-for-engage-premier-subscriptions

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
