### PR TITLE
Update Identity Resolution Onboarding

### DIFF
--- a/src/unify/identity-resolution/identity-resolution-onboarding.md
+++ b/src/unify/identity-resolution/identity-resolution-onboarding.md
@@ -5,9 +5,6 @@ redirect_from:
   - "/personas/identity-resolution/identity-resolution-onboarding"
 ---
 
-> info ""
-> The steps in this guide pertain to spaces created after **October 5th, 2020**. For spaces created before **October 5th, 2020**, please refer to [Identity Resolution Settings](/docs/unify/identity-resolution/identity-resolution-settings).
-
 > success ""
 > Workspace owners, administrators, and users with the Identity Admin role can edit Identity Resolution Settings.
 
@@ -135,26 +132,7 @@ If this event maps to this profile, the resulting profile would then contain two
 
 At this point, the event searches for any profiles that match just the identifier user_id `abc456`. Now there are no existing profiles with this identifier, so Segment creates a new profile with user_id `abc456`.
 
-By default, Segment explicitly orders user_id and email as rank `1` and `2`, respectively. All other identifiers are in alphabetical order beginning from rank `3`. This means that if the identifiers sent with events flowing into Segment are user_id, email, anonymous_id, and ga_client_id, the rank would be as follows:
-
-| Identifier   | Priority |
-| ------------ | -------- |
-| user_id      | 1        |
-| email        | 2        |
-| anonymous_id | 3        |
-| ga_client_id | 4        |
-
-If a new android.id identifier appeared without first giving it explicit order, the order would automatically reshuffle to:
-
-| Identifier   | Priority |
-| ------------ | -------- |
-| user_id      | 1        |
-| email        | 2        |
-| android.id   | 3        |
-| anonymous_id | 4        |
-| ga_client_id | 5        |
-
-If you require an explicit order for all identifiers, configure this in the Identity Resolution Settings page before sending in events.
+You can explicitly order for all identifiers through the Identity Resolution Settings page before sending in events.
 
 ![The Identity Resolution Configuration screen](images/edit-priority.png)
 


### PR DESCRIPTION
Two critical changes:

1. Removed the info section with link the old Identity Resolution Settings pages - https://segment.com/docs/unify/identity-resolution/identity-resolution-settings/ 

We are using the "Onboarding" page for ID Res v2 and "Setting" page for ID Res v1. Customers not knowing which version they are reading and getting confused. Data is duplicate and having this at the top makes it even harder for customer to know which version they are reading. they are being mislead. Also, we do not need to publish ID Res v1 documentation any more; the settings "Setting" page should be deleted. there is only 1 production grade customers using ID Rev v1 but in any case v1 is forward compatible with v2. We already have a ticket to decom ID Res v1 

the section around segment automatically ordering Id res rules is not correct behavior ID Res v2. therefore, removing from documentation

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
