### PR TITLE
Update allowed PrivateLink CIDR in inbound rules to 10.0.0.0/8

### DIFF
--- a/src/connections/aws-privatelink.md
+++ b/src/connections/aws-privatelink.md
@@ -36,7 +36,7 @@ The following Databricks integrations support PrivateLink:
 ### Prerequisites
 Before you can configure AWS PrivateLink for RDS Postgres, complete the following prerequisites in your Databricks workspace:
 - **Set up a Network Load Balancer (NLB) to route traffic to your Postgres database**: Segment recommends creating a NLB that has target group IP address synchronization, using a solution like AWS Lambda. 
-If any updates are made to the Availability Zones (AZs) enabled for your NLB, please let your CSM know so that we can update the AZs of your VPC Endpoint.
+If any updates are made to the Availability Zones (AZs) enabled for your NLB, please let your CSM know so that we can update the AZs of your VPC endpoint.
 - **Configure your NLB with one of the following settings**: 
   - Preferably, disable the **Enforce inbound rules on PrivateLink traffic** setting
   - Alternatively, add an inbound rule that allows traffic belonging to Segment's PrivateLink/Edge CIDR: `10.0.0.0/8`

--- a/src/connections/aws-privatelink.md
+++ b/src/connections/aws-privatelink.md
@@ -36,6 +36,7 @@ The following Databricks integrations support PrivateLink:
 ### Prerequisites
 Before you can configure AWS PrivateLink for RDS Postgres, complete the following prerequisites in your Databricks workspace:
 - **Set up a Network Load Balancer (NLB) to route traffic to your Postgres database**: Segment recommends creating a NLB that has target group IP address synchronization, using a solution like AWS Lambda. 
+If any updates are made to the AZs enabled for the NLB, please let the CSM know so that we can make corresponding updates to the VPC endpoint.
 - **Configure your NLB with one of the following settings**: 
   - Preferably, disable the **Enforce inbound rules on PrivateLink traffic** setting
   - Alternatively, add an inbound rule that allows traffic belonging to Segment's PrivateLink/Edge CIDR: `10.0.0.0/8`

