### PR TITLE
Add updated context re deleted records to RETL system page

### DIFF
--- a/src/connections/reverse-etl/system.md
+++ b/src/connections/reverse-etl/system.md
@@ -9,7 +9,7 @@ View reference information about how Segment detects data changes in your wareho
 Reverse ETL computes the incremental changes to your data directly within your data warehouse. The Unique Identifier column is used to detect the data changes, such as new, updated, and deleted records.
 
 > info "Delete Records Payload"
-> The only value passed for deleted records is its unique ID which can be accessed as `__segment_id`. 
+> The only value passed for deleted records is their unique ID, which can be accessed as `__segment_id`. Starting September 24, 2024, deleted records also contain all columns selected by your model, with `null` values in place of data.  
 
 For Segment to compute the data changes within your warehouse, Segment needs to have both read and write permissions to the warehouse schema table. At a high level, the extract process requires read permissions for the query being executed. Segment keeps track of changes to the query results through tables that Segment manages in a dedicated schema (for example, `_segment_reverse_etl`), which requires some write permissions.
 

--- a/src/connections/reverse-etl/system.md
+++ b/src/connections/reverse-etl/system.md
@@ -9,7 +9,7 @@ View reference information about how Segment detects data changes in your wareho
 Reverse ETL computes the incremental changes to your data directly within your data warehouse. The Unique Identifier column is used to detect the data changes, such as new, updated, and deleted records.
 
 > info "Delete Records Payload"
-> The only value passed for deleted records is their unique ID, which can be accessed as `__segment_id`. Starting September 24, 2024, deleted records also contain all columns selected by your model, with `null` values in place of data.  
+> The only value passed for deleted records is their unique ID, which can be accessed as `__segment_id`. As of September 24, 2024, deleted records also contain all columns selected by your model, with `null` values in place of data.  
 
 For Segment to compute the data changes within your warehouse, Segment needs to have both read and write permissions to the warehouse schema table. At a high level, the extract process requires read permissions for the query being executed. Segment keeps track of changes to the query results through tables that Segment manages in a dedicated schema (for example, `_segment_reverse_etl`), which requires some write permissions.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added more context at request of ENG to the Delete Records Payload note. As of today, deleted records also contain all columns selected by your model, with `null` values in place of data.  

### Merge timing
Sept. 24, 2024

### Related issues (optional)
