### PR TITLE
Update index.md Salesforce Auth limitation

### DIFF
--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -36,6 +36,11 @@ Before you connect Segment to Salesforce, please ensure you have a Salesforce ac
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings). You must select which Event Types and/or Event Names will trigger each mapping.
 7. Enable the destination and configured mappings.
 
+> info "Authenticate with Salesforce"
+> Salesforce (Actions) requires OAuth based authentication. Salesforce limits the number of apps (destinations) a single user can grant (authorize). A single user can connect five Salesforce destinations, but upon connecting a sixth destination, the oldest destination's authorization is revoked. If the same user reauthorizes that same destination, this same behavior will occur on the next oldest destination that was authorized, and so on. To prevent this behavior, ensure that a different user with the same Salesforce permissions connects any new Salesforce destinations.
+> _For additional information on this Salesforce limitation, please see this documentation [Manage OAuth-Enabled Connected Apps Access to Your Data](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_request_manage.htm&type=5#:~:text=NOTE,impact%20your%20org.)._
+
+
 {% include components/actions-fields.html %}
 
 ## Configuration options

--- a/src/connections/destinations/catalog/actions-salesforce/index.md
+++ b/src/connections/destinations/catalog/actions-salesforce/index.md
@@ -36,9 +36,10 @@ Before you connect Segment to Salesforce, please ensure you have a Salesforce ac
 6. Follow the steps in the Destinations Actions documentation on [Customizing mappings](/docs/connections/destinations/actions/#customizing-mappings). You must select which Event Types and/or Event Names will trigger each mapping.
 7. Enable the destination and configured mappings.
 
-> info "Authenticate with Salesforce"
-> Salesforce (Actions) requires OAuth based authentication. Salesforce limits the number of apps (destinations) a single user can grant (authorize). A single user can connect five Salesforce destinations, but upon connecting a sixth destination, the oldest destination's authorization is revoked. If the same user reauthorizes that same destination, this same behavior will occur on the next oldest destination that was authorized, and so on. To prevent this behavior, ensure that a different user with the same Salesforce permissions connects any new Salesforce destinations.
-> _For additional information on this Salesforce limitation, please see this documentation [Manage OAuth-Enabled Connected Apps Access to Your Data](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_request_manage.htm&type=5#:~:text=NOTE,impact%20your%20org.)._
+> info "Salesforce (Actions) authentication limitations"
+> You must authenticate with the Salesforce (Actions) destination using OAuth. A single user can connect up to 5 Salesforce destinations, but upon connecting a 6th instance of the Salesforce (Actions) destination, Salesforce revokes the oldest destination's authorization. If the same user reauthorizes that same destination, this same behavior occurs on the next oldest destination that was authorized, and so on. To prevent this behavior, ensure that a different user with the same Salesforce permissions connects any additional Salesforce destinations.
+> 
+> _For additional information on these limitations, see the Salesforce [Manage OAuth-Enabled Connected Apps Access to Your Data](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_request_manage.htm&type=5#:~:text=Each%20connected%20app%20allows%20five%20unique%20approvals%20per%20user.){:target="_blank”}  documentation._
 
 
 {% include components/actions-fields.html %}


### PR DESCRIPTION
### Proposed changes

Currently, no limitation is listed in Segment’s public docs on the number of destinations that can be authorized by a single individual, but if more than 5 are done then Salesforce will begin revoking access the the oldest authorized destination until the limit of 5 is reached.

### Merge timing
- ASAP once approved?

### Related issues (optional)

[KCS JIRA](https://segment.atlassian.net/browse/KCS-1519)
[Zendesk Ticket](https://segment.zendesk.com/agent/tickets/546180)