### PR TITLE
Add some clarifications to the Clear Schema History setting

### DIFF
--- a/src/connections/sources/schema/schema-unique-limits.md
+++ b/src/connections/sources/schema/schema-unique-limits.md
@@ -24,7 +24,7 @@ These limits can also affect the traits and properties that you can see in the C
 If you hit any of the limits or would like to clear out old events or properties, you can clear the Schema data from your Source Settings. In your Source, navigate to Settings, then Schema Configuration. Scroll down to the **Clear Schema History** setting.
 
 > warning ""
-> The settings to clear Identify/Groups traits will **not** be available if a Tracking plan is connected to the Source.
+> You can't clear Identify/Group traits if your Source is connected to a Tracking Plan. 
 
 ![Clear your Schema data with Clear Schema History](images/schema_config_clear_schema.png)
 

--- a/src/connections/sources/schema/schema-unique-limits.md
+++ b/src/connections/sources/schema/schema-unique-limits.md
@@ -23,6 +23,9 @@ These limits can also affect the traits and properties that you can see in the C
 
 If you hit any of the limits or would like to clear out old events or properties, you can clear the Schema data from your Source Settings. In your Source, navigate to Settings, then Schema Configuration. Scroll down to the **Clear Schema History** setting.
 
+> warning ""
+> The settings to clear Identify/Groups traits will **not** be available if a Tracking plan is connected to the Source.
+
 ![Clear your Schema data with Clear Schema History](images/schema_config_clear_schema.png)
 
 Clearing events from the Source Schema only clears them from the Segment interface. It does not impact the data sent to your destinations or warehouses. Once you clear the events, the Schema page starts to repopulate new events.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Add a note to our public docs to clarify that the settings to clear Identify/Groups traits will not be available if a Tracking plan is connected to the Source.


### Merge timing
ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/KCS-1672