### PR TITLE
Remove duplicate LinkedIn Audiences folder

### DIFF
--- a/src/connections/destinations/catalog/linkedin-audiences/index.md
+++ b/src/connections/destinations/catalog/linkedin-audiences/index.md
@@ -1,7 +1,0 @@
----
-title: 'LinkedIn Audiences Destination'
-hidden: true
-id: 62f435d1d311567bd5bf0e8d
-published: false
-beta: true
----


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
See title. The docs for this integration weren't populating correctly into lists of destinations - turns out there was a duplicate page that had the same ID, and that duplicate page had `hidden: true`, which prevented any documentation from showing up correctly. 

### Merge timing
ASAP

### Related issues (optional)
