### PR TITLE
Update index.md - reverse ETL, FAQ regarding retries

### DIFF
--- a/src/connections/reverse-etl/index.md
+++ b/src/connections/reverse-etl/index.md
@@ -351,3 +351,7 @@ In case of consecutive failures, Segment sends notifications for every sync fail
 
 #### Can I have multiple queries in the Query Builder?
 No. In Reverse ETL, Segment executes queries in a [common table expression](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#with_clause){:target="_blank”}, which can only bind the results from **one single** subquery. If there are multiple semicolons `;` in the query, they'll be treated as several subqueries (even if the second part is only an inline comment) and cause syntax errors.
+
+#### In Reverse ETL connections, are events that Fail to be sent to the connected Destination Retried?
+
+Currently, Reverse ETL does not include an automatic retry mechanism for events that encounter failures during their attempt to be sent to a destination.


### PR DESCRIPTION
### Proposed changes

Updated Reverse ETL Documentation to include a FAQ on Failed Events and Retry Policy

As of now, events that fail during their attempt to reach the designated destination are not subject to automatic retries.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
