### PR TITLE
Update data-lakes-manual-setup.md

### DIFF
--- a/src/connections/storage/data-lakes/data-lakes-manual-setup.md
+++ b/src/connections/storage/data-lakes/data-lakes-manual-setup.md
@@ -138,6 +138,7 @@ Add a policy to the role created above to give Segment access to the relevant Gl
                 "elasticmapreduce:DescribeCluster",
                 "elasticmapreduce:CancelSteps",
                 "elasticmapreduce:AddJobFlowSteps"
+                "elasticmapredue:AddTags"
             ],
             "Effect": "Allow",
             "Resource": "*",


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

To create a cluster with a tag, you must also have permission for the elasticmapredue:AddTags action.” [AWS guide](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-fine-grained-cluster-access.html).

This error is happening when we create temporary cluster and cloning it for Datalake replay. We get the below error message:


2024/06/05 17:11:16 twirp error internal: AccessDeniedException: User: arn:aws:sts::182695231278:assumed-role/SegmentDataLakeRole-prod/1717571475792760882 is not authorized to perform: elasticmapreduce:AddTags on resource: arn:aws:elasticmapreduce:ap-southeast-1:182695231278:cluster/* because no identity-based policy allows the elasticmapreduce:AddTags action
status code: 400, request id: 58159b25-9382-4148-8284-3fb9a65172ec

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?


### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
