### PR TITLE
Update Mutiny Destination to Remove support for page events

### DIFF
--- a/src/connections/destinations/catalog/mutiny/index.md
+++ b/src/connections/destinations/catalog/mutiny/index.md
@@ -16,17 +16,6 @@ To set up Mutiny to receive Segment data:
 2. Search for "Mutiny" in the Catalog, select it, and choose which of your sources to connect the destination to.
 3. In the destination settings, enter your personal "API Key" into Segment's Mutiny integration settings panel UI, which you can find from your [Mutiny dashboard](https://app.mutinyhq.com/integrations/segment){:target="_blank"}.
 
-## Page
-
-If you're not familiar with the Segment Specs, take a look to understand what the [Page method](/docs/connections/spec/page/) does. An example call would look like:
-
-```
-analytics.page()
-```
-
-Page calls will be sent to Mutiny as an `impression`.
-
-
 ## Identify
 
 If you're not familiar with the Segment Specs, take a look to understand what the [Identify method](/docs/connections/spec/identify/) does. An example call would look like:


### PR DESCRIPTION


### Proposed changes

Remove documentation about tracking "page" events because the Mutiny destination does not support these events

I'm not sure how to remove "Page" from the destination info card at the top of the page. It doesn't seem to be part of the markdown
![CleanShot 2024-07-23 at 10 32 56@2x](https://github.com/user-attachments/assets/409e43e1-538c-489a-acfb-2f03dbae961b)


### Merge timing
- ASAP once approved

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
