### PR TITLE
 Remove text this is only included for partner integrations

### DIFF
--- a/src/connections/destinations/catalog/actions-kafka/index.md
+++ b/src/connections/destinations/catalog/actions-kafka/index.md
@@ -8,8 +8,6 @@ id: 65dde5755698cb0dab09b489
 
 [Kafka](https://kafka.apache.org/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank”} provides a highly scalable and fault-tolerant messaging system that enables real-time data processing and stream processing at scale. When integrated with Segment, Kafka serves as a powerful backbone for managing and processing event data collected by Segment, allowing businesses to efficiently ingest, route, and analyze data across various applications and systems in real time.
 
-This destination is maintained by Segment. For any issues with the destination, [contact the Segment Support team](mailto:friends@segment.com).
-
 ## Getting started
 
 ### Create the Kafka Destination


### PR DESCRIPTION
### Proposed changes
We only include this text for partner integrations, to point folks to the partner support team. It is sort of redundant for integrations we build:

> This destination is maintained by Segment. For any issues with the destination, [contact the Segment Support team](mailto:friends@segment.com).