### PR TITLE
Add Web Setup Guide to Auto-Instrumentation Docs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     ffi (1.15.5)
     filesize (0.2.0)
     forwardable-extended (2.6.0)
+    google-protobuf (3.23.2-arm64-darwin)
     google-protobuf (3.23.2-x86_64-darwin)
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
@@ -87,7 +88,9 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.15.2-x86_64-darwin)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -101,10 +104,12 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (4.1.2)
+    rouge (3.30.0)
     ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.62.1-x86_64-darwin)
+    sass-embedded (1.58.3-arm64-darwin)
+      google-protobuf (~> 3.21)
+    sass-embedded (1.58.3-x86_64-darwin)
       google-protobuf (~> 3.21)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -119,7 +124,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  ruby
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
 
@@ -141,4 +146,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.2.18
+   2.4.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,6 @@ GEM
     ffi (1.15.5)
     filesize (0.2.0)
     forwardable-extended (2.6.0)
-    google-protobuf (3.23.2-arm64-darwin)
     google-protobuf (3.23.2-x86_64-darwin)
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
@@ -88,9 +87,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.13.10-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-darwin)
+    nokogiri (1.15.2-x86_64-darwin)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -104,12 +101,10 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
-    rouge (3.30.0)
+    rouge (4.1.2)
     ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
-    sass-embedded (1.58.3-arm64-darwin)
-      google-protobuf (~> 3.21)
-    sass-embedded (1.58.3-x86_64-darwin)
+    sass-embedded (1.62.1-x86_64-darwin)
       google-protobuf (~> 3.21)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -124,7 +119,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  arm64-darwin-23
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
 
@@ -146,4 +141,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.4.5
+   2.2.18

--- a/src/connections/auto-instrumentation/configuration.md
+++ b/src/connections/auto-instrumentation/configuration.md
@@ -3,48 +3,18 @@ title: Generate Events from Signals
 hidden: true
 ---
 
-This guide is a reference to configuring, generating, and using signals in the Signals SDK with Auto-Instrumentation. On this page, you'll find details on:
+This guide details how to use signals, and their associated data, generated in one of the Signals SDKs with the Auto-Instrumentation dashboard in your Segment workspace. On this page, you'll find details on:
 
-- Setting up and managing signal types in the Signals SDK
 - Creating custom rules to capture and translate signals into actionable analytics events
 - Example rules that you can use as a basis for further customization
 
-This guide assumes that you've already added the Signals SDK to your application. If you haven't yet, see the [Auto-Instrumentation Setup](/docs/connections/auto-instrumentation/setup/) guide for initial setup.
+This guide assumes that you've already added the Signals SDK to your application. If you haven't yet, see the [Auto-Instrumentation Setup](/docs/connections/auto-instrumentation/) guide for initial setup.
 
 > info "Auto-Instrumentation Pilot"
 > Auto-Instrumentation is currently in pilot and is governed by Segment's [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}. Segment doesn't recommend Auto-Instrumentation for use in a production environment, as Segment is actively iterating on and improving the user experience.
 
 > success "Enable Auto-Instrumentation"
