### PR TITLE
remove OpenAI mentions at request of Chris Lyon

### DIFF
--- a/src/connections/functions/copilot.md
+++ b/src/connections/functions/copilot.md
@@ -2,14 +2,14 @@
 title: Functions Copilot
 ---
 
-Functions Copilot helps you generate JavaScript code for functions using natural language prompts.
+Functions Copilot helps you generate JavaScript code for functions using natural language prompts. For more information about the language model used to generate JavaScript code, see the [Functions Copilot Nutrition Facts Label](/docs/connections/functions/functions-copilot-nutrition-facts/).
 
 > info "Functions Copilot Public Beta"
 > Functions Copilot is in public beta, and Segment is actively working on this feature. Some functionality may change before it becomes generally available.
 
 ## Functions Copilot benefits
 
-Powered by OpenAI, Functions Copilot improves efficiency and productivity by streamlining the process of creating and managing custom functions. 
+Functions Copilot improves efficiency and productivity by streamlining the process of creating and managing custom functions. 
 
 Functions Copilot can help you:
 
@@ -41,16 +41,5 @@ Follow this guidance when you use Functions Copilot:
 Keep the following limitations in mind as you work with Functions Copilot:
 
 - **Context limitations**: Functions Copilot generates code based on Segment-specific terminology and the prompts you write. As a result, the generated output may not always be accurate. If the function doesn't initially meet your needs, try to refine or rewrite your prompt.
-- **Language support**: Functions Copilot only supports English prompts. Using other languages may impact the accurancy of the generated output.
+- **Language support**: Functions Copilot only supports English prompts. Using other languages may impact the accuracy of the generated output.
 - **Regional support**: Functions Copilot is only available for US region Segment workspaces.
-
-## Segment's generative AI service
-
-<!-- PW/June 2024: Stealing this from Generative Audiences, but we should probably centralize this info at some point -->
-For Copilot to generate a function, Segment sends your query to OpenAI, Segment’s third-party AI service. All queries sent to OpenAI from Segment are anonymized, meaning that OpenAI won’t be able to identify from whom the query was sent unless you include uniquely identifiable information in the input.
-
-GPT is OpenAI’s state-of-the-art natural language generation tool powered by artificial intelligence. It can perform a variety of natural language tasks like text generation, completion, and classification. CustomerAI uses the service to inspire segmentation and build functions and audiences.
-
-According to OpenAI’s policy, OpenAI will not use data sent from Segment to train or improve their models, and they will delete the data after 30 days. Any content generated using GPT belongs to you. Segment will not claim copyright ownership of such content and makes no warranty regarding any AI generated content.
-
-For more information, see the [Functions Copilot Nutrition Facts Label](/docs/connections/functions/functions-copilot-nutrition-facts/).

--- a/src/engage/audiences/generative-audiences.md
+++ b/src/engage/audiences/generative-audiences.md
@@ -105,16 +105,3 @@ Segment solves this limitation by including only the most recently used properti
 ### Language support
 
 At this time, Segment only supports audience description prompts in the English language. Support in other languages is currently unavailable and might provide undesired results. 
-
-
-## More about Segment's generative AI service
-
-#### How is my data used?
-
-To generate the audience based on your description, Segment sends your query to OpenAI, Segment's 3rd party AI service. All queries sent to OpenAI from Segment are anonymized, meaning that OpenAI won't be able to identify from whom the query was sent unless you include uniquely identifiable information in the input.
-
-Behind the scenes, Segment instructs GPT to generate an audience based on the user inputted audience description and contextual information such as traits and events performed in your workspace.
-
-GPT is OpenAI's state-of-the-art natural language generation tool powered by artificial intelligence. It can perform a variety of natural language tasks like text generation, completion, and classification. CustomerAI uses the service to help generate audiences and inspire segmentation.
-
-According to OpenAI's policy, OpenAI will not use data sent from Segment to train or improve their models, and they will delete it after 30 days. Any content generated using GPT belongs to you. Segment will not claim copyright ownership of such content and makes no warranty regarding any AI generated content.  


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
PM for Customer AI + Profiles said Chris Lyon wanted all mentions of OpenAI to be removed from Gen Audiences docs ASAP 

### Merge timing
ASAP

### Related issues (optional)

