### PR TITLE
[Mixpane] Add info that events might failed due to message Id

### DIFF
--- a/src/connections/destinations/catalog/actions-mixpanel/index.md
+++ b/src/connections/destinations/catalog/actions-mixpanel/index.md
@@ -141,6 +141,10 @@ analytics.track('Example Event', { custom_group_key : 'group1' });
 
 If your integration is correct and you are still seeing failed events, review and verify that you are sending all date properties as UTC time format, due to Mixpanel timestamp format requirements. 
 
+### Failed events due to message Id
+
+By default, message Id of an event is map to insert ID in Mixpanel. If you are generating your own message ID, check that the message Id comply to the format of Insert ID as mentioned in the [document in Mixpanel](https://developer.mixpanel.com/reference/import-events#propertiesinsert_id). Otherwise, this will result in 400 Bad Request error from Mixpanel.
+
 ### Why is Boardman, Oregon appearing in my users' profile location field?
 
 If you are seeing traffic from Boardman or see Segment as the browser, you might be sending server side calls to your Mixpanel (Actions) destination. To correctly populate your users' profile location field, manually pass the IP information in the context object from the server.


### PR DESCRIPTION
### Proposed changes
Customer had encountered error sending events to Mixpanel when they generated their own message Id.

Add the following info
----------------------------------
"Failed events due to message Id

By default, message Id of an event is map to insert ID in Mixpanel. If you are generating your own message ID, check that the message Id comply to the format of Insert ID as mentioned in the [document in Mixpanel](https://developer.mixpanel.com/reference/import-events#propertiesinsert_id). Otherwise, this will result in 400 Bad Request error from Mixpanel."

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)
<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->

https://segment.zendesk.com/agent/tickets/549513
