### PR TITLE
Add documentation for Recombee destination

### DIFF
--- a/src/connections/destinations/catalog/actions-recombee/index.md
+++ b/src/connections/destinations/catalog/actions-recombee/index.md
@@ -19,8 +19,8 @@ This destination is maintained by Recombee. For any issues with the destination,
 
 The new Recombee destination built on the Segment Actions framework provides the following benefits over the classic Recombee AI destination:
 
-- **Streamlined Configuration**: You can now create mappings in a dedicated tab in the Segment web app, as opposed to needing to edit this in the settings. This allows you to configure the mappings on a per-event basis and makes it easier to verify that your mappings work as intended.
-- **Removable Bookmarks**: You can now configure a mapping to send a *Delete Bookmark* Action, which removes the bookmark interaction from the Recombee database.
+- **Streamlined Configuration**: You can now create mappings in a dedicated tab in the Segment web app, as opposed to needing to edit this in the destination's settings. This allows you to configure the mappings on a per-event basis and makes it easier to verify that your mappings work as intended.
+- **Removable Bookmarks**: You can now use the [Delete Bookmark Action](#delete-bookmark) to remove the bookmark interaction from the Recombee database.
 
 ## Migration from the classic Recombee AI destination
 
@@ -28,12 +28,12 @@ Recombee recommends ensuring that a Recombee (Actions) destination and a classic
 
 ### Configuration changes
 
-Compared to the classic Recombee AI destination, the following configuration changes were made:
+Recombee made the following configuration changes when setting up the new destination:
 
-- In the destination settings, the **API Key** setting was renamed **Private Token** to better reflect the type of token used.
-- The **Track Events Mapping** setting has been removed. If you want to map custom events to Recombee interactions, create your own mappings in the Mappings tab in the Segment app.
-- The **Item ID Property Name** setting is now no longer available, as this functionality is now available in Segment's native Mappings tab. Ensure that your mappings use the desired property for the **Item ID** action field.
-- *The following change only affects users that were relying on the `name` property to set their **Item ID**:* In presets, the **Item ID** property is now determined differently - in the default settings, the `asset_id` property (or `sku` for Ecommerce events) is now used as the fallback instead of `name`. The `name` property is never used by default, as it may not conform to the required **Item ID** format. Additionally, the property `content_asset_id` (or the first ID in `content_asset_ids`) is now the default **Item ID** only in Video events, where they are always present. 
+- Renamed the API Key setting to Private Token: This better reflects the type of token required.
+- **Removed the Track Events Mapping setting**: If you want to map custom events to Recombee interactions, create your own mappings on the Mappings tab in the Segment app.
+- **Removed the Item ID Property Name setting**: This functionality is now available in Segment's native Mappings tab. Ensure that your mappings use the desired property for the **Item ID** action field.
+- **In presets, the **Item ID** property is determined differently**: In the default settings, the `asset_id` property (or `sku` for Ecommerce events) is now the fallback property, instead of `name`. The `name` property is never used by default, as it may not conform to the required **Item ID** format. The property `content_asset_id` (or the first ID in `content_asset_ids`,) is now the default **Item ID** only in Video events, where they are always present. 
 
 ## Getting started
 
@@ -57,6 +57,6 @@ Once you send the data from Segment to the Recombee destination, you can:
 
 ## Reporting successful recommendations
 
-You can inform Recombee that a specific interaction resulted from a successful recommendation (meaning the recommendations were presented to a user, and the user clicked on one of the items) by setting the ID of the successful recommendation request in the `Recommendation ID` field of the action (this is the `recomm_id` property by default). You can read more about this setting in Recombee's [Reported Metrics documentations](https://docs.recombee.com/admin_ui.html#reported-metrics){:target="_blank"}
+You can inform Recombee that a specific interaction resulted from a successful recommendation (meaning the recommendations were presented to a user and the user clicked on one of the items) by setting the ID of the successful recommendation request in the `Recommendation ID` field of the action (this is the `recomm_id` property by default). You can read more about this setting in Recombee's [Reported Metrics documentation](https://docs.recombee.com/admin_ui.html#reported-metrics){:target="_blank"}
 
 Sending the `Recommendation ID` gives you precise numbers about successful recommendations in the KPI section of the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"}. This explicit feedback also helps improve the output of the recommendation models.

--- a/src/connections/destinations/catalog/actions-recombee/index.md
+++ b/src/connections/destinations/catalog/actions-recombee/index.md
@@ -39,8 +39,8 @@ Compared to the classic Recombee AI destination, the following configuration cha
 
 1. If you don't already have one, set up a [Recombee account](https://recombee.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank"}.
 2. From the Segment web app, navigate to **Connections > Destinations** and click **Add Destination**.
-3. Select **Recombee (Actions)** and click **Add Destination**.
-4. Select an existing Source to connect to Recombee (Actions).
+3. Select **Recombee** and click **Add Destination**.
+4. Select an existing Source to connect to Recombee.
 5. Navigate to the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"} and complete the following actions:
   - Choose the Recombee Database where you want to send the interactions.
   - Click **Settings** in the menu on the left.

--- a/src/connections/destinations/catalog/actions-recombee/index.md
+++ b/src/connections/destinations/catalog/actions-recombee/index.md
@@ -1,8 +1,9 @@
 ---
 title: Recombee (Actions) Destination
+hidden: true
 versions:
   - name: Recombee AI
-    link: /docs/connections/destinations/catalog/recombee-ai
+    link: /docs/connections/destinations/catalog/recombee-ai     
 ---
 
 {% include content/plan-grid.md name="actions" %}
@@ -19,23 +20,23 @@ This destination is maintained by Recombee. For any issues with the destination,
 2. From the Segment web app, navigate to **Connections > Destinations** and click **Add Destination**.
 3. Select **Recombee (Actions)** and click **Add Destination**.
 4. Select an existing Source to connect to Recombee (Actions).
-5. Go to the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"}:
+5. Navigate to the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"} and complete the following actions:
   - Choose the Recombee Database where you want to send the interactions.
   - Click **Settings** in the menu on the left.
   - In the **API ID & Tokens** settings section, find the **Database ID** and the **Private Token** of the Database.
-6. Back in the Segment web app, go to the Recombee destination settings.
+6. Back in the Segment app, navigate to the settings page of the Recombee destination you created.
   - Copy the **Database ID** from the Recombee Admin UI and paste it into the **Database ID** field in the destination settings.
   - Copy the **Private Token** from the Recombee Admin UI and paste it into the **Private Token** field in the destination settings.
 
 Once you send the data from Segment to the Recombee destination you can:
-  - Go to the KPI console of the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"} to see the numbers of the ingested interactions (updated in Real-time)
-  - Click the ID of an Item (or User) in the Items (or Users) catalog section in the Admin UI to view a specific ingested interaction.
+  - Open the KPI console of the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"} to see the numbers of the ingested interactions (updated in realtime).
+  - Select the ID of an Item (or User) in the Items (or Users) catalog section in the Admin UI to view a specific ingested interaction.
 
 {% include components/actions-fields.html %}
 
 ## Reporting successful recommendations
 
-You can inform Recombee that a specific interaction resulted from a successful recommendation (meaning the recommendations were presented to a user, and the user clicked on one of the items) by setting the ID of the successful recommendation request in the `Recommendation ID` field of the action (this is the `recomm_id` property by default). You can read more about this setting in [Recombee's Reported Metrics documentations](https://docs.recombee.com/admin_ui.html#reported-metrics){:target="_blank"}
+You can inform Recombee that a specific interaction resulted from a successful recommendation (meaning the recommendations were presented to a user, and the user clicked on one of the items) by setting the ID of the successful recommendation request in the `Recommendation ID` field of the action (this is the `recomm_id` property by default). You can read more about this setting in Recombee's [Reported Metrics documentations](https://docs.recombee.com/admin_ui.html#reported-metrics){:target="_blank"}
 
 Sending the `Recommendation ID` gives you precise numbers about successful recommendations in the KPI section of the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"}. This explicit feedback also helps improve the output of the recommendation models.
 

--- a/src/connections/destinations/catalog/actions-recombee/index.md
+++ b/src/connections/destinations/catalog/actions-recombee/index.md
@@ -10,9 +10,29 @@ versions:
 
 [Recombee](https://recombee.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank”} is a Recommender as a Service, offering precise content or product recommendations and personalized search based on user behavior.
 
-Use this Segment destination to send your interaction data (views, purchases, plays, etc.) to Recombee.
+Use this Segment destination to send your interaction data (for example, views, purchases, or plays) to Recombee.
 
 This destination is maintained by Recombee. For any issues with the destination, [contact the Recombee Support team](mailto:support@recombee.com).
+
+## Benefits of Recombee (Actions) vs Recombee AI Classic
+
+Recombee (Actions) provides the following benefits over the classic Recombee destination:
+
+- **Streamlined Configuration**. You can now create mappings in a dedicated tab in the Segment web app, as opposed to needing to edit this in the settings. This allows you to configure the mappings on a per-event basis and makes it easier to verify that they work as intended.
+- **Removing Bookmarks is now possible**. You can now configure a mapping to send a *Delete Bookmark* Action, which will remove the bookmark interaction from the Recombee database.
+
+## Migration from the classic Recombee AI destination
+
+It is recommended that for each source, the Recombee (Actions) destination and the classic Recombee AI destination are not enabled at the same time in order to prevent errors.
+
+### Configuration changes
+
+Compared to the classic Recombee AI destination, the following changes were made with regards to the configuration:
+
+- In the destination settings, the **API Key** setting has been renamed to **Private Token** to better reflect the type of token used.
+- The **Track Events Mapping** setting has been removed. If you want to map custom events to Recombee interactions, make sure to create your own mappings in the Mappings tab in the Segment web app.
+- The **Item ID Property Name** setting is now no longer available, as this functionality is now available in Segment's native Mappings tab. Ensure that your mappings use the desired property for the **Item ID** action field.
+- *The following change only affects users that were relying on the `name` property to set their **Item ID**:* In presets, the **Item ID** property is now determined differently - in the default settings, the `asset_id` property (or `sku` for Ecommerce events) is now used as the fallback instead of `name`. The `name` property is never used by default, as it may not conform to the required **Item ID** format. Additionally, the property `content_asset_id` (or the first ID in `content_asset_ids`) is now the default **Item ID** only in Video events, where they are always present. 
 
 ## Getting started
 
@@ -39,23 +59,3 @@ Once you send the data from Segment to the Recombee destination you can:
 You can inform Recombee that a specific interaction resulted from a successful recommendation (meaning the recommendations were presented to a user, and the user clicked on one of the items) by setting the ID of the successful recommendation request in the `Recommendation ID` field of the action (this is the `recomm_id` property by default). You can read more about this setting in Recombee's [Reported Metrics documentations](https://docs.recombee.com/admin_ui.html#reported-metrics){:target="_blank"}
 
 Sending the `Recommendation ID` gives you precise numbers about successful recommendations in the KPI section of the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"}. This explicit feedback also helps improve the output of the recommendation models.
-
-## Benefits of Recombee (Actions) vs Recombee AI Classic
-
-Recombee (Actions) provides the following benefits over the classic Recombee destination:
-
-- **Streamlined Configuration**. You can now create mappings in a dedicated tab in the Segment web app, as opposed to needing to edit this in the settings. This allows you to configure the mappings on a per-event basis and makes it easier to verify that they work as intended.
-- **Removing Bookmarks is now possible**. You can now configure a mapping to send a *Delete Bookmark* Action, which will remove the bookmark interaction from the Recombee database.
-
-## Migration from the classic Recombee AI destination
-
-It is recommended that for each source, the Recombee (Actions) destination and the classic Recombee AI destination are not enabled at the same time in order to prevent errors.
-
-### Configuration changes
-
-Compared to the classic Recombee AI destination, the following changes were made with regards to the configuration:
-
-- In the destination settings, the **API Key** setting has been renamed to **Private Token** to better reflect the type of token used.
-- The **Track Events Mapping** setting has been removed. If you want to map custom events to Recombee interactions, make sure to create your own mappings in the Mappings tab in the Segment web app.
-- The **Item ID Property Name** setting is now no longer available, as this functionality is now available in Segment's native Mappings tab. Ensure that your mappings use the desired property for the **Item ID** action field.
-- *The following change only affects users that were relying on the `name` property to set their **Item ID**:* In presets, the **Item ID** property is now determined differently - in the default settings, the `asset_id` property (or `sku` for Ecommerce events) is now used as the fallback instead of `name`. The `name` property is never used by default, as it may not conform to the required **Item ID** format. Additionally, the property `content_asset_id` (or the first ID in `content_asset_ids`) is now the default **Item ID** only in Video events, where they are always present. 

--- a/src/connections/destinations/catalog/actions-recombee/index.md
+++ b/src/connections/destinations/catalog/actions-recombee/index.md
@@ -1,6 +1,7 @@
 ---
 title: Recombee (Actions) Destination
 hidden: true
+id: 66f2aea175bae98028d5185a
 versions:
   - name: Recombee AI
     link: /docs/connections/destinations/catalog/recombee-ai     

--- a/src/connections/destinations/catalog/actions-recombee/index.md
+++ b/src/connections/destinations/catalog/actions-recombee/index.md
@@ -19,19 +19,19 @@ This destination is maintained by Recombee. For any issues with the destination,
 
 Recombee (Actions) provides the following benefits over the classic Recombee destination:
 
-- **Streamlined Configuration**. You can now create mappings in a dedicated tab in the Segment web app, as opposed to needing to edit this in the settings. This allows you to configure the mappings on a per-event basis and makes it easier to verify that they work as intended.
-- **Removing Bookmarks is now possible**. You can now configure a mapping to send a *Delete Bookmark* Action, which will remove the bookmark interaction from the Recombee database.
+- **Streamlined Configuration**: You can now create mappings in a dedicated tab in the Segment web app, as opposed to needing to edit this in the settings. This allows you to configure the mappings on a per-event basis and makes it easier to verify that your mappings work as intended.
+- **Removable Bookmarks**: You can now configure a mapping to send a *Delete Bookmark* Action, which removes the bookmark interaction from the Recombee database.
 
 ## Migration from the classic Recombee AI destination
 
-It is recommended that for each source, the Recombee (Actions) destination and the classic Recombee AI destination are not enabled at the same time in order to prevent errors.
+Recombee recommends ensuring that a Recombee (Actions) destination and a classic Recombee AI destination connected to the same source are not enabled at the same time in order to prevent errors.
 
 ### Configuration changes
 
-Compared to the classic Recombee AI destination, the following changes were made with regards to the configuration:
+Compared to the classic Recombee AI destination, the following configuration changes were made:
 
-- In the destination settings, the **API Key** setting has been renamed to **Private Token** to better reflect the type of token used.
-- The **Track Events Mapping** setting has been removed. If you want to map custom events to Recombee interactions, make sure to create your own mappings in the Mappings tab in the Segment web app.
+- In the destination settings, the **API Key** setting was renamed **Private Token** to better reflect the type of token used.
+- The **Track Events Mapping** setting has been removed. If you want to map custom events to Recombee interactions, create your own mappings in the Mappings tab in the Segment app.
 - The **Item ID Property Name** setting is now no longer available, as this functionality is now available in Segment's native Mappings tab. Ensure that your mappings use the desired property for the **Item ID** action field.
 - *The following change only affects users that were relying on the `name` property to set their **Item ID**:* In presets, the **Item ID** property is now determined differently - in the default settings, the `asset_id` property (or `sku` for Ecommerce events) is now used as the fallback instead of `name`. The `name` property is never used by default, as it may not conform to the required **Item ID** format. Additionally, the property `content_asset_id` (or the first ID in `content_asset_ids`) is now the default **Item ID** only in Video events, where they are always present. 
 
@@ -49,7 +49,7 @@ Compared to the classic Recombee AI destination, the following changes were made
   - Copy the **Database ID** from the Recombee Admin UI and paste it into the **Database ID** field in the destination settings.
   - Copy the **Private Token** from the Recombee Admin UI and paste it into the **Private Token** field in the destination settings.
 
-Once you send the data from Segment to the Recombee destination you can:
+Once you send the data from Segment to the Recombee destination, you can:
   - Open the KPI console of the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"} to see the numbers of the ingested interactions (updated in realtime).
   - Select the ID of an Item (or User) in the Items (or Users) catalog section in the Admin UI to view a specific ingested interaction.
 

--- a/src/connections/destinations/catalog/actions-recombee/index.md
+++ b/src/connections/destinations/catalog/actions-recombee/index.md
@@ -1,0 +1,60 @@
+---
+title: Recombee (Actions) Destination
+versions:
+  - name: Recombee AI
+    link: /docs/connections/destinations/catalog/recombee-ai
+---
+
+{% include content/plan-grid.md name="actions" %}
+
+[Recombee](https://recombee.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank”} is a Recommender as a Service, offering precise content or product recommendations and personalized search based on user behavior.
+
+Use this Segment destination to send your interaction data (views, purchases, plays, etc.) to Recombee.
+
+This destination is maintained by Recombee. For any issues with the destination, [contact the Recombee Support team](mailto:support@recombee.com).
+
+## Getting started
+
+1. If you don't already have one, set up a [Recombee account](https://recombee.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank"}.
+2. From the Segment web app, navigate to **Connections > Destinations** and click **Add Destination**.
+3. Select **Recombee (Actions)** and click **Add Destination**.
+4. Select an existing Source to connect to Recombee (Actions).
+5. Go to the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"}:
+  - Choose the Recombee Database where you want to send the interactions.
+  - Click **Settings** in the menu on the left.
+  - In the **API ID & Tokens** settings section, find the **Database ID** and the **Private Token** of the Database.
+6. Back in the Segment web app, go to the Recombee destination settings.
+  - Copy the **Database ID** from the Recombee Admin UI and paste it into the **Database ID** field in the destination settings.
+  - Copy the **Private Token** from the Recombee Admin UI and paste it into the **Private Token** field in the destination settings.
+
+Once you send the data from Segment to the Recombee destination you can:
+  - Go to the KPI console of the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"} to see the numbers of the ingested interactions (updated in Real-time)
+  - Click the ID of an Item (or User) in the Items (or Users) catalog section in the Admin UI to view a specific ingested interaction.
+
+{% include components/actions-fields.html %}
+
+## Reporting successful recommendations
+
+You can inform Recombee that a specific interaction resulted from a successful recommendation (meaning the recommendations were presented to a user, and the user clicked on one of the items) by setting the ID of the successful recommendation request in the `Recommendation ID` field of the action (this is the `recomm_id` property by default). You can read more about this setting in [Recombee's Reported Metrics documentations](https://docs.recombee.com/admin_ui.html#reported-metrics){:target="_blank"}
+
+Sending the `Recommendation ID` gives you precise numbers about successful recommendations in the KPI section of the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"}. This explicit feedback also helps improve the output of the recommendation models.
+
+## Benefits of Recombee (Actions) vs Recombee AI Classic
+
+Recombee (Actions) provides the following benefits over the classic Recombee destination:
+
+- **Streamlined Configuration**. You can now create mappings in a dedicated tab in the Segment web app, as opposed to needing to edit this in the settings. This allows you to configure the mappings on a per-event basis and makes it easier to verify that they work as intended.
+- **Removing Bookmarks is now possible**. You can now configure a mapping to send a *Delete Bookmark* Action, which will remove the bookmark interaction from the Recombee database.
+
+## Migration from the classic Recombee AI destination
+
+It is recommended that for each source, the Recombee (Actions) destination and the classic Recombee AI destination are not enabled at the same time in order to prevent errors.
+
+### Configuration changes
+
+Compared to the classic Recombee AI destination, the following changes were made with regards to the configuration:
+
+- In the destination settings, the **API Key** setting has been renamed to **Private Token** to better reflect the type of token used.
+- The **Track Events Mapping** setting has been removed. If you want to map custom events to Recombee interactions, make sure to create your own mappings in the Mappings tab in the Segment web app.
+- The **Item ID Property Name** setting is now no longer available, as this functionality is now available in Segment's native Mappings tab. Ensure that your mappings use the desired property for the **Item ID** action field.
+- *The following change only affects users that were relying on the `name` property to set their **Item ID**:* In presets, the **Item ID** property is now determined differently - in the default settings, the `asset_id` property (or `sku` for Ecommerce events) is now used as the fallback instead of `name`. The `name` property is never used by default, as it may not conform to the required **Item ID** format. Additionally, the property `content_asset_id` (or the first ID in `content_asset_ids`) is now the default **Item ID** only in Video events, where they are always present. 

--- a/src/connections/destinations/catalog/actions-recombee/index.md
+++ b/src/connections/destinations/catalog/actions-recombee/index.md
@@ -1,5 +1,5 @@
 ---
-title: Recombee (Actions) Destination
+title: Recombee Destination
 hidden: true
 id: 66f2aea175bae98028d5185a
 versions:
@@ -17,7 +17,7 @@ This destination is maintained by Recombee. For any issues with the destination,
 
 ## Benefits of Recombee (Actions) vs Recombee AI Classic
 
-Recombee (Actions) provides the following benefits over the classic Recombee destination:
+The new Recombee destination built on the Segment Actions framework provides the following benefits over the classic Recombee AI destination:
 
 - **Streamlined Configuration**: You can now create mappings in a dedicated tab in the Segment web app, as opposed to needing to edit this in the settings. This allows you to configure the mappings on a per-event basis and makes it easier to verify that your mappings work as intended.
 - **Removable Bookmarks**: You can now configure a mapping to send a *Delete Bookmark* Action, which removes the bookmark interaction from the Recombee database.

--- a/src/connections/destinations/catalog/recombee-ai/index.md
+++ b/src/connections/destinations/catalog/recombee-ai/index.md
@@ -2,7 +2,7 @@
 title: Recombee AI Destination
 rewrite: true
 maintenance: true
-maintenance-content: This destination is no longer available in the Segment catalog but will remain active in workspaces where it has already been installed. Recombee has developed an updated destination built on the Actions framework. See [Recombee Destination](/docs/connections/destinations/catalog/actions-recombee/) for more information.
+maintenance-content: This destination is no longer available in the Segment catalog, but will remain active in workspaces where it has already been configured. Recombee has developed an updated destination built on the Actions framework. See [Recombee Destination](/docs/connections/destinations/catalog/actions-recombee/) for more information.
 hide-settings: true
 hide-personas-partial: true
 id: 6095391bd839b62fca8a8606
@@ -13,7 +13,7 @@ versions:
 
 [Recombee](https://recombee.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank”} is a Recommender as a Service that can use your data to provide the most accurate recommendations of content or products for your users.
 
-Use this Segment destination to send your interaction data (views, purchases, plays, etc.) to Recombee.
+Use this Segment destination to send your interaction data, like views, purchases, or plays, to Recombee.
 
 ## Getting Started
 

--- a/src/connections/destinations/catalog/recombee-ai/index.md
+++ b/src/connections/destinations/catalog/recombee-ai/index.md
@@ -2,6 +2,7 @@
 title: Recombee AI Destination
 rewrite: true
 maintenance: true
+maintenance-content: This destination is no longer available in the Segment catalog but will remain active in workspaces where it has already been installed. Recombee has developed an updated destination built on the Actions framework. See [Recombee Destination](/docs/connections/destinations/catalog/actions-recombee/) for more information.
 hide-settings: true
 hide-personas-partial: true
 id: 6095391bd839b62fca8a8606

--- a/src/connections/destinations/catalog/recombee-ai/index.md
+++ b/src/connections/destinations/catalog/recombee-ai/index.md
@@ -1,23 +1,20 @@
 ---
 title: Recombee AI Destination
 rewrite: true
+maintenance: true
 hide-settings: true
 hide-personas-partial: true
 id: 6095391bd839b62fca8a8606
+versions:
+  - name: Recombee (Actions)
+    link: /docs/connections/destinations/catalog/actions-recombee
 ---
-[Recombee](https://recombee.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank”} is a Recommender as a Service, that can use your data to provide the most accurate recommendations of content or products for your users.
 
-Use this Segment destination to send your interaction data views, purchases, plays, etc.) to Recombee.
+[Recombee](https://recombee.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank”} is a Recommender as a Service that can use your data to provide the most accurate recommendations of content or products for your users.
 
-This destination is maintained by Recombee. For any issues with the destination, [contact the Recombee Support team](mailto:support@recombee.com).
-
-> note "Note:"
-> The Recombee Destination is currently in beta, which means that they are still actively developing the destination. If you have any feedback to help improve the Recombee Destination and its documentation, [contact the Recombee support team](mailto:support@recombee.com)!
-
+Use this Segment destination to send your interaction data (views, purchases, plays, etc.) to Recombee.
 
 ## Getting Started
-
-
 
 1. If you don't already have one, set up a [Recombee account](https://recombee.com/?utm_source=segmentio&utm_medium=docs&utm_campaign=partners){:target="_blank"}.
 1. From the Destinations catalog page in the Segment App, click **Add Destination**.
@@ -26,15 +23,14 @@ This destination is maintained by Recombee. For any issues with the destination,
 4. Go to the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"}:
    - Choose the Recombee Database where you want to send the interactions.
    - Click **Settings** in the menu on the left.
-   - In the **Settings** section find the **API Identifier** of the Database and its corresponding **Private Token**
+   - In the **Settings** section find the **Database ID** and the **Private Token** of the Database.
 5. Back in the Segment web app, go to the Recombee destination settings.
-    - Paste the **API Identifier** you just copied in the **Database ID** field.
+    - Paste the **Database ID** you just copied in the **Database ID** field.
     - Paste the **Private Token** you just copied in the **API Key** field.
 
 Once you send the data from Segment to the Recombee destination you can:
    - Go to the KPI console of the [Recombee Admin UI](https://admin.recombee.com){:target="_blank"} to see the numbers of the ingested interactions (updated in Real-time)
    - Click the ID of an Item, User in Items, or section in the Users catalog to see a specific ingested interaction.
-
 
 ## Page
 
@@ -45,7 +41,6 @@ analytics.page()
 ```
 
 Segment sends Page calls to Recombee as a [Detail View](https://docs.recombee.com/api.html#add-detail-view){:target="_blank"}.
-
 
 ## Track
 
@@ -62,6 +57,7 @@ analytics.track('Video Content Playing', {
 ```
 
 #### Sending semantic spec events to Recombee
+
 Recombee Destination can process several [Semantic Events](/docs/connections/spec/semantic/):
 
 [Ecommerce](/docs/connections/spec/ecommerce/v2/):
@@ -91,7 +87,6 @@ If you aren't familiar with the Segment Spec, take a look at the [Screen method 
 
 Segment sends Screen calls to Recombee as a [Detail View](https://docs.recombee.com/api.html#add-detail-view){:target="_blank"}.
 
-
 ## Alias
 
 If you aren't familiar with the Segment Spec, take a look at the [Alias method documentation](/docs/connections/spec/alias/) to learn about what it does. An example call would look like:
@@ -108,8 +103,8 @@ Segment sends a [Delete User](https://docs.recombee.com/api.html#delete-user){:t
 All the data associated with the user (including interactions) are removed from Recombee.
 
 ## Reporting successful recommendations
-You can tell Recombee that a specific interaction is based on a successful recommendation (meaning that the recommendations were presented to a user, and the user clicked one of the items), by setting the ID of the successful recommendation request on the `recomm_id` property of a Segment event. You can read more about this setting in [Recombee's Reported Metrics documentations](https://docs.recombee.com/admin_ui.html#reported-metrics){:target="_blank"}
 
+You can tell Recombee that a specific interaction is based on a successful recommendation (meaning that the recommendations were presented to a user, and the user clicked one of the items), by setting the ID of the successful recommendation request on the `recomm_id` property of a Segment event. You can read more about this setting in [Recombee's Reported Metrics documentations](https://docs.recombee.com/admin_ui.html#reported-metrics){:target="_blank"}
 
 Recombee recognizes the `recomm_id` property in all the events that send interactions.
 
@@ -140,7 +135,6 @@ If you don't provide an **Item ID Property Name**:
 - `content_asset_id` or `asset_id` is used for [Video Events](/docs/connections/spec/video/).
 - `name` property is used if it exists.
 
-
 ### Track Events Mapping (Optional)
 
 Recombee can automatically handle different [Ecommerce Events](/docs/connections/spec/ecommerce/v2/) and [Video Events](/docs/connections/spec/video/) in the *Track* call type (see the [Track section](#track)).
@@ -157,7 +151,6 @@ The value of the mapping is the name of your event, and the key can be one of:
   - a property `rating` must exist and contain a number from interval [-1.0,1.0], where -1.0 means the worst rating possible, 0.0 means neutral, and 1.0 means absolutely positive rating.
 - [View Portion](https://docs.recombee.com/api.html#set-view-portion){:target="_blank"}
   - the portion (how much of the content was consumed by the user) is computed from the `position` and `total_length` properties (see [Content Event Object](/docs/connections/spec/video/#content-event-object)), or can be given as the `portion` property (a number between 0 and 1).
-
 
 ### API URI (Optional)
 


### PR DESCRIPTION
### Proposed changes

Hello,

Here at Recombee, we were asked to develop a new version of our existing [Recombee AI](https://segment.com/docs/connections/destinations/catalog/recombee-ai/) destination that would use the new Action Destinations framework.

This pull request contains the documentation to this new destination, called _Recombee_, as well as changes to the old destination (such as deprecating it and changing the wording in some places).

### Merge timing

Probably should be merged after the implementation pull request in the **action-destinations** repository is merged:

https://github.com/segmentio/action-destinations/pull/2429