-> To enable Auto-Instrumentation in your Segment workspace, reach out to your dedicated account manager.
-
-## Signals configuration
-
-Using the Signals Configuration object, you can control the destination, frequency, and types of signals that Segment automatically tracks within your application. The following tables detail the configuration options for both Signals-Swift and Signals-Kotlin.
-
-### Signals-Swift
-
-| `Option`               | Required | Value                      | Description                                                                                                                                                                                            |
-| ---------------------- | -------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `writeKey`             | Yes      | String                     | Source write key                                                                                                                                                                                       |
-| `maximumBufferSize`    | No       | Integer                    | The number of signals to be kept for JavaScript inspection. This buffer is first-in, first-out. Default is `1000`.                                                                                     |
-| `relayCount`           | No       | Integer                    | Relays signals to Segment every Xth event. Default is `20`.                                                                                                                                            |
-| `relayInterval`        | No       | TimeInterval  | Relays signals to segment every X seconds. Default is `60`.                                                                                                                                            |
-| `broadcasters`         | No       | `SignalBroadcaster`        | An array of broadcasters. These objects forward signal data to their destinations, like `WebhookBroadcaster` or  `DebugBroadcaster` writing to the developer console. Default is `SegmentBroadcaster`. |
-| `useUIKitAutoSignal`   | No       | Bool                       | Tracks UIKit component interactions automatically. Default is `false`.                                                                                                                                 |
-| `useSwiftUIAutoSignal` | No       | Bool                       | Tracks SwiftUI component interactions automatically. Default is `false`.                                                                                                                               |
-| `useNetworkAutoSignal` | No       | Bool                       | Tracks network events automatically. Default is `false`.                                                                                                                                               |
-| `allowedNetworkHosts`  | No       | Array                      | An array of allowed network hosts.                                                                                                                                                                     |
-| `blockedNetworkHosts`  | No       | Array                      | An array of blocked network hosts.                                                                                                                                                                     |
-
-
-### Signals-Kotlin
-
-| `Option`            | Required | Value                     | Description                                                                                                                                                                                           |
-| ------------------- | -------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `writeKey`          | Yes      | String                    | Source write key                                                                                                                                                                                      |
-| `maximumBufferSize` | No       | Integer                   | The number of signals to be kept for JavaScript inspection. This buffer is first-in, first-out. Default is `1000`.                                                                                    |
-| `broadcastInterval` | No       | Integer                   | Broadcasts signals to Segment every X event. Default is `60`.                                                                                                                                         |
-| `broadcasters`      | No       | `List<SignalBroadcaster>` | An array of broadcasters. These objects forward signal data to their destinations, like `WebhookBroadcaster` or `DebugBroadcaster` writing to the developer console. Default is `SegmentBroadcaster`. |
+> To enable Auto-Instrumentation in your Segment workspace, reach out to your dedicated account manager.                     
 
 
 ## Converting signals to events

--- a/src/connections/auto-instrumentation/index.md
+++ b/src/connections/auto-instrumentation/index.md
@@ -1,6 +1,25 @@
 ---
 title: Auto-Instrumentation
 hidden: true
+sources: 
+  - name: Android
+    url: /connections/auto-instrumentation/kotlin-setup/
+    logo:
+      url: https://cdn.filepicker.io/api/file/9BoiIqVRFmsAuBbMMy9D
+    mark:
+      url: https://cdn.filepicker.io/api/file/9BoiIqVRFmsAuBbMMy9D
+  - name: Apple 
+    url: /connections/auto-instrumentation/swift-setup/
+    logo:
+      url: https://cdn.filepicker.io/api/file/qWgSP5cpS7eeW2voq13u
+    mark:
+      url: https://cdn.filepicker.io/api/file/qWgSP5cpS7eeW2voq13u
+  - name: Web
+    url: /connections/auto-instrumentation/web-setup/
+    logo:
+      url: https://cdn.filepicker.io/api/file/aRgo4XJQZausZxD4gZQq
+    mark:
+      url: https://cdn.filepicker.io/api/file/aRgo4XJQZausZxD4gZQq
 ---
 
 Auto-Instrumentation simplifies tracking in your websites and apps by eliminating the need for a traditional Segment instrumentation.
@@ -29,9 +48,34 @@ Some Auto-Instrumentation advantages include:
 
 ## How it works
 
-After you [integrate the Analytics SDK and Signals SDK into your application](/docs/connections/auto-instrumentation/setup/), Segment begins to passively monitor user activity like button clicks, page navigation, and network data. Segment captures these events as "signals" and sends them to your Auto-Instrumentation source in real time.
+Once you integrate the Analytics SDK and Signals SDK into your  website or application, Segment begins to passively monitor user activity like button clicks, page navigation, and network data. Segment captures these events as "signals" and sends them to your Auto-Instrumentation source in real time.
 
 In Segment, the Auto-Instrumentation source lets you view raw signals. You can then [use this data to create detailed analytics events](/docs/connections/auto-instrumentation/configuration/) based on those signals, enriching your insights into user behavior and applicatino performance.
+
+## Setup Guides
+
+<div class="auto-instrumentation-catalog">
+<div class="auto-insturmentation__section markdown" id="{{ category | slugify }}">
+ <div class="flex flex--wrap waffle waffle--xlarge">
+        {% assign category = "source" %}
+        {% assign resources = page.sources %}
+        {% for resource in resources %}
+          <div class="flex__column flex__column--6">
+            <a class="thumbnail-integration flex flex--middle" href="{{ site.baseurl }}/{{ resource.url }}">
+              <div class="thumbnail-integration__content">
+                <div class="flex flex--wrap flex--middle waffle waffle--xlarge@medium">
+                  <div class="flex__column flex__column--12 flex__column--2@medium thumbnail-integration__logo-wrapper">
+                      <img class="thumbnail-integration__logo image" alt="{{resource.name}}" src="{{resource.mark.url}}" />
+                  </div>
+                  <h5 class="flex__column flex__column--12 flex__column--10@medium">{{ resource.name }}</h5>
+                </div>
+              </div>
+            </a>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
 
 ## Privacy
 

