### PR TITLE
Update Product Based Audiences AI Label

### DIFF
--- a/src/_data/sidenav/main.yml
+++ b/src/_data/sidenav/main.yml
@@ -431,8 +431,8 @@ sections:
       title: Generative Audiences Nutrition Facts Label
     - path: '/engage/audiences/product-based-audiences'
       title: Product Based Audiences
-    - path: '/engage/audiences/recommendation-audiences-nutrition-label'
-      title: Recommendation Audiences Nutrition Facts Label
+    - path: '/engage/audiences/product-based-audiences-nutrition-label'
+      title: Product Based Audiences Nutrition Facts Label
     - path: '/engage/audiences/organization'
       title: Organize Audiences
     - path: '/engage/audiences/send-audience-data'

--- a/src/_includes/content/product-based-audiences-nutrition-facts.html
+++ b/src/_includes/content/product-based-audiences-nutrition-facts.html
@@ -57,14 +57,14 @@
           <p class="c14"><span class="c25">AI Nutrition Facts</span>
               <br />
               <br />
-          <span class="c0">Customer AI Recommendations</span></p>
+          <span class="c0">Customer AI Product Based Audiences</span></p>
           </td>
       </tr><tr class="c4">
               <td class="c26" colspan="1" rowspan="1">
                   <p class="c10"><span class="c8">Description</span>
                   <br />
                   <br />
-                  <span class="c1">CustomerAI Recommendations lets customers improve marketing campaigns by segmenting users based on preferences like product, category, or brand to automate the creation and maintenance of personalized recommendations for businesses in the retail, media, and entertainment industries. </span></p>
+                  <span class="c1">CustomerAI Product Based Audiences lets customers improve marketing campaigns by segmenting users based on preferences like product, category, or brand to automate the creation and maintenance of personalized recommendations for businesses in the retail, media, and entertainment industries. </span></p>
               </td>
               </tr>
                   <tr class="c4">

--- a/src/engage/audiences/product-based-audiences-nutrition-label.md
+++ b/src/engage/audiences/product-based-audiences-nutrition-label.md
@@ -1,0 +1,9 @@
+---
+title: Product Based Audiences Nutrition Facts Label
+plan: engage-foundations
+redirect_from:
+  - '/engage/audiences/recommendation-audiences-nutrition-label'
+---
+
+Twilio’s [AI Nutrition Facts](https://nutrition-facts.ai/){:target="_blank"} provide an overview of the AI feature you’re using, so you can better understand how the AI is working with your data. Twilio outlines AI qualities in Product Based Audiences in the Nutrition Facts label below. For more information, including the AI Nutrition Facts label glossary, refer to the [AI Nutrition Facts](https://nutrition-facts.ai/){:target="_blank"} page. 
+{% include content/product-based-audiences-nutrition-facts.html %}

--- a/src/engage/audiences/recommendation-audiences-nutrition-label.md
+++ b/src/engage/audiences/recommendation-audiences-nutrition-label.md
@@ -1,7 +1,0 @@
----
-title: Recommendation Audiences Nutrition Facts Label
-plan: engage-foundations
----
-
-Twilio’s [AI Nutrition Facts](https://nutrition-facts.ai/){:target="_blank"} provide an overview of the AI feature you’re using, so you can better understand how the AI is working with your data. Twilio outlines AI qualities in Recommendation Audiences in the Nutrition Facts label below. For more information, including the AI Nutrition Facts label glossary, refer to the [AI Nutrition Facts](https://nutrition-facts.ai/){:target="_blank"} page. 
-{% include content/recommendation-audiences-nutrition-facts.html %}


### PR DESCRIPTION
### Proposed changes

- Recommendation Audiences is now called Product Based Audiences.
- Updated the name in the AI nutrition facts label.
- Added a redirect from the old page.
- Updated the links in the side navigation.

### Merge timing

- ASAP once approved.

### Related issues (optional)

#7039
