### PR TITLE
Update group.md - required fields

### DIFF
--- a/src/connections/spec/group.md
+++ b/src/connections/spec/group.md
@@ -54,6 +54,8 @@ Beyond the common fields, the Group call takes the following fields:
   {% include content/spec-table-header.md %}
   {% include content/spec-field-group-id.md %}
   {% include content/spec-field-group-traits.md %}
+   {% include content/spec-field-user-id.md %}
+ {% include content/spec-field-anonymous-id.md %}
 </table>
 
 


### PR DESCRIPTION
### Proposed changes

Update to clarify that userId or anonymousId is a required field in Group calls by including in table found [here](https://segment.com/docs/connections/spec/group/#:~:text=Beyond%20the%20common%20fields%2C%20the%20Group%20call%20takes%20the%20following%20fields%3A). 

This will match the formatting of the ‘Identify’ Spec field table:
[https://segment.com/docs/connections/spec/identify/#:~:text=Beyond the common fields%2C an Identify call has the following fields%3A](https://segment.com/docs/connections/spec/identify/#:~:text=Beyond%20the%20common%20fields%2C%20an%20Identify%20call%20has%20the%20following%20fields%3A)

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
