### PR TITLE
Update faq-best-practices.md - journey entry conditions w/ backfill

### DIFF
--- a/src/engage/journeys/faq-best-practices.md
+++ b/src/engage/journeys/faq-best-practices.md
@@ -99,3 +99,8 @@ Journeys triggers audience or trait-related events for each email `external_id` 
 #### How quickly do user profiles move through Journeys?
 
 It may take up to five minutes for a user profile to enter each step of a Journey, including the entry condition. For Journey steps that reference a batch audience or SQL trait, Journeys processes user profiles at the same rate as the audience or trait computation. Visit the Engage docs to [learn more about compute times](/docs/engage/audiences/#understanding-compute-times).
+
+#### How to ensure consistent user evaluation in Journey entry conditions that use Historical Data?
+
+When a Journey is published, the computation of the entry step begins immediately in real-time, while the backfill process of historical data runs concurrently. It is important to note that if a user's events or traits evaluated in the entry condition span both real-time and historical data, unintended behavior may occur. This discrepancy could result in users qualifying in real-time, but should not have when their historical data is taken into account.
+To prevent this, it is recommended to manually create an audience, using the same conditions, that includes historical data. This pre-built audience can then be referenced in your Journey entry condition, to ensure a consistent evaluation based on all relevant data.


### PR DESCRIPTION
### Proposed changes

Added a FAQ/Known undesired behavior

When a Journey is published, the real-time computation of the audience begins immediately, with the backfill process running concurrently. This can lead to unintended behavior if the users' events or traits, evaluated in the entry condition, span both real-time and historical data. This discrepancy might result in users qualifying in real-time but not when their historical data is considered.
To avoid this issue, consider manually creating an audience that incorporates these conditions, including historical data. You can then reference this pre-built audience in your new audience or Journey setup. This approach ensures a consistent evaluation of users based on both their real-time and historical data.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
