### PR TITLE
Added note that Web (Actions) destinations can't use insert functions 🦆  [DOC-897]

### DIFF
--- a/src/_includes/content/destination-dossier.html
+++ b/src/_includes/content/destination-dossier.html
@@ -56,7 +56,7 @@
   {% endif %}
   {% if connectionModes.cloud.web == true %}
     {% unless connectionModes.cloud.mobile == true or connectionModes.cloud.server == true or connectionModes.device.web == true or connectionModes.device.mobile == true or connectionModes.device.server == true %}
-      <li>This destination is not compatible with Destination Insert functions. For more information, see the <a href="/docs/connections/functions/insert-functions/">Destination Insert Functions documentation.</a></li>
+      <li>This destination is not compatible with <a href="/docs/connections/functions/insert-functions/">Destination Insert Functions.</a></li>
       {% endunless %}    
     {% endif %}
   {% if destinationInfo.status == "PUBLIC_BETA" %}<li>This destination is in <span class="release-pill">Beta</span></li>{% endif %}

--- a/src/_includes/content/destination-dossier.html
+++ b/src/_includes/content/destination-dossier.html
@@ -54,6 +54,11 @@
    {% if connectionModes.cloud.web == true or connectionModes.cloud.mobile == true or connectionModes.cloud.server == true %} <li>In Cloud-mode, refer to it as <strong>{{previous_names | join: '</strong>, or <strong>' }}</strong> in the <a href="/docs/guides/filtering-data/#filtering-with-the-integrations-object">Integrations object</a></li>{%endif%}
    {% if connectionModes.device.web == true or connectionModes.device.mobile == true or connectionModes.device.server == true %} <li>In Device-mode, refer to it as <strong>{{previous_names | first}}</strong> in the <a href="/docs/guides/filtering-data/#filtering-with-the-integrations-object">Integrations object</a> </li>{%endif%}
   {% endif %}
+  {% if connectionModes.cloud.web == true %}
+    {% unless connectionModes.cloud.mobile == true or connectionModes.cloud.server == true or connectionModes.device.web == true or connectionModes.device.mobile == true or connectionModes.device.server == true %}
+      <li>This destination is not compatible with Destination Insert functions. For more information, see the <a href="/docs/connections/functions/insert-functions/">Destination Insert Functions documentation.</a></li>
+      {% endunless %}    
+    {% endif %}
   {% if destinationInfo.status == "PUBLIC_BETA" %}<li>This destination is in <span class="release-pill">Beta</span></li>{% endif %}
   {% if page.engage == true %}<li>This destination is <b>only</b> compatible with <a href="/docs/engage">Twilio Engage</a>.</li>{% endif %}
 </ul>


### PR DESCRIPTION
### Proposed changes
Customer Success wanted us to call out that folks with Web (Actions) destinations can't use destination functions. I added a bullet point in the destination dossier to call this out:

![Screenshot 2024-06-14 at 4 54 07 PM](https://github.com/segmentio/segment-docs/assets/92472883/93c54239-4749-4568-8744-d96b66117b6c)

### Merge timing
after approval. not urgent

### Related issues (optional)
Closes #6379 