--- a/src/connections/auto-instrumentation/index.md
+++ b/src/connections/auto-instrumentation/index.md
@@ -20,6 +20,8 @@ sources:
       url: https://cdn.filepicker.io/api/file/aRgo4XJQZausZxD4gZQq
     mark:
       url: https://cdn.filepicker.io/api/file/aRgo4XJQZausZxD4gZQq
+redirect_from:
+  - '/docs/connections/auto-instrumentation/setup/'
 ---
 
 Auto-Instrumentation simplifies tracking in your websites and apps by eliminating the need for a traditional Segment instrumentation.
@@ -48,7 +50,7 @@ Some Auto-Instrumentation advantages include:
 
 ## How it works
 
-Once you integrate the Analytics SDK and Signals SDK into your  website or application, Segment begins to passively monitor user activity like button clicks, page navigation, and network data. Segment captures these events as "signals" and sends them to your Auto-Instrumentation source in real time.
+Once you integrate the Analytics SDK and Signals SDK into your website or application, Segment begins to passively monitor user activity like button clicks, page navigation, and network data. Segment captures these events as "signals" and sends them to your Auto-Instrumentation source in real time.
 
 In Segment, the Auto-Instrumentation source lets you view raw signals. You can then [use this data to create detailed analytics events](/docs/connections/auto-instrumentation/configuration/) based on those signals, enriching your insights into user behavior and applicatino performance.
 

--- a/src/connections/auto-instrumentation/kotlin-setup.md
+++ b/src/connections/auto-instrumentation/kotlin-setup.md
@@ -44,7 +44,10 @@ Next, you'll need to add the Signals SDKs to your Kotlin application.
     }
     ```
 
-2. Add the following code to your application to initialize the Signals SDK:
+2. Add the initialization code and configuration options:
+
+> success ""
+> see [configuration options](#configuration-options) for a complete list.
 
     ```kotlin
     // Configure Analytics with your settings
@@ -88,6 +91,18 @@ Next, you'll need to verify signal emission and [create rules](/docs/connections
 5. Click **Preview**, then click **Save & Deploy**.
 
 Segment displays `Rule updated successfully` to verify that it saved your rule.
+
+## Configuration Options
+
+Using the Signals Configuration object, you can control the destination, frequency, and types of signals that Segment automatically tracks within your application. The following table details the configuration options for Signals-Kotlin.
+
+| `Option`            | Required | Value                     | Description                                                                                                                                                                                           |
+| ------------------- | -------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `writeKey`          | Yes      | String                    | Source write key                                                                                                                                                                                      |
+| `maximumBufferSize` | No       | Integer                   | The number of signals to be kept for JavaScript inspection. This buffer is first-in, first-out. Default is `1000`.                                                                                    |
+| `broadcastInterval` | No       | Integer                   | Broadcasts signals to Segment every X event. Default is `60`.                                                                                                                                         |
+| `broadcasters`      | No       | `List<SignalBroadcaster>` | An array of broadcasters. These objects forward signal data to their destinations, like `WebhookBroadcaster` or `DebugBroadcaster` writing to the developer console. Default is `SegmentBroadcaster`. |
+
 
 ## Next steps
 

--- a/src/connections/auto-instrumentation/kotlin-setup.md
+++ b/src/connections/auto-instrumentation/kotlin-setup.md
@@ -106,4 +106,4 @@ Using the Signals Configuration object, you can control the destination, frequen
 
 ## Next steps
 
-This guide walked you through initial Signals SDK/Auto-Instrumentation setup. Next, read the [Auto-Instrumentation Signals Implementation Guide](/docs/connections/auto-instrumentation/configuration/), which dives deeper into Signals and offers examples rules. 
+This guide walked you through initial Signals SDK/Auto-Instrumentation setup. Next, read the [Auto-Instrumentation Signals Implementation Guide](/docs/connections/auto-instrumentation/configuration/), which dives deeper into Signals and offers example rules. 

