### PR TITLE
Add note about empty campaign objects in Analytics.js

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/troubleshooting.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/troubleshooting.md
@@ -227,7 +227,7 @@ You'll also need to modify the Segment script with your `nonce` tag, which shoul
 
 ## Why am I getting an empty campaign object in my event payload?
 
-When any search parameters are present in the URL, Analytics.js will generate a campaign object inside the context object. If there are no UTM parameters present to be parsed, then the campaign object will remain empty. 
+Analytics.js generates a campaign object inside the context object whenever the URL contains search parameters. Without any UTM parameters, the campaign object remains empty. 
 
 ## Known issues:
 

--- a/src/connections/sources/catalog/libraries/website/javascript/troubleshooting.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/troubleshooting.md
@@ -225,6 +225,10 @@ You'll also need to modify the Segment script with your `nonce` tag, which shoul
 > info ""
 > Since Segment interacts with several integrations, support surrounding Content Security Policy issues is limited.
 
+## Why am I getting an empty campaign object in my event payload?
+
+When any search parameters are present in the URL, Analytics.js will generate a campaign object inside the context object. If there are no UTM parameters present to be parsed, then the campaign object will remain empty. 
+
 ## Known issues:
 
 [Review and contribute to these on GitHub](https://github.com/segmentio/analytics.js/issues).


### PR DESCRIPTION
### Proposed changes
AJS has some legacy behavior that appends an empty campaign object to the payload if any search parameters are present in the URL. I've added a note to our docs about this behavior until a time that engineering can review it and determine if it can be removed. 

### Merge timing
- ASAP once approved

### Related issues (optional)

n/a
