### PR TITLE
Unhide Use Cases Docs

### DIFF
--- a/src/_data/sidenav/main.yml
+++ b/src/_data/sidenav/main.yml
@@ -20,6 +20,17 @@ sections:
     title: Testing and Debugging
   - path: /getting-started/whats-next
     title: What's Next
+  - section_title: Use Cases
+    slug: getting-started/use-cases
+    section:
+    - path: /getting-started/use-cases/
+      title: Use Cases Overview
+    - path: /getting-started/use-cases/guide/
+      title: Choosing a Use Case
+    - path: /getting-started/use-cases/setup/
+      title: Use Cases Setup
+    - path: /getting-started/use-cases/reference/
+      title: Use Cases Reference
 
 - section_title: Guides
   section:

--- a/src/getting-started/use-cases/guide.md
+++ b/src/getting-started/use-cases/guide.md
@@ -1,6 +1,5 @@
 ---
 title: Choosing a Use Case
-hidden: true
 ---
 
 Segment built Use Cases to streamline the process of implementing Segment for specific business objectives. 

--- a/src/getting-started/use-cases/guide.md
+++ b/src/getting-started/use-cases/guide.md
@@ -7,6 +7,9 @@ Segment built Use Cases to streamline the process of implementing Segment for sp
 
 This guide will help you navigate through the available use cases and select the one that best aligns with your business goals. 
 
+> info ""
+> You can onboard to Segment with a Use Case if you’re a new business tier user or haven’t yet connected a source and destination.
+
 ## Understanding business goals and use cases
 
 Segment supports 25 use cases, organized into 4 main business goals:

--- a/src/getting-started/use-cases/guide.md
+++ b/src/getting-started/use-cases/guide.md
@@ -7,7 +7,7 @@ Segment built Use Cases to streamline the process of implementing Segment for sp
 This guide will help you navigate through the available use cases and select the one that best aligns with your business goals. 
 
 > info ""
-> You can onboard to Segment with a Use Case if you’re a new business tier user or haven’t yet connected a source and destination.
+> You can onboard to Segment with a Use Case if you’re a new Business Tier customer or haven’t yet connected a source and destination.
 
 ## Understanding business goals and use cases
 

--- a/src/getting-started/use-cases/index.md
+++ b/src/getting-started/use-cases/index.md
@@ -7,6 +7,8 @@ Use Cases are pre-built Segment setup guides tailored to common business goals.
 
 Use Cases eliminate guesswork with a structured approach to onboarding, helping you configure Segment correctly and align its features to your business objectives.
 
+> info ""
+> You can onboard to Segment with a Use Case if you’re a new business tier user or haven’t yet connected a source and destination.
 
 ## Onboard to Segment with Use Cases
 

--- a/src/getting-started/use-cases/index.md
+++ b/src/getting-started/use-cases/index.md
@@ -1,6 +1,5 @@
 ---
 title: Use Cases Overview
-hidden: true
 ---
 
 Use Cases are pre-built Segment setup guides tailored to common business goals. 

--- a/src/getting-started/use-cases/index.md
+++ b/src/getting-started/use-cases/index.md
@@ -7,7 +7,7 @@ Use Cases are pre-built Segment setup guides tailored to common business goals.
 Use Cases eliminate guesswork with a structured approach to onboarding, helping you configure Segment correctly and align its features to your business objectives.
 
 > info ""
-> You can onboard to Segment with a Use Case if you’re a new business tier user or haven’t yet connected a source and destination.
+> You can onboard to Segment with a Use Case if you’re a new Business Tier customer or haven’t yet connected a source and destination.
 
 ## Onboard to Segment with Use Cases
 

--- a/src/getting-started/use-cases/reference.md
+++ b/src/getting-started/use-cases/reference.md
@@ -1,6 +1,5 @@
 ---
 title: Use Cases Reference
-hidden: true
 ---
 
 This reference guide provides detailed information on the suggested events, sources, and destinations for each Segment use case. Use this guide to ensure you're tracking the right events and connecting the best sources and destinations for your specific needs.

--- a/src/getting-started/use-cases/setup.md
+++ b/src/getting-started/use-cases/setup.md
@@ -1,6 +1,5 @@
 ---
 title: Use Cases Setup
-hidden: true
 ---
 
 Use Cases help you onboard quickly and efficiently to Segment by guiding you through specific steps tailored to your business needs.

--- a/src/getting-started/use-cases/setup.md
+++ b/src/getting-started/use-cases/setup.md
@@ -10,6 +10,9 @@ This page walks you through the steps to set up a use case in your Segment insta
 > info "Permissions"
 > To implement a use case, you'll need to be a Workspace Owner for your Segment account. See the [Roles](/docs/segment-app/iam/roles/) documentation for more information. 
 
+> info ""
+> You can onboard to Segment with a Use Case if you’re a new business tier user or haven’t yet connected a source and destination.
+
 ## Use case setup overview
 
 From a high level, setting Segment up with a use case takes place in four stages:

--- a/src/getting-started/use-cases/setup.md
+++ b/src/getting-started/use-cases/setup.md
@@ -10,7 +10,7 @@ This page walks you through the steps to set up a use case in your Segment insta
 > To implement a use case, you'll need to be a Workspace Owner for your Segment account. See the [Roles](/docs/segment-app/iam/roles/) documentation for more information. 
 
 > info ""
-> You can onboard to Segment with a Use Case if you’re a new business tier user or haven’t yet connected a source and destination.
+> You can onboard to Segment with a Use Case if you’re a new Business Tier customer or haven’t yet connected a source and destination.
 
 ## Use case setup overview
 


### PR DESCRIPTION
### Proposed changes

- Unhid Use Cases docs.  They can be shared publicly now.
- Added Use Cases to the side navigation.
- Added a callout to a couple of the pages noting current Use Cases availability.

### Merge timing

- ASAP once approved.

