### PR TITLE
Update roles.md

### DIFF
--- a/src/segment-app/iam/roles.md
+++ b/src/segment-app/iam/roles.md
@@ -81,9 +81,9 @@ The Segment App doesn't show detected Personally Identifiable Information (PII) 
 
 Workspace Owners can grant specific individuals or groups access to PII from their Access Management settings. PII Access only applies to the resources a user or user group has access to; it doesn't expand a user's access beyond the original scope. All Workspace Owners have PII access by default.
 
-For a user with PII Access and Source Admin/Read-Only permission, it means there are PII's in the Sources/Debugger and they would be able to view it. However, this doesn't translate to Privacy Portal access.
+For example, users with PII Access and Source Admin/Read-Only permissions can view any PII present in the Source Debugger. However, users with the PII Access role don't have Privacy Portal access.
 
-The Privacy Portal is only accessible by Workspace owners.
+Only users with the Workspace Owner role can access the Privacy Portal.
 
 
 ## Roles for managing Engage destinations

--- a/src/segment-app/iam/roles.md
+++ b/src/segment-app/iam/roles.md
@@ -81,6 +81,10 @@ The Segment App doesn't show detected Personally Identifiable Information (PII) 
 
 Workspace Owners can grant specific individuals or groups access to PII from their Access Management settings. PII Access only applies to the resources a user or user group has access to; it doesn't expand a user's access beyond the original scope. All Workspace Owners have PII access by default.
 
+For a user with PII Access and Source Admin/Read-Only permission, it means there are PII's in the Sources/Debugger and they would be able to view it. However, this doesn't translate to Privacy Portal access.
+
+The Privacy Portal is only accessible by Workspace owners.
+
 
 ## Roles for managing Engage destinations
 


### PR DESCRIPTION
New Information added to PII access:

For a user with PII Access and Source Admin/Read-Only permission, it means it there are PII's in the Sources/Debugger, they would be able to view it. However, this doesn't translate to Privacy Portal access.

The Privacy Portal is only accessible by Workspace owners.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

The [PII access](https://segment.com/docs/segment-app/iam/roles/#pii-access) is a part of Privacy portal, however PII permissions doesn't translate to Privacy Portal access, and it wasn't clearly mentioned earlier.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?


### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
