### PR TITLE
Remove Automatic Event Collection References from Native Mobile Spec

### DIFF
--- a/src/connections/spec/mobile.md
+++ b/src/connections/spec/mobile.md
@@ -6,7 +6,7 @@ redirect_from:
 
 One of the core components of the Segment [Spec](/docs/connections/spec/) is the [Track](/docs/connections/spec/track) method. It records any arbitrary event that the user has triggered. For Mobile tracking, in addition to Screen calls, you'll want to send **specific event names** that Segment recognizes semantically. That way, Segment can transform them correctly before sending them off to downstream destinations.
 
-By standardizing the events that comprise the core **mobile application lifecycle** and associated **mobile campaign and referral events**, Segment and its partners can, wherever possible, automatically collect and forward these events on your behalf and build downstream destinations which take full advantage of the semantic meaning associated with these events and their properties.
+By standardizing the events that comprise the core **mobile application lifecycle** and associated **mobile campaign and referral events**, Segment and its partners can, wherever possible, forward these events on your behalf and build downstream destinations that take full advantage of the semantic meaning associated with these events and their properties.
 
 > info ""
 >  If you're already collecting similar events, Segment recommends migrating to these event names so that you can take advantage of available features in Segment destinations that depend on the spec as they become available.
@@ -39,21 +39,13 @@ The Segment Native Mobile Spec includes the following semantic events:
 
 Segment recommends using the above event names if you're going to be integrating the events yourself. This will ensure that they can be mapped effectively in downstream tools.
 
-Additionally, though they're not formally part of the Native Mobile Spec, Segment also collects `Order Completed` from its ecommerce spec automatically upon in-app purchases on iOS and can collect screen views automatically in iOS and Android.
-
 ## Lifecycle events
 
-Mobile applications live within a fairly bounded lifecycle. In order to understand and communicate effectively with your users, it's crucial to instrument the core flows associated with installing and opening your app. The following events, many of which Segment can capture automatically in the latest versions of Segment SDKs, allow you to get a picture of top-line metrics such as DAUs, MAUs, and Screen Views per session. Automatic tracking of lifecycle events is completely optional - you can learn how to enable and disable them in Segment's [iOS](https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#step-2-install-the-sdk){:target="_blank"} and [Android](https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/quickstart/#step-3-initialize-the-client){:target="_blank"} library docs.
-
-The following events will be tracked automatically when lifecycle events are enabled:
-
-- [Application Installed](#application-installed)
-- [Application Opened](#application-opened)
-- [Application Updated](#application-updated)
+Mobile applications live within a fairly bounded lifecycle. In order to understand and communicate effectively with your users, it's crucial to instrument the core flows associated with installing and opening your app. The following events, allow you to get a picture of top-line metrics such as DAUs, MAUs, and Screen Views per session. Automatic tracking of lifecycle events is completely optional - you can learn how to enable and disable them in Segment's [iOS](https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#step-2-install-the-sdk){:target="_blank"} and [Android](https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/quickstart/#step-3-initialize-the-client){:target="_blank"} library docs.
 
 ### Application Installed
 
-This event fires when a user **first** opens your mobile application. Note, if the user never opens your app after installing, Segment will not be able to collect this event. This event doesn't wait for attribution or campaign information to be received, and is collected automatically by Segment's SDKs. Advertising providers like Facebook and Google require discrete install events to correctly attribute installs to ads served through their platform.
+This event fires when a user **first** opens your mobile application. Note, if the user never opens your app after installing, Segment will not be able to collect this event. This event doesn't wait for attribution or campaign information to be received. Advertising providers like Facebook and Google require discrete install events to correctly attribute installs to ads served through their platform.
 
 {% comment %} api-example '{ "userId": "019mr8mf4r", "type": "track", "event": "Application Installed", "properties": { "version": "1.2.3", "build": "1234" }}'}}} {% endcomment %}
 
@@ -94,13 +86,13 @@ This event fires when a user launches or foregrounds your mobile application aft
 }
 ```
 
-| **Property**            | **Type** | **Description**                                                                                                                                                                                                                                                                     |
-| ----------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Property**            | **Type** | **Description**                                                                                                                                                                                                                                                                                       |
+| ----------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `from_background`       | Boolean  | If application [transitioned](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/#//apple_ref/doc/uid/TP40006786-CH3-SW52){:target="_blank"} from "Background" to "Inactive" state prior to foregrounding (as opposed to from "Not Running" state). |
-| `url`                   | String   | The value of `UIApplicationLaunchOptionsURLKey` from `launchOptions`. **Collected on iOS only**.        |
-| `referring_application` | String   | The value of `UIApplicationLaunchOptionsSourceApplicationKey` from `launchOptions`. **Automatically collected on iOS only**.     |
-| `version`               | String   | The version installed.     |
-| `build`                 | String   | The build number of the installed app.    |
+| `url`                   | String   | The value of `UIApplicationLaunchOptionsURLKey` from `launchOptions`. **Collected on iOS only**.                                                                                                                                                                                                      |
+| `referring_application` | String   | The value of `UIApplicationLaunchOptionsSourceApplicationKey` from `launchOptions`.                                                                                                                                                                                                                   |
+| `version`               | String   | The version installed.                                                                                                                                                                                                                                                                                |
+| `build`                 | String   | The build number of the installed app.                                                                                                                                                                                                                                                                |
 
 
 ### Application Backgrounded
@@ -120,7 +112,7 @@ This event should be sent when a user backgrounds the application upon [`applica
 
 ### Application Updated
 
-This event fires when a user updates the application. Segment's SDK will automatically collect this event instead of an "Application Opened" event when Segment determines that the Open is first since an update.
+This event fires when a user updates the application.
 
 {% comment %} api-example '{ "userId": "019mr8mf4r", "type": "track", "event": "Application Updated", "properties": { "previous_version": "1.1.2", "previous_build": 1234, "version": "1.2.0", "build": "1456" }}'}}} {% endcomment %}
 