--- a/src/connections/auto-instrumentation/kotlin-setup.md
+++ b/src/connections/auto-instrumentation/kotlin-setup.md
@@ -3,7 +3,7 @@ title: Auto-Instrumentation Setup
 hidden: true
 ---
 
-This guide outlines the steps required to set up the Signals SDK in your applications using Swift or Kotlin.
+This guide outlines the steps required to set up the Signals SDK in your Android OS applications using Kotlin.
 
 You'll learn how to add Auto-Instrumentation sources, integrate dependencies, and ensure that your setup captures and processes data as intended.  
 
@@ -25,61 +25,7 @@ You'll first need to add a source and copy its write key:
 
 ## Step 2: Add dependencies and initialization code
 
-Next, you'll need to add the Signals SDKs to your Swift and Kotlin development environments.
-
-### Swift
-
-Follow these steps to integrate the Signals SDK into your Swift application:
-
-1. Use Swift Package Manager to add the Signals SDK from the following repository:
-
-    ```zsh
-    https://github.com/segmentio/Signals-swift.git
-    ```
-
-2. Add the initialization code:
-
-    ```swift
-    // Configure Analytics with your settings
-    {... <analytics config>....} 
-
-    // Set up the Signals SDK configuration
-    let config = Signals.Configuration(
-        writeKey: "<WRITE_KEY>",          // Replace <WRITE_KEY> with the write key you previously copied
-        maximumBufferSize: 100,
-        useSwiftUIAutoSignal: true,
-        useNetworkAutoSignal: true
-    )
-
-    // Locate and set the fallback JavaScript file for edge functions
-    let fallbackURL = Bundle.main.url(forResource: "MyEdgeFunctions", withExtension: "js")
-
-    // Apply the configuration and add the Signals plugin
-    Signals.shared.useConfiguration(config)
-    Analytics.main.add(plugin: LivePlugins(fallbackFileURL: fallbackURL))
-    Analytics.main.add(plugin: Signals.shared)
-    ```
-
-Verify that you replaced `<WRITE_KEY>` with the actual write key you copied in Step 1.
-
-#### SwiftUI projects
-
-If your app is written in SwiftUI, you'll need to add a `TypeAlias.swift` file to your project that captures interaction and navigation Signals, like in this example:
-
-```swift
-import Foundation
-import Signals
-
-typealias Button = SignalButton
-typealias NavigationStack = SignalNavigationStack
-typealias NavigationLink = SignalNavigationLink
-typealias TextField = SignalTextField
-typealias SecureField = SignalSecureField
-```
-
-### Kotlin
-
-Follow these steps to integrate the Signals SDK into your Kotlin application: 
+Next, you'll need to add the Signals SDKs to your Kotlin application.
 
 1. Update your module’s Gradle build file to add the right dependencies:
 

--- a/src/connections/auto-instrumentation/swift-setup.md
+++ b/src/connections/auto-instrumentation/swift-setup.md
@@ -109,4 +109,4 @@ Using the Signals Configuration object, you can control the destination, frequen
 
 ## Next steps
 
-This guide walked you through initial Signals SDK/Auto-Instrumentation setup. Next, read the [Auto-Instrumentation Signals Implementation Guide](/docs/connections/auto-instrumentation/configuration/), which dives deeper into Signals and offers examples rules. 
+This guide walked you through initial Signals SDK/Auto-Instrumentation setup. Next, read the [Auto-Instrumentation Signals Implementation Guide](/docs/connections/auto-instrumentation/configuration/), which dives deeper into Signals and offers example rules. 

