### PR TITLE
Add Info Alert about Identify Events to Unify Quickstart

### DIFF
--- a/src/unify/quickstart.md
+++ b/src/unify/quickstart.md
@@ -66,7 +66,7 @@ A good test is to look at _your own_ user profile, and maybe some colleagues' pr
 If your user profiles look wrong, or you aren't confident users are being accurately defined and merged, stop here and troubleshoot. It's important to have accurate identity resolution before you continue. See the [detailed Identity Resolution documentation](/docs/unify/identity-resolution/) to better understand how it works, and why you may be running into problems. (Still need help? [Contact Segment](https://segment.com/help/contact/){:target="_blank"} for assistance.)
 
 > info ""
-> Identify events triggered by a user don't appear in the Events tab of their profile. However, the traits from these events are still assigned to the profile and can be viewed under the Traits tab.
+> Identify events triggered by a user don't appear in the Events tab of their profile. However, the traits from these events are still assigned to the profile. You can view them under the Traits tab.
 
 
 

--- a/src/unify/quickstart.md
+++ b/src/unify/quickstart.md
@@ -65,8 +65,10 @@ A good test is to look at _your own_ user profile, and maybe some colleagues' pr
 
 If your user profiles look wrong, or you aren't confident users are being accurately defined and merged, stop here and troubleshoot. It's important to have accurate identity resolution before you continue. See the [detailed Identity Resolution documentation](/docs/unify/identity-resolution/) to better understand how it works, and why you may be running into problems. (Still need help? [Contact Segment](https://segment.com/help/contact/){:target="_blank"} for assistance.)
 
-> warning ""
-> **Note:**: The `identify` events triggered by a user will not appear in the **Events** tab of their profile, however, the traits from the `identify` event will still be assigned to the profile under the **Traits** tab.
+> info ""
+> Identify events triggered by a user don't appear in the Events tab of their profile. However, the traits from these events are still assigned to the profile and can be viewed under the Traits tab.
+
+
 
 ## Step 5: Create your production space
 

--- a/src/unify/quickstart.md
+++ b/src/unify/quickstart.md
@@ -65,6 +65,9 @@ A good test is to look at _your own_ user profile, and maybe some colleagues' pr
 
 If your user profiles look wrong, or you aren't confident users are being accurately defined and merged, stop here and troubleshoot. It's important to have accurate identity resolution before you continue. See the [detailed Identity Resolution documentation](/docs/unify/identity-resolution/) to better understand how it works, and why you may be running into problems. (Still need help? [Contact Segment](https://segment.com/help/contact/){:target="_blank"} for assistance.)
 
+> warning ""
+> **Note:**: The `identify` events triggered by a user will not appear in the **Events** tab of their profile, however, the traits from the `identify` event will still be assigned to the profile under the **Traits** tab.
+
 ## Step 5: Create your production space
 
 Once you validate that your data is flowing through Unify, you're ready to create a Production space. Segment recommends that you repeat the same steps outlined above, focusing on your production use cases and data sources.


### PR DESCRIPTION
Added info to Step 4 about identify events not appearing in the Events tab of a user's profile in Unify

### Proposed changes

> Warning
> **Note:**: The `identify` events triggered by a user will not appear in the **Events** tab of their profile, however, the traits from the `identify` event will still be assigned to the profile under the **Traits** tab.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
