### PR TITLE
Add note about Identify events generated by the CSV uploader

### DIFF
--- a/src/engage/profiles/csv-upload.md
+++ b/src/engage/profiles/csv-upload.md
@@ -5,7 +5,7 @@ plan: engage-foundations
 You can use the Profiles CSV Uploader to add or update user profiles and traits. This page contains guidelines for your CSV upload and explains how to upload a CSV file to Engage.
 
 > info ""
-> When you use the CSV upload feature, Engage generates internal Identify calls via Segment's Tracking API and sends them into the [Engage output source](/docs/unify/debugger/). 
+> When you upload a CSV file, Engage generates internal Identify calls using Segment's Tracking API and sends them into the [Engage output source](/docs/unify/debugger/). 
 
 ## CSV file upload guidelines
 

--- a/src/engage/profiles/csv-upload.md
+++ b/src/engage/profiles/csv-upload.md
@@ -4,6 +4,9 @@ plan: engage-foundations
 ---
 You can use the Profiles CSV Uploader to add or update user profiles and traits. This page contains guidelines for your CSV upload and explains how to upload a CSV file to Engage.
 
+> info ""
+> When you use the CSV upload feature, Engage generates internal Identify calls via Segment's Tracking API and sends them into the [Engage output source](/docs/unify/debugger/). 
+
 ## CSV file upload guidelines
 
 Keep the following guidelines in mind as you upload CSV files to Twilio Engage:


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Adding a note to our public docs to indicate that using CSV uploader will  generate Identify events via the Engage event source. 


### Merge timing
ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/KCS-1664