### PR TITLE
Add Warning to Unify/Engage Source Debugger

### DIFF
--- a/src/unify/debugger.md
+++ b/src/unify/debugger.md
@@ -12,7 +12,7 @@ Because Segment generates a unique source for every destination connected to a S
 The Debugger provides you with the payload information you need to troubleshoot potential formatting issues and ensure Segment sends events as your destinations expect.
 
 > warning "Modifying or disabling these system-generated sources could result in unforeseen issues and data loss."
-> Turning off these sources might impede profile updates, while removing them could compromise the stability of the Engage space, potentially making it irrecoverable. To ensure the system's integrity, we highly recommend leaving these sources enabled.
+> Turning off these sources might impede profile updates, while removing them could compromise the stability of the Engage space, potentially making it irrecoverable. To ensure the system's integrity, Segment highly recommends leaving these sources enabled.
 
 ## Working with the Debugger
 

--- a/src/unify/debugger.md
+++ b/src/unify/debugger.md
@@ -11,6 +11,9 @@ Because Segment generates a unique source for every destination connected to a S
 
 The Debugger provides you with the payload information you need to troubleshoot potential formatting issues and ensure Segment sends events as your destinations expect.
 
+> warning "Modifying or disabling these system-generated sources could result in unforeseen issues and data loss."
+> Turning off these sources might impede profile updates, while removing them could compromise the stability of the Engage space, potentially making it irrecoverable. To ensure the system's integrity, we highly recommend leaving these sources enabled.
+
 ## Working with the Debugger
 
 Navigate to the Debugger tab on the Unify settings page of the space you want to debug. Select the source you want to inspect in the Debugger.


### PR DESCRIPTION
### Proposed changes

Added warning message to the Unify Profile Source Debugger documentation to highlight the importance of not tampering with them.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
