### PR TITLE
Remove Google Ads Hourly Sync Info

### DIFF
--- a/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
+++ b/src/connections/destinations/catalog/adwords-remarketing-lists/index.md
@@ -45,7 +45,7 @@ Google Ads Remarketing Lists allows you to efficiently run several marketing and
 
 ### Exclusion audiences (suppression audiences)
 
-Create an audience of users that signed up, purchased a product, or otherwise performed some conversion event. You can then send those users to Google in a timely manner (hourly syncs) to prevent advertising to users that already converted. You can do this by creating an audience in Engage, syncing it to the Google Ads Remarketing Lists, and setting it as an [Exclusion List](https://support.google.com/google-ads/answer/2549058){:target="_blank"} in your Google Ads campaign.
+Create an audience of users that signed up, purchased a product, or otherwise performed some conversion event. You can then send those users to Google in a timely manner to prevent advertising to users that already converted. You can do this by creating an audience in Engage, syncing it to the Google Ads Remarketing Lists, and setting it as an [Exclusion List](https://support.google.com/google-ads/answer/2549058){:target="_blank"} in your Google Ads campaign.
 
 
 ### Similar audience


### PR DESCRIPTION
### Proposed changes

Continuation of previous PR's : 
https://github.com/segmentio/segment-docs/pull/6741
https://github.com/segmentio/segment-docs/pull/6732

That should be the last one needed to remove the mention of google ads remarketing lists being synced to hourly.



### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
