### PR TITLE
Update RETL Query Length Limit

### DIFF
--- a/src/connections/reverse-etl/system.md
+++ b/src/connections/reverse-etl/system.md
@@ -38,7 +38,7 @@ If you have a non-standard or high volume usage plan, you may have unique Revers
 
 Name | Details | Limit
 --------- | ------- | ------
-Model query length | The maximum length for the model SQL query. | 131,072 characters
+Model query length | The maximum length for the model SQL query. | 65,535 characters
 Model identifier column name length | The maximum length for the ID column name. | 191 characters
 Model timestamp column name length | The maximum length for the timestamp column name. | 191 characters
 Sync frequency | The shortest possible duration Segment allows between syncs. | 15 minutes


### PR DESCRIPTION
Hi, I am on the RETL team and we noticed that in our public docs we are using an erroneous value for the query length. For the `query` column in our MySQL DB we use [MYSQL](https://www.atlassian.com/data/databases/understanding-strorage-sizes-for-mysql-text-data-types#:~:text=TEXT%3A%2065%2C535%20characters%20%2D%2064%20KB,requires%20a%202%20byte%20overhead.) `TEXT` which has a character limit of 65,535. When a customer/user saves anything longer than that it auto truncates to that limit, which will lead to the query failing. 

Confirmed that by writing a model query at 131,071 (right below our listed limit), and when I queried the DB it was truncated 
```
mysql> select LENGTH(query) from reverse_etl_models where id = '5PuvDCsS6FdJXP2iJH3SiY';
+---------------+
| LENGTH(query) |
+---------------+
|         65535 |
+---------------+
```


### Merge timing
Merge whenever it is approved please :) 

