### PR TITLE
Link Show an Ad step for advertising destinations

### DIFF
--- a/src/engage/journeys/send-data.md
+++ b/src/engage/journeys/send-data.md
@@ -18,6 +18,8 @@ Ensure you have connected and enabled destinations in your Space.
 3. Click **Connect destinations** to select the destination you'll send the data to.
 4. Click **Save**.
 
+To include an advertising destination in a Journey, ensure you have connected and enabled the destination within your Space, then utilize the [Show an Ad](docs/engage/journeys/step-types/#show-an-ad) step.
+
 ## Test event payloads
 
 With the Engage event tester, you can send a test event payload to a Destination. As a result, you can confirm that you've correctly configured Journey Audiences before you publish your Journey.


### PR DESCRIPTION
### Proposed changes

Revised the 'Send data to Destination' section in the Journey documentation to include a reference to the 'Show an Ad' step, which is required for connecting advertising destinations to a Journey.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
