### PR TITLE
Freshsales Suite - traits is mandatory for Identify

### DIFF
--- a/src/connections/destinations/catalog/freshsales-suite-crm/index.md
+++ b/src/connections/destinations/catalog/freshsales-suite-crm/index.md
@@ -55,7 +55,7 @@ userId is a mandatory field which is used to identify the contact in Freshsales.
 
 #### Traits
 
-Traits are mandatory in an identify method, which contains pieces of information you know about a user.
+Traits are pieces of information you know about a user. They are a mandatory part of the [Identify method](/docs/connections/spec/identify/).
 
 #### Default Traits
 

--- a/src/connections/destinations/catalog/freshsales-suite-crm/index.md
+++ b/src/connections/destinations/catalog/freshsales-suite-crm/index.md
@@ -55,7 +55,7 @@ userId is a mandatory field which is used to identify the contact in Freshsales.
 
 #### Traits
 
-Traits are pieces of information you know about a user that are included in an identify method.
+Traits are mandatory in an identify method, which contains pieces of information you know about a user.
 
 #### Default Traits
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
According to Freshsales's support team, traits are **mandatory** for Identify events:
> ​After conducting a more thorough investigation, we have discovered that the payload is missing the necessary traits, which is the root cause of the 400 error. It is important to note that traits are mandatory in the payload.

### Merge timing
ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/KCS-1451