@@ -316,8 +308,6 @@ This event fires when a push notification from a provider bounces. If your push 
 When your application is opened using a referring link, Segment or your packaged deep link partner can fire this event on your behalf. If the deep link has additional data associated with it, either passed through the third party service or as `annotations` in `launchOption`, you may want to include those values as properties here as well.
 
 This event is fired *in addition* to the associated `Application Opened` event.
-
-Our [iOS](/docs/connections/sources/catalog/libraries/mobile/ios/#automatic-deep-link-tracking) SDK can collect this event automatically if configured to do so.
 
 {% comment %} api-example '{"userId": "019mr8mf4r", "type": "track", "event": "Deep Link Opened", "properties": {"provider": "Branch Metrics", "url": "app://landing" }}'}}} {% endcomment %}
 

--- a/src/connections/spec/mobile.md
+++ b/src/connections/spec/mobile.md
@@ -4,17 +4,17 @@ redirect_from:
   - '/spec/mobile'
 ---
 
-One of the core components of the Segment [Spec](/docs/connections/spec/) is the [Track](/docs/connections/spec/track) method. It records any arbitrary event that the user has triggered. For Mobile tracking, in addition to Screen calls, you'll want to send **specific event names** that Segment recognizes semantically. That way, we can transform them correctly before sending them off to downstream destinations.
+One of the core components of the Segment [Spec](/docs/connections/spec/) is the [Track](/docs/connections/spec/track) method. It records any arbitrary event that the user has triggered. For Mobile tracking, in addition to Screen calls, you'll want to send **specific event names** that Segment recognizes semantically. That way, Segment can transform them correctly before sending them off to downstream destinations.
 
-By standardizing the events that comprise the core **mobile application lifecycle** and associated **mobile campaign and referral events**, Segment and our partners can, wherever possible, automatically collect and forward these events on your behalf and build downstream destinations which take full advantage of the semantic meaning associated with these events and their properties.
+By standardizing the events that comprise the core **mobile application lifecycle** and associated **mobile campaign and referral events**, Segment and its partners can, wherever possible, automatically collect and forward these events on your behalf and build downstream destinations which take full advantage of the semantic meaning associated with these events and their properties.
 
 > info ""
->  If you're already collecting similar events, Segment recommends migrating to these event names so that you can take advantage of available features in our destinations which depend on the spec as they become available.
+>  If you're already collecting similar events, Segment recommends migrating to these event names so that you can take advantage of available features in Segment destinations that depend on the spec as they become available.
 
 These events pair nicely with Segment's [ecommerce spec](/docs/connections/spec/ecommerce/v2/) for mobile marketplaces to take full advantage of features like dynamic ads in Facebook and the ability to take full advantage of server-side destinations with Mobile Attribution Platforms like [Tune](https://www.tune.com/){:target="_blank"} and [Kochava](https://www.kochava.com/){:target="_blank"}.
 
 > info ""
