### PR TITLE
Add consent management docs

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -199,6 +199,8 @@ sections:
     title: Typewriter for Kotlin
   - path: /connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-destination-filters
     title: Destination Filters for Kotlin
+  - path: /connections/sources/catalog/libraries/mobile/kotlin-android/consent
+    title: Consent Management for Kotlin
   - path: /connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-faq
     title: FAQs
 
@@ -223,6 +225,8 @@ sections:
     title: Typewriter for Swift
   - path: /connections/sources/catalog/libraries/mobile/apple/swift-destination-filters
     title: Destination Filters for Swift
+  - path: /connections/sources/catalog/libraries/mobile/apple/consent
+    title: Consent Management for Swift
   - path: /connections/sources/catalog/libraries/mobile/apple/ios-17
     title: iOS 17 & Privacy Manifests
 

--- a/src/connections/sources/catalog/libraries/mobile/apple/consent.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/consent.md
@@ -1,0 +1,211 @@
+---
+title: Consent Manager for Swift
+strat: swift
+---
+Add Segment-driven consent management support for your application via this plugin for [Analytics-Swift](https://github.com/segmentio/analytics-swift) 
+
+This plugin provides the framework to integrate Consent Management Platform (CMP) SDKs like OneTrust to supply consent status and potentially block events going to device mode destinations.
+
+Read more about Segment’s Consent Management solutions [here](https://segment.com/docs/privacy/configure-consent-management/), as well as enabling it for your workspace.
+
+## Background
+
+Consent Management is the management of a user’s consent preferences related to privacy. You might be familiar with the privacy pop-ups that have become mandated recently that ask the user if they consent to the use of certain categories of cookies.
+
+The privacy pop-up asks the user if they will consent to the use of cookies and allows the user to customize their consent by turning on/off different categories of cookies.
+
+After the user selects “Allow All” or “Save Preferences,” a callback is fired and the owner of the website is notified as to the consent preferences of a given user. The website owner must then store that consent preference and abide by it. Any rejected cookies must not be set or read to avoid large fines that can be handed down by government authorities.
+
+Additionally, besides the initial pop-up, the website owner must give users a way to later change any preferences they originally selected. This is usually accomplished by providing a link to display the customization screen.
+
+
+## Segment managed CMP
+
+Segment provides a framework for users to integrate any CMP they choose and use the Segment web app to map consent categories to device mode destinations. This information is sent down the analytics-swift SDK and stored for later lookup.
+
+Every event that flows through the library will be stamped with the current status according to whatever configured CMP is used. Event stamping is handled by the ConsentManagementPlugin. 
+
+Using consent status stamped on the events and the mappings sent down from the Segment web app each event is evaluated and action is taken. Currently the supported actions are:
+
+- Blocking - This action is implemented by the ConsentBlockingPlugin
+
+## Event Stamping
+
+Event stamping is the process of adding the consent status information to an existing event. The information is added to the context object of every event. Below is a before and after example:
+
+Before
+
+```json
+{
+    "anonymousId": "23adfd82-aa0f-45a7-a756-24f2a7a4c895",
+    "type": "track",
+    "event": "MyEvent",
+    "userId": "u123",
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "context": {
+        "traits": {
+            "email": "peter@example.com",
+            "phone": "555-555-5555"
+        },
+        "device": {
+            "advertisingId": "7A3CBBA0-BDF5-11E4-8DFC-AA02A5B093DB"
+        }
+    }
+}
+```
+After
+
+```json
+{
+    "anonymousId": "23adfd82-aa0f-45a7-a756-24f2a7a4c895",
+    "type": "track",
+    "event": "MyEvent",
+    "userId": "u123",
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "context": {
+        "traits": {
+            "email": "peter@example.com",
+            "phone": "555-555-5555"
+        },
+        "device": {
+            "advertisingId": "7A3CBBA0-BDF5-11E4-8DFC-AA02A5B093DB"
+        },
+        "consent": {
+            "categoryPreferences": {
+                "Advertising": true,
+                "Analytics": false,
+                "Functional": true,
+                "DataSharing": false
+            }
+        }
+    }
+}
+```
+
+## Segment Consent Preference Event
+
+When notified by the CMP SDK that consent has changed, a track event with name “Segment Consent Preference” will be emitted. Below is example of what that event will look like:
+
+```json
+{
+    "anonymousId": "23adfd82-aa0f-45a7-a756-24f2a7a4c895",
+    "type": "track",
+    "event": "Segment Consent Preference",
+    "userId": "u123",
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "context": {
+        "device": {
+            "advertisingId": "7A3CBEA0-BDF5-11E4-8DFC-AA07A5B093DB"
+        },
+        "consent": {
+            "categoryPreferences": {
+                "Advertising": true,
+                "Analytics": false,
+                "Functional": true,
+                "DataSharing": false
+            }
+        }
+    }
+}
+```
+
+## Event Flow
+
+1. An event is dropped onto the timeline by some tracking call.
+2. The ConsentManagementPlugin consumes the event, stamps it, and returns it.
+3. The event is now stamped with consent information from this point forward.
+4. The event is copied. The copy is consumed by a Destination Plugin and continues down its internal timeline. The original event is returned and continues down the main timeline.
+    - a. The stamped event is now on the timeline of the destination plugin.
+    - b. The event reaches the ConsentBlockingPlugin which makes a decision as to whether or not to let the event continue down the timeline.
+    - c. If the event has met the consent requirements it continues down the timeline.
+5. The event continues down the timeline.
+
+
+
+
+## Getting Started
+
+### via Xcode
+In the Xcode `File` menu, click `Add Packages`.  You'll see a dialog where you can search for Swift packages.  In the search field, enter the URL to this repo.
+```
+https://github.com/segment-integrations/analytics-swift-consent
+```
+
+You'll then have the option to pin to a version, or specific branch, as well as which project in your workspace to add it to.  Once you've made your selections, click the `Add Package` button.  
+
+### via Package.swift
+
+Open your Package.swift file and add the following do your the `dependencies` section:
+
+```
+.package(
+            name: "Segment",
+            url: "https://github.com/segment-integrations/analytics-swift-consent.git",
+            from: "1.0.0"
+        ),
+```
+
+Next pick from one of the prebuilt integration:
+
+- OneTrust: `https://github.com/segment-integrations/analytics-swift-consent-onetrust`
+
+Or build your own integration (see below)
+
+Next you'll need to write some setup/init code where you have your
+Analytics setup:
+
+```swift
+let analytics = Analytics(configuration: Configuration(writeKey: "<YOUR WRITE KEY>")
+                    .flushAt(3)
+                    .trackApplicationLifecycleEvents(true))
+
+let consentManager = ConsentManager(provider: MyConsentProvider())
+analytics.add(plugin: consentManager)
+// add any device mode destinations you might have ...
+analytics.add(plugin: FirebaseDestination())
+analytics.add(plugin: TaplyticsDestination())
+        
+// Note: Different consent management providers may require consentManager.start() be called differently.
+// Tell the consent manager to start processing events.  It will queue events until start() is called.
+consentManager.start()
+```
+
+The Consent Manager plugin will automatically add a ConsentBlockingPlugin to any device mode destinations, so there's no extra steps for you to do in your code. Blocking for cloud mode destinations will be handled server-side at Segment.
+
+## Building your own integration
+In order to integrate a new CMP, you will need to satisfy the below requirements.
+
+### Consent Category Provider
+You'll need to create a `ConsentCategoryProvider` that will provide a mapping of consent category to whether or not a given category has been consented by the user.  It must also provide a way to inform the `ConsentManager` of any changes that happen during runtime.
+
+Example:
+```swift
+class MyConsentProvider: ConsentCategoryProvider {
+    // this will be set later by the ConsentManager.
+    var changeCallback: ConsentChangeCallback? = nil
+    // this is the imaginary Consent SDK you supplied/wrote.
+    let consentSDK: MyConsentSDK
+
+    var categories: [String : Bool] {
+        // Returns a simple dictionary of categories and their 
+        // enabled/disabled status.
+        //
+        // ie: ["Analytics": true, "Advertising": false, "Performance": true]
+        return consentSDK.categoriesAndStatus()
+    }
+    
+    init(consentSDK: MyConsentSDK) {
+        self.consentSDK = consentSDK
+        self.consentSDK.changeListener = consentChanged
+    }
+
+    func consentChanged() {
+        guard let changeCallback else { return }
+        // this will tell the ConsentManager that consent has changed, it 
+        // will check the `categories` above again and then send
+        // a "Segment Consent Preference" track event with the updates.
+        changeCallback()
+    }
+}
+
+```

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/consent.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/consent.md
@@ -1,0 +1,265 @@
+---
+title: Consent Manager for Kotlin
+strat: kotlin-android
+---
+Add Segment-driven consent management support for your application via this plugin for [Analytics-Kotlin](https://github.com/segmentio/analytics-kotlin) 
+
+This plugin provides the framework to integrate Consent Management Platform (CMP) SDKs like OneTrust to supply consent status and potentially block events going to device mode destinations.
+
+Read more about Segment’s Consent Management solutions [here](https://segment.com/docs/privacy/configure-consent-management/), as well as enabling it for your workspace.
+
+## Background
+
+Consent Management is the management of a user’s consent preferences related to privacy. You might be familiar with the privacy pop-ups that have become mandated recently that ask the user if they consent to the use of certain categories of cookies.
+
+The privacy pop-up asks the user if they will consent to the use of cookies and allows the user to customize their consent by turning on/off different categories of cookies.
+
+After the user selects “Allow All” or “Save Preferences,” a callback is fired and the owner of the website is notified as to the consent preferences of a given user. The website owner must then store that consent preference and abide by it. Any rejected cookies must not be set or read to avoid large fines that can be handed down by government authorities.
+
+Additionally, besides the initial pop-up, the website owner must give users a way to later change any preferences they originally selected. This is usually accomplished by providing a link to display the customization screen.
+
+
+## Segment managed CMP
+
+Segment provides a framework for users to integrate any CMP they choose and use the Segment web app to map consent categories to device mode destinations. This information is sent down the analytics-kotlin SDK and stored for later lookup.
+
+Every event that flows through the library will be stamped with the current status according to whatever configured CMP is used. Event stamping is handled by the ConsentManagementPlugin. 
+
+Using consent status stamped on the events and the mappings sent down from the Segment web app each event is evaluated and action is taken. Currently the supported actions are:
+
+- Blocking - This action is implemented by the ConsentBlockingPlugin
+
+## Event Stamping
+
+Event stamping is the process of adding the consent status information to an existing event. The information is added to the context object of every event. Below is a before and after example:
+
+Before
+
+```json
+{
+    "anonymousId": "23adfd82-aa0f-45a7-a756-24f2a7a4c895",
+    "type": "track",
+    "event": "MyEvent",
+    "userId": "u123",
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "context": {
+        "traits": {
+            "email": "peter@example.com",
+            "phone": "555-555-5555"
+        },
+        "device": {
+            "advertisingId": "7A3CBBA0-BDF5-11E4-8DFC-AA02A5B093DB"
+        }
+    }
+}
+```
+After
+
+```json
+{
+    "anonymousId": "23adfd82-aa0f-45a7-a756-24f2a7a4c895",
+    "type": "track",
+    "event": "MyEvent",
+    "userId": "u123",
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "context": {
+        "traits": {
+            "email": "peter@example.com",
+            "phone": "555-555-5555"
+        },
+        "device": {
+            "advertisingId": "7A3CBBA0-BDF5-11E4-8DFC-AA02A5B093DB"
+        },
+        "consent": {
+            "categoryPreferences": {
+                "Advertising": true,
+                "Analytics": false,
+                "Functional": true,
+                "DataSharing": false
+            }
+        }
+    }
+}
+```
+
+## Segment Consent Preference Updated Event
+
+When notified by the CMP SDK that consent has changed, a track event with name “Segment Consent Preference Updated” will be emitted. Below is example of what that event will look like:
+
+```json
+{
+    "anonymousId": "23adfd82-aa0f-45a7-a756-24f2a7a4c895",
+    "type": "track",
+    "event": "Segment Consent Preference Updated",
+    "userId": "u123",
+    "timestamp": "2023-01-01T00:00:00.000Z",
+    "context": {
+        "device": {
+            "advertisingId": "7A3CBEA0-BDF5-11E4-8DFC-AA07A5B093DB"
+        },
+        "consent": {
+            "categoryPreferences": {
+                "Advertising": true,
+                "Analytics": false,
+                "Functional": true,
+                "DataSharing": false
+            }
+        }
+    }
+}
+```
+
+## Event Flow
+
+1. An event is dropped onto the timeline by some tracking call.
+2. The ConsentManagementPlugin consumes the event, stamps it, and returns it.
+3. The event is now stamped with consent information from this point forward.
+4. The event is copied. The copy is consumed by a Destination Plugin and continues down its internal timeline. The original event is returned and continues down the main timeline.
+    - a. The stamped event is now on the timeline of the destination plugin.
+    - b. The event reaches the ConsentBlockingPlugin which makes a decision as to whether or not to let the event continue down the timeline.
+    - c. If the event has met the consent requirements it continues down the timeline.
+5. The event continues down the timeline.
+
+
+
+
+## Getting Started
+
+To get started add the dependency for consent management to your app's build.gradle file:
+
+```groovy
+    implementation 'com.segment.analytics.kotlin.destinations:consent:<LATEST_VERSION>'
+```
+
+Next pick from one of the prebuilt integration:
+
+- OneTrust: https://github.com/segment-integrations/analytics-kotlin-consent-onetrust
+
+Or build your own integration (see below)
+
+Next you'll need to write some setup/init code where you have your
+Analytics setup:
+
+```kotlin
+// Setup Analytics
+analytics = Analytics(SEGMENT_WRITE_KEY, applicationContext) {
+   this.collectDeviceId = true
+   this.trackApplicationLifecycleEvents = true
+   this.trackDeepLinks = true
+   this.flushPolicies = listOf(
+      CountBasedFlushPolicy(5), // Flush after 5 events
+      FrequencyFlushPolicy(5000) // Flush after 5 Seconds
+   )
+}
+
+// Add the myDestination plugin into the main timeline
+val myDestinationPlugin = myDestinationPlugin()
+analytics.add(myDestinationPlugin)
+
+// Create the Consent Category Provider that will get the status of consent categories
+val consentCategoryProvider = MyConsentCategoryProvider(cmpSDK)
+val store = SynchronousStore() // Use only a Synchronous store here!
+
+val consentPlugin = ConsentManagementPlugin(store, consentCategoryProvider)
+
+// Add the Consent Plugin directly to analytics
+analytics.add(consentPlugin)
+
+// Use the CMP SDK to get the list of consent categories.
+consentCategoryProvider.setCategories(cmpSDK.getCategories())
+
+// Once the categories have been set we can start processing events by starting
+// the Consent Management plugin
+consentPlugin.start()
+```
+
+## Building your own integration
+In order to integrate a new CMP, you will need to satisfy the below requirements.
+
+### Consent Category Provider
+First you'll need to create a `ConsentCategoryProvider` that will provide a mapping of consent category to whether or not a given category has been consented by the user.
+
+Example:
+```Kotlin
+class OneTrustConsentCategoryProvider(
+    val otPublishersHeadlessSDK: OTPublishersHeadlessSDK,
+    val categories: List<String>
+) : ConsentCategoryProvider {
+
+    override fun getCategories(): Map<String, Boolean> {
+        var categoryConsentMap = HashMap<String, Boolean>()
+
+        categories.forEach { category ->
+            val consent = otPublishersHeadlessSDK.getConsentStatusForGroupId(category)
+            val consentValue = when (consent) {
+                1 -> true
+                else -> false
+            }
+
+            categoryConsentMap.put(category, consentValue)
+        }
+
+        return categoryConsentMap
+    }
+}
+```
+
+Here we show how OneTrust is integrated. As you can see it uses a passed in list of categories to query the OneTrust SDK and maps the OneTrust response (-1, 0, or 1) to true/false.
+
+### Consent Changed Notifier
+The second and last integration point is a way to notify the ConsentManagementPlugin that consent has changed for the user.
+
+Here is an OneTrust example:
+```kotlin
+package com.segment.analytics.kotlin.destinations.consent.onetrust
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import com.onetrust.otpublishers.headless.Public.Keys.OTBroadcastServiceKeys
+import com.segment.analytics.kotlin.destinations.consent.ConsentManagementPlugin
+import java.lang.ref.WeakReference
+
+class OneTrustConsentChangedNotifier(
+    val contextReference: WeakReference<Context>,
+    val categories: List<String>,
+    val consentPlugin: ConsentManagementPlugin
+) {
+
+    private val consentChangedReceiver: BroadcastReceiver? = null
+
+    fun register() {
+        if (consentChangedReceiver != null) {
+            unregister()
+        }
+
+        val context = contextReference.get()
+        categories.forEach {
+
+            if (context != null) {
+                context.registerReceiver(
+                    OneTrustConsentChangedReceiver(consentPlugin),
+                    IntentFilter(OTBroadcastServiceKeys.OT_CONSENT_UPDATED)
+                )
+            }
+        }
+    }
+
+    fun unregister() {
+        val context = contextReference.get()
+        if (context != null) {
+            context.unregisterReceiver(consentChangedReceiver)
+        }
+    }
+}
+
+class OneTrustConsentChangedReceiver(val consentPlugin: ConsentManagementPlugin) :
+    BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        consentPlugin.notifyConsentChanged()
+    }
+}
+```
+
+Here we can see that the OneTrust SDK notifies us of consent change via an Android Intent with the action `OTBroadcastServiceKeys.OT_CONSENT_UPDATED` so our notifier must create a broadcast receiver and listen for this event. One the event is broadcast the reciever will then call `consentPlugin.notifyConsentChanged()` to let the ConsentManagmentPlugin to send the `Segment Consent Preference Updated` event.


### PR DESCRIPTION
### Proposed changes
Add consent management docs to our public docs site. There are docs available on GH, which these files are heavily based on:
- [Kotlin](https://github.com/segment-integrations/analytics-kotlin-consent/blob/main/README.md#getting-started)
- [Swift](https://github.com/segment-integrations/analytics-swift-consent#segment-consent-management) 