### PR TITLE
Specifying which user IDs should be submitted for deletion

### DIFF
--- a/src/privacy/user-deletion-and-suppression.md
+++ b/src/privacy/user-deletion-and-suppression.md
@@ -6,6 +6,9 @@ In keeping with Segment's commitment to GDPR and CCPA readiness, Segment offers 
 
 [Contact Support](https://segment.com/help/contact/) if you need to process more than 110,000 users within a 30 day period.
 
+> warning "User IDs for deletion"
+> It's important to note that the userID required for deletion requests are the user IDs sent through your events according to the [Segment Spec](https://segment.com/docs/connections/spec/).  In other words, the IDs under the userId fields specifically, not just any identifier.
+
 > info "Business Plan Customers"
 > If you use this feature to delete data, you can not Replay the deleted data. For standard Replay requests, you must wait for any pending deletions to complete, and you cannot submit new deletion requests for the period of time that Segment replays data for you.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

I added a warning containing the following message:
"It's important to note that the userID required for deletion requests are the user IDs sent through your events according to the [Segment Spec](https://segment.com/docs/connections/spec/).  In other words, the IDs under the userId fields specifically, not just any identifier."

I've had a few customers in the past complain that the documentation should be clearer on which userIDs should be submitted for deletion.  They've usually written in because they used some sort of internal identifier or an email as the ID for deletion, when it should be the user ID per the Segment Spec.  I wanted to add this warning in order to prevent this from happening in the future.  

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
