### PR TITLE
Add note to restore API host

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
@@ -247,3 +247,7 @@ analytics.load({
    cdnSettings: {...} // object from https://cdn.segment.com/v1/projects/<YOUR_WRITE_KEY>/settings'
  })
 ```
+
+## Restore the API Host to the Segment Default
+
+If you wish to restore the proxied API host to it's original value, navigate to the Source >> Settings >> Analytis.js tab, and then scroll down until you see the Host address field. Under the field, there will be small blue text that says 'Restore to a default value'. Click 'Restore' and then the 'Save' button. Any changes made to the CDN host must be update manually in your code. 

--- a/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/custom-proxy.md
@@ -248,6 +248,11 @@ analytics.load({
  })
 ```
 
-## Restore the API Host to the Segment Default
+## Restore the API host to the Segment default
 
-If you wish to restore the proxied API host to it's original value, navigate to the Source >> Settings >> Analytis.js tab, and then scroll down until you see the Host address field. Under the field, there will be small blue text that says 'Restore to a default value'. Click 'Restore' and then the 'Save' button. Any changes made to the CDN host must be update manually in your code. 
+If you wish to restore the proxied API host to it's original value:
+1. Navigate to the **Source > Settings > Analytis.js tab**
+2. Scroll down until you see the Host address field. 
+3. Under the field, there is a small blue text that says 'Restore to a default value'. Click **Restore** and then **Save**. 
+
+Any changes made to the CDN host must be update manually in your code. 


### PR DESCRIPTION

### Proposed changes

Customers ocassionally want to revert their proxy back to Segments API host. The option to do so is not very noticable in the UI 

### Merge timing
- ASAP once approved

### Related issues (optional)

n/a
