### PR TITLE
Add note that messageId is limited to 100 chars

### DIFF
--- a/src/_includes/content/spec-field-message-id.md
+++ b/src/_includes/content/spec-field-message-id.md
@@ -2,5 +2,5 @@
   <td markdown="span">`messageId`</td>
   <td markdown="span">*implicit*</td>
   <td markdown="span">String</td>
-  <td markdown="span">Automatically collected by Segment, a unique identifier for each message that lets you find an individual message across the API.</td>
+  <td markdown="span">Automatically collected by Segment, a unique identifier for each message that lets you find an individual message across the API. This field is limited to 100 characters.</td>
 </tr>

--- a/src/connections/sources/catalog/libraries/server/http-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/http-api/index.md
@@ -82,7 +82,7 @@ Common reasons events are not accepted by Segment include:
   - **Payload is too large:** The HTTP API can handle API requests that are 32KB or smaller. The batch API endpoint accepts a maximum of 500KB per request, with a limit of 32KB per event in the batch. If these limits are exceeded, Segment returns a 400 Bad Request error. 
   - **Identifier is not present**: The HTTP API requires that each payload has a userId and/or anonymousId.
   - **Track event is missing name**: All Track events sent to Segment must have an `event` field. 
-  - **Deduplication**: Segment deduplicates events using the `messageId` field, which is automatically added to all payloads coming into Segment. If you're setting up the HTTP API yourself, ensure all events have unique messageId values.
+  - **Deduplication**: Segment deduplicates events using the `messageId` field, which is automatically added to all payloads coming into Segment. If you're setting up the HTTP API yourself, ensure all events have unique messageId values with fewer than 100 characters. 
   - **Invalid JSON**: If you send an event with invalid JSON, Segment returns a 400 Bad Request error.
 
 Segment welcomes feedback on API responses and error messages. [Reach out to support](https://segment.com/help/contact/){:target="_blank"} with any requests or suggestions you may have.

--- a/src/guides/duplicate-data.md
+++ b/src/guides/duplicate-data.md
@@ -11,7 +11,7 @@ Segment has a special deduplication service that sits behind the `api.segment.co
 Segment deduplicates on the event's `messageId`, _not_ on the contents of the event payload. Segment doesn't have a built-in way to deduplicate data for events that don't generate `messageId`s. The message de-duplication is not scoped to a specific source or a workspace, and applies to all events being received by Segment.
 
 > info ""
-> Keep in mind that Segment's libraries all generate `messageId`s for each event payload, with the exception of the Segment HTTP API, which assigns each event a unique `messageId` when the message is ingested. You can override these default generated IDs and manually assign a `messageId` if necessary.
+> Keep in mind that Segment's libraries all generate `messageId`s for each event payload, with the exception of the Segment HTTP API, which assigns each event a unique `messageId` when the message is ingested. You can override these default generated IDs and manually assign a `messageId` if necessary. The `messageId` field is limited to 100 characters.
 
 ## Warehouse deduplication
 Duplicate events that are more than 24 hours apart from one another deduplicate in the Warehouse. Segment deduplicates messages going into a Warehouse ([including Profiles Sync data](/docs/unify/profiles-sync/)) based on the `messageId`, which is the `id` column in a Segment Warehouse.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added notes to the Common spec, HTTP API, and Duplicate Data guide pages that the messageId must be fewer than 100 chars

### Merge timing
ASAP

### Related issues (optional)
Closes #5924 
