### PR TITLE
Remove section referencing iAD

### DIFF
--- a/src/connections/destinations/catalog/singular/index.md
+++ b/src/connections/destinations/catalog/singular/index.md
@@ -28,56 +28,6 @@ This destination is maintained by Singular. For any issues with the destination,
 Enable automatic tracking of lifecycle events (`Application Opened`, `Application Installed`, `Application Updated`) using initialization config parameters ([iOS](/docs/connections/sources/catalog/libraries/mobile/ios/#application-lifecycle-tracking), [Android](/docs/connections/sources/catalog/libraries/mobile/android/#step-2-initialize-the-client)) to track installs and sessions in Singular. The Singular "**session**" will be sent automatically by the integration as long as you are including the events above.
 
 
-## Apple Search Ads Attribution
-
-> note "Note"
-> If you are using the Device-Based Destination, there's no need to implement the code below, as the data is already collected automatically.
-
-To get attribution data into Singular, you must include the [analytics-ios-iads-attribution](https://github.com/segmentio/analytics-ios-iads-attribution){:target="_blank"} dependency and version 3.6.0 or higher of the [Analytics SDK](https://github.com/segmentio/analytics-ios){:target="_blank"}.
-
-To install it, simply add the following line to your Podfile:
-`pod "Analytics"`
-`pod "Analytics-iAds-Attribution"`
-
-Then import the header and initialize the configuration:
-```
-#import <Analytics-iAds-Attribution/SEGADTracker.h>
-
-// Initialize the configuration as you would normally.
-SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:@"YOUR_WRITE_KEY"];
-...
-
-// Configure the client with the iAD middleware to attach iAd properties.
-configuration.middlewares = @[ [SEGADTracker middleware] ];
-
-[SEGAnalytics setupWithConfiguration:configuration];
-
-```
-When iAd information is available, the attribution information is transformed to Segment context this way:
-```
-[analytics track:@"Application Installed",
-    properties: nil,
-    options: @{
-      @"context" : @{
-        @"campaign" : @{
-          @"provider" : @"Apple",
-          @"click_date" : attributionInfo[@"iad-click-date"],
-          @"conversion_date" : attributionInfo[@"iad-conversion-date"],
-          @"source" : @"iAd",
-          @"name" : attributionInfo[@"iad-campaign-name"],
-          @"content" : attributionInfo[@"iad-keyword"],
-          @"ad_creative" : attributionInfo[@"iad-org-name"],
-          @"ad_group" : attributionInfo[@"iad-adgroup-name"],
-          @"id" : attributionInfo[@"iad-campaign-id"],
-          @"ad_group_id" : attributionInfo[@"iad-adgroup-id"]
-        }
-      }
-    }];
-
-```
-Singular has explicitly mapped the `Application Installed` lifecycle event to provide the iAd Information.
-
-
 ## Tracking Custom Events
 
 If you're not familiar with the Segment Specs, take a look to understand what the [Track method](/docs/connections/spec/track/) does. An example call (in Android) would look like:


### PR DESCRIPTION
### Proposed changes
iAD is no longer used since it's been updated with AdSupport/ATT

Relevant thread: https://twilio.slack.com/archives/GTM41A6G7/p1711487561107329

### Merge timing
Once approved

### Related issues (optional)

