### PR TITLE
Move Salesforce Unify Integration Guide

### DIFF
--- a/src/_data/sidenav/strat.yml
+++ b/src/_data/sidenav/strat.yml
@@ -83,21 +83,24 @@ sections:
   section_title: Salesforce Integrations
   section:
   - path: /connections/destinations/catalog/actions-salesforce
-    title: Salesforce (Actions) destination
+    title: Salesforce (Actions) Destination
   - path: /connections/destinations/catalog/salesforce
-    title: Salesforce destination
+    title: Salesforce Destination
   - path: /connections/destinations/catalog/actions-salesforce-marketing-cloud
-    title: Salesforce Marketing Cloud (Actions) destination
+    title: Salesforce Marketing Cloud (Actions) Destination
   - path: /connections/destinations/catalog/salesforce-marketing-cloud
-    title: Salesforce Marketing Cloud destination
+    title: Salesforce Marketing Cloud Destination
   - path: /connections/destinations/catalog/actions-pardot
-    title: Salesforce Pardot (Actions) destination
+    title: Salesforce Pardot (Actions) Destination
   - path: /connections/destinations/catalog/pardot
-    title: Salesforce Pardot destination
+    title: Salesforce Pardot Destination
   - path: /connections/sources/catalog/cloud-apps/salesforce
-    title: Salesforce cloud source
+    title: Salesforce Cloud Source
   - path: /connections/sources/catalog/cloud-apps/salesforce-marketing-cloud
-    title: Salesforce Marketing Cloud cloud source
+    title: Salesforce Marketing Cloud Source
+  - path: /connections/sources/catalog/cloud-apps/salesforce-unify
+    title: Salesforce Unify Direct Integration 
+
 
 
 

--- a/src/connections/sources/catalog/cloud-apps/salesforce-unify/index.md
+++ b/src/connections/sources/catalog/cloud-apps/salesforce-unify/index.md
@@ -1,6 +1,8 @@
 ---
 title: Salesforce Unify Direct Integration Guide
 plan: unify
+redirect_from:
+  - '/unify/salesforce-unify'
 ---
 
 This guide outlines the process for setting up Salesforce as a data source with Segment Profiles. 


### PR DESCRIPTION
### Proposed changes

- Moved the Salesforce Unify Direct Integration Guide from Unify to Salesforce Integrations.
- Updated the side navigation.

### Merge timing

- ASAP once approved.
