### PR TITLE
Update index.md - update the add/remove user frequency google ads rem…

### DIFF
--- a/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
+++ b/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
@@ -66,7 +66,7 @@ When you create an audience in Engage and connect it to Google Ads Remarketing L
 
 1. Creates a Google Ads User List (Customer List) with the name you entered in Engage.
 2. Adds any users that fit the audience definition based on email or mobile ID (IDFA). Google uses these identifiers to match users in your list to users in the Google system who can be served ads.
-3. Segment either adds or removes users from this audience based on the same identifiers.
+3. Either adds or removes users from this audience based on the same identifiers.
 
 ## Set up
 

--- a/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
+++ b/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
@@ -66,7 +66,7 @@ When you create an audience in Engage and connect it to Google Ads Remarketing L
 
 1. Creates a Google Ads User List (Customer List) with the name you entered in Engage.
 2. Adds any users that fit the audience definition based on email or mobile ID (IDFA). Google uses these identifiers to match users in your list to users in the Google system who can be served ads.
-3. Every hour, Segment either adds or removes users from this audience based on the same identifiers.
+3. Segment either adds or removes users from this audience based on the same identifiers.
 
 ## Set up
 


### PR DESCRIPTION
### Proposed changes

In the 'How it Works' section of Google Ads Remarketing Lists, it is mentioned that Segment adds/removes users every hour. However, the default compute frequency for audiences is set at 8 hours and various factors may influence the sync frequency as well, being that this is a list-destination.

I've removed the 'Every hour' verbiage, as we should not have absolute value in the doc per Engineering.


### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
