### PR TITLE
Update index.md - add profile to list engage, listID restraints

### DIFF
--- a/src/connections/destinations/catalog/actions-klaviyo/index.md
+++ b/src/connections/destinations/catalog/actions-klaviyo/index.md
@@ -88,3 +88,7 @@ To add and remove profiles in Klaviyo with Engage Audience data:
 ### Dealing with 429 Responses from Klaviyo's API
 
 If you're encountering rate limiting issues, consider enabling batching for the Action receiving these errors. Ensure that within the mapping configuration, "Batch data to Klaviyo" is set to "Yes". This adjustment can help alleviate the rate limiting problem.
+
+### Can I send Engage Audiences to a pre-created List in Klaviyo?
+
+Please note that when using the 'Add Profile to List - Engage' Mapping, Engage audiences are designed to initiate the creation of new lists in Klaviyo, and cannot be linked to existing Klaviyo lists, making the List ID non-editable.

--- a/src/connections/destinations/catalog/actions-klaviyo/index.md
+++ b/src/connections/destinations/catalog/actions-klaviyo/index.md
@@ -89,6 +89,6 @@ To add and remove profiles in Klaviyo with Engage Audience data:
 
 If you're encountering rate limiting issues, consider enabling batching for the Action receiving these errors. Ensure that within the mapping configuration, "Batch data to Klaviyo" is set to "Yes". This adjustment can help alleviate the rate limiting problem.
 
-### Can I send Engage Audiences to a pre-created List in Klaviyo?
+### Can I send Engage Audiences to a pre-created Klaviyo List?
 
-Please note that when using the 'Add Profile to List - Engage' Mapping, Engage audiences are designed to initiate the creation of new lists in Klaviyo, and cannot be linked to existing Klaviyo lists, making the List ID non-editable.
+No. Engage audiences are designed to initiate the creation of new lists in Klaviyo when you use the "Add Profile to List - Engage" mapping. You cannot link Engage lists to existing Klaviyo lists and cannot edit the List ID for Engage audiences.


### PR DESCRIPTION
### Proposed changes

Clarified in FAQ that the LIST ID cannot be edited/modified in the 'Add Profile to List - Engage' Action. Engage sends the external_audience_id as the List Id.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
