### PR TITLE
Update index.md - remove beta refs for trait enrichment in fb additio…

### DIFF
--- a/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
+++ b/src/connections/destinations/catalog/personas-facebook-custom-audiences/index.md
@@ -107,9 +107,6 @@ Once created, the audience should be available in Facebook in ten minutes unless
 
 ## Additional Traits Matching
 
-> info ""
-> This feature is in Public Preview and usage is subject to the terms contained in the [First Access and Beta Preview Terms](https://segment.com/legal/first-access-beta-preview/){:target="_blank"}{:target="_blank"}. For access, contact your CSM or email Segment at [friends@segment.com](mailto:friends@segment.com).
-
 Previously, Segment only sent email and mobile IDs to Facebook. A new beta feature can send an expanded list of identifiers or traits to Facebook, so that Facebook can try to use these additional data points to match to their user profiles. If you have this feature enabled and implemented any of these traits in your Segment tracking, Engage can send this data to Facebook. Segment can now also sync multiple emails if the profile contains more than one. Additionally as part of this feature, Segment hashes fields before sending them downstream to Facebook, if required. (See the table below for hashing requirements.) Note that the trait data implemented in your Segment tracking must match the naming convention and format specified in the table below, otherwise Segment can't send it to Facebook.
 
 > success ""


### PR DESCRIPTION
…nal trait matching


### Proposed changes

The Facebook Custom Audiences documentation references needing trait enrichment enabled for the additional trait matching functionality. Trait Activation (ID Sync & Trait Enrichment) are no longer in beta nor do they require enablement from Segment at this time.



### Merge timing
- ASAP once approved


### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