--- a/src/connections/auto-instrumentation/swift-setup.md
+++ b/src/connections/auto-instrumentation/swift-setup.md
@@ -1,0 +1,92 @@
+---
+title: Auto-Instrumentation Setup
+hidden: true
+---
+
+This guide outlines the steps required to set up the Signals SDK in your Apple OS applications using Swift. 
+
+You'll learn how to add Auto-Instrumentation sources, integrate dependencies, and ensure that your setup captures and processes data as intended.  
+
+> info "Auto-Instrumentation Pilot"
+> Auto-Instrumentation is currently in pilot and is governed by Segment's [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}. Segment doesn't recommend Auto-Instrumentation for use in a production environment, as Segment is actively iterating on and improving the user experience.
+
+> success "Enable Auto-Instrumentation"
+> To enable Auto-Instrumentation in your Segment workspace, reach out to your dedicated account manager.
+
+## Step 1: Add a source and get its write key
+
+You'll first need to add a source and copy its write key: 
+
+1. In your Segment workspace, navigate to **Connections > Auto-Instrumentation** and click **Add source**.
+2. Select a source, give the source a name, and click **Save**.
+3. Return to **Connections > Sources** to view your sources. 
+4. In the **My sources** table, find and click the new source you just set up.
+5. In the **Initialize the Client** section, look for and copy the `writeKey` displayed in the code block. 
+
+## Step 2: Add dependencies and initialization code
+
+Next, you'll need to add the Signals SDKs to your Swift applicatiion.
+
+1. Use Swift Package Manager to add the Signals SDK from the following repository:
+
+    ```zsh
+    https://github.com/segmentio/Signals-swift.git
+    ```
+
+2. Add the initialization code:
+
+    ```swift
+    // Configure Analytics with your settings
+    {... <analytics config>....} 
+
+    // Set up the Signals SDK configuration
+    let config = Signals.Configuration(
+        writeKey: "<WRITE_KEY>",          // Replace <WRITE_KEY> with the write key you previously copied
+        maximumBufferSize: 100,
+        useSwiftUIAutoSignal: true,
+        useNetworkAutoSignal: true
+    )
+
+    // Locate and set the fallback JavaScript file for edge functions
+    let fallbackURL = Bundle.main.url(forResource: "MyEdgeFunctions", withExtension: "js")
+
+    // Apply the configuration and add the Signals plugin
+    Signals.shared.useConfiguration(config)
+    Analytics.main.add(plugin: LivePlugins(fallbackFileURL: fallbackURL))
+    Analytics.main.add(plugin: Signals.shared)
+    ```
+
+Verify that you replaced `<WRITE_KEY>` with the actual write key you copied in Step 1.
+
+#### SwiftUI projects
+
+If your app is written in SwiftUI, you'll need to add a `TypeAlias.swift` file to your project that captures interaction and navigation Signals, like in this example:
+
+```swift
+import Foundation
+import Signals
+
+typealias Button = SignalButton
+typealias NavigationStack = SignalNavigationStack
+typealias NavigationLink = SignalNavigationLink
+typealias TextField = SignalTextField
+typealias SecureField = SignalSecureField
+```
+## Step 3: Verify and deploy events
+
+Next, you'll need to verify signal emission and [create rules](/docs/connections/auto-instrumentation/configuration/#example-rule-implementations) to convert those signals into events:
+
+1. In your Segment workspace, return to **Connections > Auto-Instrumentation** and click on the new source you created. 
+2. Verify that signals appear as expected on the dashboard.
+
+    ![Signals successfully appearing in the Segment UI](images/autoinstrumentation_signals.png "Signals successfully appearing in the Segment UI")
+
+3. Click **Create Rules**.
+4. In the Rules Editor, add a rule that converts signal data into an event.
+5. Click **Preview**, then click **Save & Deploy**.
+
+Segment displays `Rule updated successfully` to verify that it saved your rule.
+
+## Next steps
+
+This guide walked you through initial Signals SDK/Auto-Instrumentation setup. Next, read the [Auto-Instrumentation Signals Implementation Guide](/docs/connections/auto-instrumentation/configuration/), which dives deeper into Signals and offers examples rules. 

--- a/src/connections/auto-instrumentation/swift-setup.md
+++ b/src/connections/auto-instrumentation/swift-setup.md
@@ -33,7 +33,10 @@ Next, you'll need to add the Signals SDKs to your Swift applicatiion.
     https://github.com/segmentio/Signals-swift.git
     ```
 
-2. Add the initialization code:
+2. Add the initialization code and configuration options:
+
+> success ""
+> see [configuration options](#configuration-options) for a complete list.
 
     ```swift
     // Configure Analytics with your settings
@@ -86,6 +89,23 @@ Next, you'll need to verify signal emission and [create rules](/docs/connections
 5. Click **Preview**, then click **Save & Deploy**.
 
 Segment displays `Rule updated successfully` to verify that it saved your rule.
