### PR TITLE
Rename Bucket Tracking Key to Publishable Key

### DIFF
--- a/src/connections/destinations/catalog/bucket-web/index.md
+++ b/src/connections/destinations/catalog/bucket-web/index.md
@@ -30,8 +30,8 @@ Bucket Web (Actions) provides the following benefits over the classic Bucket des
 1. From the Destinations catalog page in the Segment App, click **Add Destination**.
 2. Search for "Bucket Web" in the Destinations Catalog, and select the Bucket Web (Actions) destination.
 3. Select a source to send data to the Bucket destination.
-4. Go to [Bucket's Settings](https://app.bucket.co){:target="blank"} and find and copy the Tracking Key on the Tracking page.
-5. Enter the Tracking Key as Tracking Key in the "Bucket Web (Actions)" destination settings in Segment.
+4. Go to [Bucket's Settings](https://app.bucket.co){:target="blank"} and find and copy the Publishable Key on the Tracking page.
+5. Enter the Publishable Key as Publishable Key in the "Bucket Web (Actions)" destination settings in Segment.
 
 {% include components/actions-fields.html %}
 

--- a/src/connections/destinations/catalog/bucket/index.md
+++ b/src/connections/destinations/catalog/bucket/index.md
@@ -18,8 +18,8 @@ This destination is maintained by Bucket. For any issues with the destination, [
 1. From the Destinations catalog page in the Segment App, click **Add Destination**.
 2. Search for "Bucket" in the Destinations Catalog, and select the Bucket destination.
 3. Choose which Source should send data to the Bucket destination.
-4. Go to [Bucket's Settings](https://app.bucket.co){:target="blank"} and find and copy the "Tracking Key" under Settings.
-5. Enter the "Tracking Key" as "API Key" in the "Bucket" destination settings in Segment.
+4. Go to [Bucket's Settings](https://app.bucket.co){:target="blank"} and find and copy the "Publishable Key" under Settings.
+5. Enter the "Publishable Key" as "Publishable Key" in the "Bucket" destination settings in Segment.
 
 ## Identify
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

At Bucket we're changing the terminology around keys from tracking key to publishable key.

This change has already been effected in the `bucket` direct destination settings:
![image](https://github.com/segmentio/segment-docs/assets/331790/a79d9a3d-6043-44b6-9ef7-e30ff0d4e822)


### Merge timing

ASAP once approved

### Related issues (optional)

Related to https://github.com/segmentio/action-destinations/pull/2039
