### PR TITLE
feat(content): clarify no dependency on profiles sync for linked events

### DIFF
--- a/src/unify/linked-profiles/data-graph.md
+++ b/src/unify/linked-profiles/data-graph.md
@@ -25,7 +25,7 @@ To help you get started with the Data Graph, [view this short setup demo](https:
 To use the Data Graph, you'll need the following:
 
 - A supported data warehouse. 
-- If setting up Linked Audiences, [Profiles Sync](/docs/unify/profiles-sync/) set up with ready-to-use [data models and tables](/docs/unify/profiles-sync/tables/) in your warehouse.
+- (If setting up Linked Audiences) [Profiles Sync](/docs/unify/profiles-sync/) set up with ready-to-use [data models and tables](/docs/unify/profiles-sync/tables/) in your warehouse.
 - Workspace Owner or Unify Read-only/Admin and Entities Admin permissions.
 
 > info ""

--- a/src/unify/linked-profiles/data-graph.md
+++ b/src/unify/linked-profiles/data-graph.md
@@ -14,7 +14,7 @@ Segment's Data Graph powers [Linked Events](/docs/unify/linked-profiles/linked-e
 
 To help you get started with the Data Graph, [view this short setup demo](https://drive.google.com/file/d/1oZNvs0raYaxK6tds3OEF0Ri3NGVCoXys/view?pli=1){:target="_blank"}.
 
-> > info ""
+> info ""
 > Linked Profiles follows zero-copy principles, and doesn't copy entities to store in Segment. Segment stores and processes all data in the United States. 
 
 > warning ""
@@ -25,8 +25,11 @@ To help you get started with the Data Graph, [view this short setup demo](https:
 To use the Data Graph, you'll need the following:
 
 - A supported data warehouse. 
-- [Profiles Sync](/docs/unify/profiles-sync/) set up with ready-to-use [data models and tables](/docs/unify/profiles-sync/tables/) in your warehouse.
+- If setting up Linked Audiences, [Profiles Sync](/docs/unify/profiles-sync/) set up with ready-to-use [data models and tables](/docs/unify/profiles-sync/tables/) in your warehouse.
 - Workspace Owner or Unify Read-only/Admin and Entities Admin permissions.
+
+> info ""
+> Profiles Sync is not required for Linked Events
 
 ## Step 1: Set up required permissions in your data warehouse
 

--- a/src/unify/linked-profiles/linked-events.md
+++ b/src/unify/linked-profiles/linked-events.md
@@ -38,7 +38,7 @@ To use Linked Events, you'll need the following:
 > Segment stores and processes all data in the United States.
 
 > info ""
-> Profiles Sync not required for Linked Events
+> Profiles Sync isn't required for Linked Events.
 
 ### Linked Events roles
 

--- a/src/unify/linked-profiles/linked-events.md
+++ b/src/unify/linked-profiles/linked-events.md
@@ -37,6 +37,9 @@ To use Linked Events, you'll need the following:
 > info ""
 > Segment stores and processes all data in the United States.
 
+> info ""
+> Profiles Sync not required for Linked Events
+
 ### Linked Events roles
 
 The following Segment access [roles](/docs/segment-app/iam/roles/) apply to Linked Events:


### PR DESCRIPTION
### Proposed changes
- Clarify that Profiles Sync is not required if only setting up Linked Events
- Profiles Sync is only required if setting up Linked Audiences

### Merge timing
- ASAP once approved?

### Related issues (optional)
- [Slack Thread that prompted the Change](https://twilio.slack.com/archives/C05BMCB3P2P/p1718371491162549?thread_ts=1718365144.787859&cid=C05BMCB3P2P)
- [Dan Lasky stated he had seen it twice this week](https://twilio.slack.com/archives/C05BMCB3P2P/p1718378807182159?thread_ts=1718365144.787859&cid=C05BMCB3P2P)
