### PR TITLE
Update Predictions Events Limit

### DIFF
--- a/src/unify/Traits/predictions/using-predictions.md
+++ b/src/unify/Traits/predictions/using-predictions.md
@@ -123,6 +123,6 @@ Yes.
 Yes. Keep the following in mind when you work with Predictions:
 
 - **Predictions made for more than 100 million users will fail.** Segment recommends making predictions only for non-anonymous users, or, as an alternative, use the Starting Cohort to narrow down the audience for which you want to make a prediction.
-- **Predictions will not work as intended if you track more than 5,000 unique events in your workspace.** If this applies to your use case, [contact Segment Support](https://segment.com/help/contact/){:target="_blank"} for help with removing unused events, which will allow you to create predictions.
+- **Predictions will not work as intended if you've tracked more than 5,000 unique events in your workspace in the last 30 days.** If this applies to your use case, [contact Segment Support](https://segment.com/help/contact/){:target="_blank"} for help with removing unused events, which will allow you to create predictions.
 - **Prediction is failing with error "We weren't able to create this prediction because your requested prediction event is not being tracked anymore. Please choose a different prediction event and try again."** Predictions are computed based on the available data and the conditions specified for the trait. A gap in tracking events for seven continuous days could potentially affect the computation of the prediction.
 Nevertheless, once data tracking resumes and there is enough data, the prediction should be recomputed.


### PR DESCRIPTION
### Proposed changes

Currently, we state "Predictions will not work as intended if you track more than 5,000 unique events in your workspace. "

I've revised this to state that they will not work if tracking more than 5,000 unique events in the **last 30 days**.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