+
+## Configuration Options
+
+Using the Signals Configuration object, you can control the destination, frequency, and types of signals that Segment automatically tracks within your application. The following table details the configuration options for Signals-Swift.
+
+| `Option`               | Required | Value                      | Description                                                                                                                                                                                            |
+| ---------------------- | -------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `writeKey`             | Yes      | String                     | Source write key                                                                                                                                                                                       |
+| `maximumBufferSize`    | No       | Integer                    | The number of signals to be kept for JavaScript inspection. This buffer is first-in, first-out. Default is `1000`.                                                                                     |
+| `relayCount`           | No       | Integer                    | Relays signals to Segment every Xth event. Default is `20`.                                                                                                                                            |
+| `relayInterval`        | No       | TimeInterval  | Relays signals to segment every X seconds. Default is `60`.                                                                                                                                            |
+| `broadcasters`         | No       | `SignalBroadcaster`        | An array of broadcasters. These objects forward signal data to their destinations, like `WebhookBroadcaster` or  `DebugBroadcaster` writing to the developer console. Default is `SegmentBroadcaster`. |
+| `useUIKitAutoSignal`   | No       | Bool                       | Tracks UIKit component interactions automatically. Default is `false`.                                                                                                                                 |
+| `useSwiftUIAutoSignal` | No       | Bool                       | Tracks SwiftUI component interactions automatically. Default is `false`.                                                                                                                               |
+| `useNetworkAutoSignal` | No       | Bool                       | Tracks network events automatically. Default is `false`.                                                                                                                                               |
+| `allowedNetworkHosts`  | No       | Array                      | An array of allowed network hosts.                                                                                                                                                                     |
+| `blockedNetworkHosts`  | No       | Array                      | An array of blocked network hosts.                                                                                                                                                
 
 ## Next steps
 

--- a/src/connections/auto-instrumentation/web-setup.md
+++ b/src/connections/auto-instrumentation/web-setup.md
@@ -40,7 +40,10 @@ Follow these steps to integrate the Signals SDK into your website:
     pnpm install @segment/analytics-signals 
 ```
 
-2. Add the initialization code:
+2. Add the initialization code and configuration options:
+
+> success ""
+> see [configuration options](#configuration-options) for a complete list.
 
 ```ts
 // analytics.js/ts