--- a/src/connections/aws-privatelink.md
+++ b/src/connections/aws-privatelink.md
@@ -19,7 +19,7 @@ Before you can configure AWS PrivateLink for Databricks, complete the following 
 - Databricks account must be on the [Enterprise pricing tier](https://www.databricks.com/product/pricing/platform-addons){:target="_blank”} and use the [E2 version](https://docs.databricks.com/en/archive/aws/end-of-life-legacy-workspaces.html#e2-architecture){:target="_blank”} of the platform. 
 - Databricks workspace must use a [Customer-managed VPC](https://docs.databricks.com/en/security/network/classic/customer-managed-vpc.html){:target="_blank”} and [Secure cluster connectivity](https://docs.databricks.com/en/security/network/classic/secure-cluster-connectivity.html){:target="_blank”}.
   - Configure your [VPC](https://docs.databricks.com/en/security/network/classic/customer-managed-vpc.html){:target="_blank”} with DNS hostnames and DNS resolution
-  - Configure a [security group](https://docs.databricks.com/en/security/network/classic/customer-managed-vpc.html#security-groups){:target="_blank”} with bidirectional access to 0.0.0/0 and ports 443, 3306, 6666, 2443, and 8443-8451. 
+  - Configure a [security group](https://docs.databricks.com/en/security/network/classic/customer-managed-vpc.html#security-groups){:target="_blank”} with bidirectional access to 0.0.0.0/0 and ports 443, 3306, 6666, 2443, and 8443-8451. 
 
 ### Configure PrivateLink for Databricks
 To configure PrivateLink for Databricks:
@@ -37,8 +37,8 @@ The following Databricks integrations support PrivateLink:
 Before you can configure AWS PrivateLink for RDS Postgres, complete the following prerequisites in your Databricks workspace:
 - **Set up a Network Load Balancer (NLB) to route traffic to your Postgres database**: Segment recommends creating a NLB that has target group IP address synchronization, using a solution like AWS Lambda. 
 - **Configure your NLB with one of the following settings**: 
-  - Disable the **Enforce inbound rules on PrivateLink traffic** setting
-  - Add an inbound rule that allows traffic belonging from Segment's `us-east-1` PrivateLink/Edge CIDR: `10.248.64.0/18`
+  - Disable the **Enforce inbound rules on PrivateLink traffic** setting (Preferably)
+  - Alternatively, add an inbound rule that allows traffic belonging to Segment's PrivateLink/Edge CIDR: `10.0.0.0/8`
 
 ### Configure PrivateLink for RDS Postgres
 1. Create a Network Load Balancer VPC endpoint service using the instructions in the [Create a service powered by AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html){:target="_blank”} documentation. 

--- a/src/connections/aws-privatelink.md
+++ b/src/connections/aws-privatelink.md
@@ -37,7 +37,7 @@ The following Databricks integrations support PrivateLink:
 Before you can configure AWS PrivateLink for RDS Postgres, complete the following prerequisites in your Databricks workspace:
 - **Set up a Network Load Balancer (NLB) to route traffic to your Postgres database**: Segment recommends creating a NLB that has target group IP address synchronization, using a solution like AWS Lambda. 
 - **Configure your NLB with one of the following settings**: 
-  - Disable the **Enforce inbound rules on PrivateLink traffic** setting (Preferably)
+  - Preferably, disable the **Enforce inbound rules on PrivateLink traffic** setting
   - Alternatively, add an inbound rule that allows traffic belonging to Segment's PrivateLink/Edge CIDR: `10.0.0.0/8`
 
 ### Configure PrivateLink for RDS Postgres
@@ -45,7 +45,7 @@ Before you can configure AWS PrivateLink for RDS Postgres, complete the followin
 2. Reach out to your Customer Success Manager (CSM) for more details about Segment's AWS principal.
 3. Add the Segment AWS principal as an “Allowed Principal” to consume the Network Load Balancer VPC endpoint service you created in step 1.
 4. Reach out to your CSM and provide them with the Service name for the service that you created above. Segment's engineering team provisions a VPC endpoint for the service in the Segment Edge VPC. 
-5. After creating the VPC, Segment provides you with private DNS so you can update the **Host** in your Segment app settings or create a new Postgres integration. <br> The following RDS Postgres integrations support PrivateLink: 
+5. After creating the VPC endpoint, Segment provides you with private DNS so you can update the **Host** in your Segment app settings or create a new Postgres integration. <br> The following RDS Postgres integrations support PrivateLink: 
   - [RDS Postgres storage destination](/docs/connections/storage/catalog/postgres/)
   - [RDS Postgres Reverse ETL source](/docs/connections/reverse-etl/reverse-etl-source-setup-guides/postgres-setup/)
 
@@ -59,7 +59,7 @@ Before you can configure AWS PrivateLink for RDS Postgres, complete the followin
 ### Configure PrivateLink for Redshift
 Implement Segment's PrivateLink integration by taking the following steps:
 1. Let your Customer Success Manager (CSM) know that you're interested in PrivateLink. They will share information with you about Segment’s Edge account and VPC.
-2. After you receive the Edge account and VPC, [grant cluster access to Segment's Edge account and VPC](https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-connect-to-cluster.html){:target="_blank”}.
+2. After you receive the Edge account ID and VPC ID, [grant cluster access to Segment's Edge account and VPC](https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-connect-to-cluster.html){:target="_blank”}.
 3. Reach back out to your CSM and provide them with the Cluster identifier for your cluster and your AWS account ID. 
 4. Segment creates a Redshift managed VPC endpoint within the Segment Redshift subnet on your behalf, which creates a PrivateLink Endpoint URL. Segment then provides you with the internal PrivateLink Endpoint URL. 
 5. After Segment provides you with the URL, use it to update or create new Redshift integrations. The following integrations support PrivateLink: 

--- a/src/connections/aws-privatelink.md
+++ b/src/connections/aws-privatelink.md
@@ -36,7 +36,7 @@ The following Databricks integrations support PrivateLink:
 ### Prerequisites
 Before you can configure AWS PrivateLink for RDS Postgres, complete the following prerequisites in your Databricks workspace:
 - **Set up a Network Load Balancer (NLB) to route traffic to your Postgres database**: Segment recommends creating a NLB that has target group IP address synchronization, using a solution like AWS Lambda. 
-If any updates are made to the Availability Zones (AZs) enabled for your NLB, please let your CSM know so that we can update the AZs of your VPC endpoint.
+If any updates are made to the Availability Zones (AZs) enabled for your NLB, please let your CSM know so that Segment can update the AZs of your VPC endpoint.
 - **Configure your NLB with one of the following settings**: 
   - Preferably, disable the **Enforce inbound rules on PrivateLink traffic** setting
   - Alternatively, add an inbound rule that allows traffic belonging to Segment's PrivateLink/Edge CIDR: `10.0.0.0/8`

--- a/src/connections/aws-privatelink.md
+++ b/src/connections/aws-privatelink.md
@@ -38,8 +38,8 @@ Before you can configure AWS PrivateLink for RDS Postgres, complete the followin
 - **Set up a Network Load Balancer (NLB) to route traffic to your Postgres database**: Segment recommends creating a NLB that has target group IP address synchronization, using a solution like AWS Lambda. 
 If any updates are made to the Availability Zones (AZs) enabled for your NLB, please let your CSM know so that Segment can update the AZs of your VPC endpoint.
 - **Configure your NLB with one of the following settings**: 
-  - Preferably, disable the **Enforce inbound rules on PrivateLink traffic** setting
-  - Alternatively, add an inbound rule that allows traffic belonging to Segment's PrivateLink/Edge CIDR: `10.0.0.0/8`
+  - Disable the **Enforce inbound rules on PrivateLink traffic** setting
+  - If you must enforce inbound rules on PrivateLink traffic, add an inbound rule that allows traffic belonging to Segment's PrivateLink/Edge CIDR: `10.0.0.0/8`
 
 ### Configure PrivateLink for RDS Postgres
 1. Create a Network Load Balancer VPC endpoint service using the instructions in the [Create a service powered by AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html){:target="_blank”} documentation. 

--- a/src/connections/aws-privatelink.md
+++ b/src/connections/aws-privatelink.md
@@ -36,7 +36,7 @@ The following Databricks integrations support PrivateLink:
 ### Prerequisites
 Before you can configure AWS PrivateLink for RDS Postgres, complete the following prerequisites in your Databricks workspace:
 - **Set up a Network Load Balancer (NLB) to route traffic to your Postgres database**: Segment recommends creating a NLB that has target group IP address synchronization, using a solution like AWS Lambda. 
-If any updates are made to the AZs enabled for the NLB, please let the CSM know so that we can make corresponding updates to the VPC endpoint.
+If any updates are made to the Availability Zones (AZs) enabled for your NLB, please let your CSM know so that we can update the AZs of your VPC Endpoint.
 - **Configure your NLB with one of the following settings**: 
   - Preferably, disable the **Enforce inbound rules on PrivateLink traffic** setting
   - Alternatively, add an inbound rule that allows traffic belonging to Segment's PrivateLink/Edge CIDR: `10.0.0.0/8`


### PR DESCRIPTION
For context, please refer to the conversation in internal Slack - https://twilio.slack.com/archives/C06HE252MK2/p1721744192599429?thread_ts=1719934516.398509&cid=C06HE252MK2

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

According to the PrivateLink docs - 

> You can control whether PrivateLink traffic is subject to inbound rules. If you enable inbound rules on PrivateLink traffic, the source of the traffic is the private IP address of the client, not the endpoint interface.

The `10.248.64.0/18` CIDR belongs to the VPC in the PrivateLink/Edge account. The VPC endpoints use this CIDR. But the clients are not going to be in the edge account VPC. Instead they are going to be in the peered VPCs. So we are proposing allowing a wider CIDR range.

### Merge timing

- ASAP once approved


### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
