### PR TITLE
Auto-Instrumentation Updates

### DIFF
--- a/src/connections/auto-instrumentation/configuration.md
+++ b/src/connections/auto-instrumentation/configuration.md
@@ -1,9 +1,9 @@
 ---
-title: Signals Implementation Guide
+title: Generate Events from Signals
 hidden: true
 ---
 
-This guide is a reference to configuring and using signals in the Signals SDK with Auto-Instrumentation. On this page, you'll find details on:
+This guide is a reference to configuring, generating, and using signals in the Signals SDK with Auto-Instrumentation. On this page, you'll find details on:
 
 - Setting up and managing signal types in the Signals SDK
 - Creating custom rules to capture and translate signals into actionable analytics events

--- a/src/connections/auto-instrumentation/setup.md
+++ b/src/connections/auto-instrumentation/setup.md
@@ -143,12 +143,6 @@ Next, you'll need to verify signal emission and [create rules](/docs/connections
 
 Segment displays `Rule updated successfully` to verify that it saved your rule.
 
-## Step 4: Redeploy your application
-
-After you've finished deploying your new rule(s), redeploy your application.
-
-Redeployment ensures that the new rules are active and that your application can generate events from signals.
-
 ## Next steps
 
 This guide walked you through initial Signals SDK/Auto-Instrumentation setup. Next, read the [Auto-Instrumentation Signals Implementation Guide](/docs/connections/auto-instrumentation/configuration/), which dives deeper into Signals and offers examples rules. 


### PR DESCRIPTION
### Proposed changes

- Removed a step from the auto-instrumentation setup guide, as it's no longer necessary.
- Changed the title of the Signals page from "Signals Implementation Guide" to "Generate Events from Signals," on PM request.

### Merge timing

- ASAP once approved.