### PR TITLE
Update user-deletion-and-suppression.md

### DIFF
--- a/src/privacy/user-deletion-and-suppression.md
+++ b/src/privacy/user-deletion-and-suppression.md
@@ -71,7 +71,7 @@ Note that list only includes `SUPPRESS_ONLY` regulations. If you created a User 
 
 To create a suppression regulation and add a `userId` to this list, click **Suppress New User**, and enter the `userId` in the field that appears. Then click **Request Suppression**.
 
-Segment creates a `SUPPRESS` regulation, and adds the `userId` to your suppression list, mostly processed within 24 hours. In some cases, the suppression request can take up to 30 days to process.
+Segment creates a `SUPPRESS` regulation, and adds the `userId` to your suppression list, mostly processed within 24 hours. In some cases, the suppression request can take up to 30 days to process. You can suppress up to 5000 userIds per call via Public API.
 
 ### Remove a user from the suppression list
 

--- a/src/privacy/user-deletion-and-suppression.md
+++ b/src/privacy/user-deletion-and-suppression.md
@@ -71,7 +71,7 @@ Note that list only includes `SUPPRESS_ONLY` regulations. If you created a User 
 
 To create a suppression regulation and add a `userId` to this list, click **Suppress New User**, and enter the `userId` in the field that appears. Then click **Request Suppression**.
 
-Segment creates a `SUPPRESS` regulation, and adds the `userId` to your suppression list, mostly processed within 24 hours. In some cases, the suppression request can take up to 30 days to process. You can suppress up to 5000 userIds per call via Public API.
+Segment creates a `SUPPRESS` regulation, and adds the `userId` to your suppression list, mostly processed within 24 hours. In some cases, the suppression request can take up to 30 days to process. You can suppress up to 5000 userIds per call through the Public API.
 
 ### Remove a user from the suppression list
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Customer was looking for a confirmation on how many userIds they could submit in a single PAPI call. Since our docs spoke of the limit for only deletion requests, here is a suggestion to include the same for suppression. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
