### PR TITLE
update .flush info

### DIFF
--- a/src/connections/sources/catalog/libraries/server/python/index.md
+++ b/src/connections/sources/catalog/libraries/server/python/index.md
@@ -406,7 +406,7 @@ If the module detects that it can't flush faster than it's receiving messages, i
 
 ### Flush
 
-At the end of your program, you'll want to flush to make sure there's nothing left in the queue by calling the `flush` method:
+You can all the `flush` method at the end of your program to make sure there's nothing left in the queue:
 
 ```python
 analytics.flush()

--- a/src/connections/sources/catalog/libraries/server/python/index.md
+++ b/src/connections/sources/catalog/libraries/server/python/index.md
@@ -404,9 +404,9 @@ There is a maximum of `500KB` per batch request and `32KB` per call.
 
 If the module detects that it can't flush faster than it's receiving messages, it'll simply stop accepting messages. This means your program will never crash because of a backed up analytics queue. The default `max_queue_size` is `10000`.
 
-### How do I flush right now?!
+### Flush
 
-You can also flush on demand. For example, at the end of your program, you'll want to flush to make sure there's nothing left in the queue. Just call the `flush` method:
+At the end of your program, you'll want to flush to make sure there's nothing left in the queue by calling the `flush` method:
 
 ```python
 analytics.flush()

--- a/src/connections/sources/catalog/libraries/server/python/index.md
+++ b/src/connections/sources/catalog/libraries/server/python/index.md
@@ -406,7 +406,7 @@ If the module detects that it can't flush faster than it's receiving messages, i
 
 ### Flush
 
-You can all the `flush` method at the end of your program to make sure there's nothing left in the queue:
+You can call the `flush` method at the end of your program to make sure there's nothing left in the queue:
 
 ```python
 analytics.flush()


### PR DESCRIPTION
### Proposed changes

An engineer recently reviewed the analytics-python flush behavior ([Slack thread](https://twilio.slack.com/archives/CALA7QMJQ/p1725402103562029)) and confirmed that it isn't meant to send events immediately. It's meant to be called at the end of a program to ensure all events are sent to Segment before the program terminates. This update clarifies that.

### Merge timing
ASAP is fine