->  Per the [Privacy Policy](https://segment.com/legal/privacy/#sensitive-personal-information){:target="_blank"} and applicable terms, don't send Segment sensitive personal information about your users. Certain features from Segment and our partners allow you to opt-in to automatically track data (for example: Application Installed or Deep Link Clicked). When working with these features and Segment in general, be cognizant of the data that is being tracked to ensure its matching both your obligations under your agreement with Segment and the privacy expectations of your users.
+>  Per the [Privacy Policy](https://segment.com/legal/privacy/#sensitive-personal-information){:target="_blank"} and applicable terms, don't send Segment sensitive personal information about your users. Certain features from Segment and its partners allow you to opt-in to automatically track data (for example: Application Installed or Deep Link Clicked). When working with these features and Segment in general, be cognizant of the data that is being tracked to ensure its matching both your obligations under your agreement with Segment and the privacy expectations of your users.
 
 ## Overview of events
 
@@ -39,11 +39,11 @@ The Segment Native Mobile Spec includes the following semantic events:
 
 Segment recommends using the above event names if you're going to be integrating the events yourself. This will ensure that they can be mapped effectively in downstream tools.
 
-Additionally, though they're not formally part of the Native Mobile Spec, Segment also collects `Order Completed` from our ecommerce spec automatically upon in-app purchases on iOS and can collect screen views automatically in iOS and Android.
+Additionally, though they're not formally part of the Native Mobile Spec, Segment also collects `Order Completed` from its ecommerce spec automatically upon in-app purchases on iOS and can collect screen views automatically in iOS and Android.
 
 ## Lifecycle events
 
-Mobile applications live within a fairly bounded lifecycle. In order to understand and communicate effectively with your users, it's crucial to instrument the core flows associated with installing and opening your app. The following events, many of which Segment can capture automatically in the latest versions of our SDKs, allow you to get a picture of top-line metrics such as DAUs, MAUs, and Screen Views per session. Automatic tracking of lifecycle events is completely optional - you can learn how to enable and disable them in Segment's [iOS](https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#step-2-install-the-sdk){:target="_blank"} and [Android](https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/quickstart/#step-3-initialize-the-client){:target="_blank"} library docs.
+Mobile applications live within a fairly bounded lifecycle. In order to understand and communicate effectively with your users, it's crucial to instrument the core flows associated with installing and opening your app. The following events, many of which Segment can capture automatically in the latest versions of Segment SDKs, allow you to get a picture of top-line metrics such as DAUs, MAUs, and Screen Views per session. Automatic tracking of lifecycle events is completely optional - you can learn how to enable and disable them in Segment's [iOS](https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#step-2-install-the-sdk){:target="_blank"} and [Android](https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/quickstart/#step-3-initialize-the-client){:target="_blank"} library docs.
 
 The following events will be tracked automatically when lifecycle events are enabled:
 
@@ -120,7 +120,7 @@ This event should be sent when a user backgrounds the application upon [`applica
 
 ### Application Updated
 
-This event fires when a user updates the application. Segment's SDK will automatically collect this event instead of an "Application Opened" event when we determine that the Open is first since an update.
+This event fires when a user updates the application. Segment's SDK will automatically collect this event instead of an "Application Opened" event when Segment determines that the Open is first since an update.
 
 {% comment %} api-example '{ "userId": "019mr8mf4r", "type": "track", "event": "Application Updated", "properties": { "previous_version": "1.1.2", "previous_build": 1234, "version": "1.2.0", "build": "1456" }}'}}} {% endcomment %}
 

--- a/src/connections/spec/mobile.md
+++ b/src/connections/spec/mobile.md
@@ -43,9 +43,15 @@ Segment recommends using the above event names if you're going to be integrating
 
 Mobile applications live within a fairly bounded lifecycle. In order to understand and communicate effectively with your users, it's crucial to instrument the core flows associated with installing and opening your app. The following events, allow you to get a picture of top-line metrics such as DAUs, MAUs, and Screen Views per session. Automatic tracking of lifecycle events is completely optional - you can learn how to enable and disable them in Segment's [iOS](https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#step-2-install-the-sdk){:target="_blank"} and [Android](https://segment.com/docs/connections/sources/catalog/libraries/mobile/android/quickstart/#step-3-initialize-the-client){:target="_blank"} library docs.
 
+The following events will be tracked automatically when lifecycle events are enabled:
+
+- [Application Installed](#application-installed)
+- [Application Opened](#application-opened)
+- [Application Updated](#application-updated)
+
 ### Application Installed
 
-This event fires when a user **first** opens your mobile application. Note, if the user never opens your app after installing, Segment will not be able to collect this event. This event doesn't wait for attribution or campaign information to be received. Advertising providers like Facebook and Google require discrete install events to correctly attribute installs to ads served through their platform.
+This event fires when a user **first** opens your mobile application. Note, if the user never opens your app after installing, Segment will not be able to collect this event. This event doesn't wait for attribution or campaign information to be received, and is collected automatically by Segment's SDKs. Advertising providers like Facebook and Google require discrete install events to correctly attribute installs to ads served through their platform.
 
 {% comment %} api-example '{ "userId": "019mr8mf4r", "type": "track", "event": "Application Installed", "properties": { "version": "1.2.3", "build": "1234" }}'}}} {% endcomment %}
 
@@ -112,7 +118,7 @@ This event should be sent when a user backgrounds the application upon [`applica
 
 ### Application Updated
 
-This event fires when a user updates the application.
+This event fires when a user updates the application. Segment's SDK will automatically collect this event instead of an "Application Opened" event when we determine that the Open is first since an update.
 
 {% comment %} api-example '{ "userId": "019mr8mf4r", "type": "track", "event": "Application Updated", "properties": { "previous_version": "1.1.2", "previous_build": 1234, "version": "1.2.0", "build": "1456" }}'}}} {% endcomment %}
 


### PR DESCRIPTION
### Proposed changes

- Removed a handful of references to automatic iOS event collection.

### Merge timing

- ASAP once approved.

### Related issues (optional)

https://github.com/segmentio/analytics-swift/issues/338