@@ -103,6 +106,22 @@ signalsPlugin.addSignal({
   data: { foo: 'bar' }
 })
 ```
+
+## Configuration Options
+
+Using the Signals Configuration object, you can control the destination, frequency, and types of signals that Segment automatically tracks within your application. The following table details the configuration options for Signals-Kotlin.
+
+| `Option`            | Required | Value                     | Description                                                                                                                                                                                           |
+| ------------------- | -------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `writeKey`          | Yes      | string                    | Source write key                                                                                                                                                                                      |
+| `maxBufferSize` | No       | number                  | The number of signals to be kept for JavaScript inspection. This buffer is first-in, first-out. Default is `1000`.                                                                                    |
+| `processSignal` | No       | string                  | Override the default signal processing function from the edge function. If this is set, the edge function will not be used.
+| `enableDebugLogging` | No       | boolean                  | Enable debug logs.
+| `disableSignalRedaction` | No       | boolean                  | Disable default Signal data redaction.
+| `apiHost` | No       | string                 | Override the default signals API host. Default is `signals.segment.io/v1`.
+| `functionHost` | No       | string                 | Override the default edge host. Default is `cdn.edgefn.segment.com`
+| `flushAt` | No       | number                   | How many signals to flush at once when sending to the signals API. Default is `5` .                                                                                                                                         |
+| `flushInterval`      | No       | number | How many ms to wait before flushing signals to the API. The default is `2000`. |
 
 ## Next steps
 

--- a/src/connections/auto-instrumentation/web-setup.md
+++ b/src/connections/auto-instrumentation/web-setup.md
@@ -1,0 +1,109 @@
+---
+title: Auto-Instrumentation Setup
+hidden: true
+---
+
+This guide outlines the steps required to set up the Signals SDK in your JavaScript website.
+
+You'll learn how to add Auto-Instrumentation sources, integrate dependencies, and ensure that your setup captures and processes data as intended.  
+
+> info "Auto-Instrumentation Pilot"
+> Auto-Instrumentation is currently in pilot and is governed by Segment's [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}. Segment doesn't recommend Auto-Instrumentation for use in a production environment, as Segment is actively iterating on and improving the user experience.
+
+> success "Enable Auto-Instrumentation"
+> To enable Auto-Instrumentation in your Segment workspace, reach out to your dedicated account manager.
+
+## Step 1: Add a source and get its write key
+
+You'll first need to add a source and copy its write key: 
+
+1. In your Segment workspace, navigate to **Connections > Auto-Instrumentation** and click **Add source**.
+2. Select a source, give the source a name, and click **Save**.
+3. Return to **Connections > Sources** to view your sources. 
+4. In the **My sources** table, find and click the new source you just set up.
+5. In the **Initialize the Client** section, look for and copy the `writeKey` displayed in the code block. 
+
+## Step 2: Add dependencies and initialization code
+
+Next, you'll need to add the Signals SDKs to your web environment. 
+
+Follow these steps to integrate the Signals SDK into your website:
+
+1. Add the Signals SDK to your project: 
+
+```bash
+    # npm
+    npm install @segment/analytics-signals
+    # yarn
+    yarn add @segment/analytics-signals
+    # pnpm
+    pnpm install @segment/analytics-signals 
+```
+
+2. Add the initialization code:
+
+```ts
+// analytics.js/ts
+import { AnalyticsBrowser } from '@segment/analytics-next'
+import { SignalsPlugin } from '@segment/analytics-signals'
+
+const analytics = new AnalyticsBrowser()
+const signalsPlugin = new SignalsPlugin()
+analytics.register(signalsPlugin)
+
+analytics.load({
+  writeKey: '<YOUR_WRITE_KEY>'
+})
+```
+
+Verify that you replaced `<WRITE_KEY>` with the actual write key you copied in Step 1.
+
+4. Build and run your app.
+
+## Step 3: Verify and deploy events
+
+Next, you'll need to verify signal emission and [create rules](/docs/connections/auto-instrumentation/configuration/#example-rule-implementations) to convert those signals into events:
+
+1. In your Segment workspace, return to **Connections > Auto-Instrumentation** and click on the new source you created. 
+2. Verify that signals appear as expected on the dashboard.
+
+    ![Signals successfully appearing in the Segment UI](images/autoinstrumentation_signals.png "Signals successfully appearing in the Segment UI")
+
+3. Click **Create Rules**.
+4. In the Rules Editor, add a rule that converts signal data into an event.
+5. Click **Preview**, then click **Save & Deploy**.
+
+Segment displays `Rule updated successfully` to verify that it saved your rule.
+
+### Debugging
+#### Enable debug mode
+Values sent to the signals API are redacted by default.
+This adds a local storage key.  To disable redaction, add a magic query string:
+```
+https://my-website.com?segment_signals_debug=true
+```
+You can *turn off debugging* by doing:
+```
+https://my-website.com?segment_signals_debug=false
+```
+
+### Advanced
+
+#### Listening to signals
+```ts
+const signalsPlugin = new SignalsPlugin()
+signalsPlugin.onSignal((signal) => console.log(signal))
+```
+
+### Emitting Signals
+```ts
+const signalsPlugin = new SignalsPlugin()
+signalsPlugin.addSignal({
+  type: 'userDefined',
+  data: { foo: 'bar' }
+})
+```
+
+## Next steps
+
+This guide walked you through initial Signals SDK/Auto-Instrumentation setup. Next, read the [Auto-Instrumentation Signals Implementation Guide](/docs/connections/auto-instrumentation/configuration/), which dives deeper into Signals and offers examples rules. 

--- a/src/connections/auto-instrumentation/web-setup.md
+++ b/src/connections/auto-instrumentation/web-setup.md
@@ -125,4 +125,4 @@ Using the Signals Configuration object, you can control the destination, frequen
 
 ## Next steps
 
-This guide walked you through initial Signals SDK/Auto-Instrumentation setup. Next, read the [Auto-Instrumentation Signals Implementation Guide](/docs/connections/auto-instrumentation/configuration/), which dives deeper into Signals and offers examples rules. 
+This guide walked you through initial Signals SDK/Auto-Instrumentation setup. Next, read the [Auto-Instrumentation Signals Implementation Guide](/docs/connections/auto-instrumentation/configuration/), which dives deeper into Signals and offers example rules. 


### PR DESCRIPTION
### Proposed changes

- Refactored index.md of Auto-instrumentation to break out kotlin and swift guides as well as add web guide 
- added auto-instrumentation web  setup-guide

### Merge timing
- ASAP once approved
