### PR TITLE
Add FAQ on Changing Email Templates and Journeys Impact

### DIFF
--- a/src/engage/content/email/template.md
+++ b/src/engage/content/email/template.md
@@ -128,4 +128,9 @@ Segment doesn't support profile traits in object and array datatypes in [Broadca
 - View some [email deliverability tips and tricks](https://docs.sendgrid.com/ui/sending-email/deliverability){:target="blank"} from SendGrid.
 
 - You can also use the Templates screen in Engage to [build SMS templates](/docs/engage/content/sms/template/).
- 
+
+## FAQs
+
+### Will changes made to a template be automatically reflected in a Journey step that utilizes the template?
+
+When using a template in a Journey Step, it serves as the foundational template for that particular step. Once an email template is selected for use in a Journey, any modifications made to that original template will not reflect in the Journey's version of the template after it has been added. Similarly, any customizations made to the email template within a Journey step will not alter the original template.

--- a/src/engage/content/email/template.md
+++ b/src/engage/content/email/template.md
@@ -131,6 +131,6 @@ Segment doesn't support profile traits in object and array datatypes in [Broadca
 
 ## FAQs
 
-### Will changes made to a template be automatically reflected in a Journey step that utilizes the template?
+### Do updates to an email template automatically apply to Journey steps using it?
 
-When using a template in a Journey Step, it serves as the foundational template for that particular step. Once an email template is selected for use in a Journey, any modifications made to that original template will not reflect in the Journey's version of the template after it has been added. Similarly, any customizations made to the email template within a Journey step will not alter the original template.
+When you add a template to a Journey step, it becomes a copy specific to that step. Changes made to the original template won’t update the Journey version, and edits made in the Journey step won’t affect the original template. This keeps your Journey changes separate while preserving the original for reuse.


### PR DESCRIPTION
### Proposed changes

I've added a FAQs section as we receive this question quite a few times. It is about how changes to email templates affect Journeys.
Once an email template is selected for use in a Journey, any modifications made to that original template will not reflect in the Journey's version of the template after it has been added.
Similarly, any customizations made to the email template within a Journey step will not alter the original template.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
