### PR TITLE
Add ID Sync info to Google Ads Remarketing Lists Destination

### DIFF
--- a/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
+++ b/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
@@ -151,6 +151,9 @@ You can set an email on the user profile by including `email` as a trait, as a p
 
 If a user has more than one email address or IDFA on their account as `external_ids`, Engage sends the most recent id on the user profile to Adwords for matching. The match rate will be low if Google can't identify users based on the data that you provide.
 
+> info [**ID Sync**]([url](https://segment.com/docs/engage/trait-activation/id-sync/))
+> Now with Segment's ID Sync feature, you can send additional identifiers to actions destinations. Since Google has a requirement on the limit of identifiers that can be sent in each request, the Google Ads Remarketing Lists destination can only be configured to send one additional identifier in its audience's payloads. If the Google Ads Remarketing Lists destination has already been receiving data from an audience, then configuring ID Sync on the destination afterwards will not be applied to the audience users retroactively, and would require a resync in order to add those identifiers to the entire user base. [Contact Segment support](https://segment.com/requests/integrations/) if you would like to request a resync of your audience to its Google Ads Remarketing Lists destination with the newly enabled ID Sync configuration added.
+
 ### Invalid Settings error in Event Delivery
 
 Make sure that this destination was created in [Engage](/docs/engage/) as it requires additional event data not available in standard destinations.

--- a/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
+++ b/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
@@ -151,8 +151,8 @@ You can set an email on the user profile by including `email` as a trait, as a p
 
 If a user has more than one email address or IDFA on their account as `external_ids`, Engage sends the most recent id on the user profile to Adwords for matching. The match rate will be low if Google can't identify users based on the data that you provide.
 
-> info [**ID Sync**]([url](https://segment.com/docs/engage/trait-activation/id-sync/))
-> Now with Segment's ID Sync feature, you can send additional identifiers to actions destinations. Since Google has a requirement on the limit of identifiers that can be sent in each request, the Google Ads Remarketing Lists destination can only be configured to send one additional identifier in its audience's payloads. If the Google Ads Remarketing Lists destination has already been receiving data from an audience, then configuring ID Sync on the destination afterwards will not be applied to the audience users retroactively, and would require a resync in order to add those identifiers to the entire user base. [Contact Segment support](https://segment.com/requests/integrations/) if you would like to request a resync of your audience to its Google Ads Remarketing Lists destination with the newly enabled ID Sync configuration added.
+> info "ID Sync"
+> [Segment's ID Sync](/docs/engage/trait-activation/id-sync/), you can send additional identifiers to Actions destinations. However, due to Google’s restrictions on identifier limits per request, the Google Ads Remarketing Lists destination can only include one additional identifier in audience payloads. If the Google Ads Remarketing Lists destination is already receiving data from an audience and you enable ID Sync afterward, the new identifiers won’t be applied retroactively to existing users. To update identifiers for the entire user base, a full resync is required. [Contact Segment support](https://segment.com/requests/integrations/){:target="_blank"} to request a resync with your new ID Sync configuration.
 
 ### Invalid Settings error in Event Delivery
 


### PR DESCRIPTION
### Proposed changes

ID Sync is available for this destination but with limitations.

ℹ ID Sync 
Now with Segment's ID Sync feature, you can send additional identifiers to actions destinations. Since Google has a requirement on the limit of identifiers that can be sent in each request, the Google Ads Remarketing Lists destination can only be configured to send one additional identifier in its audience's payloads. If the Google Ads Remarketing Lists destination has already been receiving data from an audience, then configuring ID Sync on the destination afterwards will not be applied to the audience users retroactively, and would require a resync in order to add those identifiers to the entire user base. [Contact Segment support](https://segment.com/requests/integrations/) if you would like to request a resync of your audience to its Google Ads Remarketing Lists destination with the newly enabled ID Sync configuration added.

### Merge timing
- ASAP once approved?

### Related issues (optional)

[Zendesk Ticket](https://segment.zendesk.com/agent/tickets/536756)
[KCS JIRA](https://segment.atlassian.net/browse/KCS-1432)
