### PR TITLE
Add EU endpoint callout to HTTP API doc

### DIFF
--- a/src/connections/sources/catalog/libraries/server/http-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/http-api/index.md
@@ -7,6 +7,9 @@ The Segment HTTP Tracking API lets you record analytics data from any website or
 
 Segment has native [sources](/docs/connections/sources/) for most use cases (like JavaScript and iOS) that are all built for high-performance and are open-source. But sometimes you may want to send to the HTTP API directly—that's what this reference is for.
 
+> info "HTTP API sources in EU workspaces should use the `events.eu1.segmentapis.com` endpoint"
+> If you are located in the EU and use the `https://api.segment.io/v1/` endpoint, you might not see any errors, but your events will not appear in the Segment app. For more information, see the [Source Regional support](/docs/guides/regional-segment/#source-regional-support) documentation. 
+
 ## Headers
 
 ### Authentication

--- a/src/connections/sources/catalog/libraries/server/http-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/http-api/index.md
@@ -8,7 +8,7 @@ The Segment HTTP Tracking API lets you record analytics data from any website or
 Segment has native [sources](/docs/connections/sources/) for most use cases (like JavaScript and iOS) that are all built for high-performance and are open-source. But sometimes you may want to send to the HTTP API directly—that's what this reference is for.
 
 > info "HTTP API sources in EU workspaces should use the `events.eu1.segmentapis.com` endpoint"
-> If you are located in the EU and use the `https://api.segment.io/v1/` endpoint, you might not see any errors, but your events will not appear in the Segment app. For more information, see the [Source Regional support](/docs/guides/regional-segment/#source-regional-support) documentation. 
+> If you are located in the EU and use the `https://api.segment.io/v1/` endpoint, you might not see any errors, but your events will not appear in the Segment app. For more information about regional support, see the [Source Regional support](/docs/guides/regional-segment/#source-regional-support) documentation. 
 
 ## Headers
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added a note about which endpoint customers with EU workspaces should use, as there was some confusion from a German customer about the link not working. ([Slack thread](https://twilio.slack.com/archives/CALA7QMJQ/p1720821343759909) with the libraries folks, for reference). 

### Merge timing
asap after approval!

### Related issues (optional)
Closes #5991 
