### PR TITLE
Update Migration Guides for Swift and Kotlin

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/apple/migration.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/migration.md
@@ -359,5 +359,35 @@ The following options were removed in Analytics-Swift:
 | `trackInAppPurchases`       | Deprecated                                                                                                  |
 | `trackPushNotifications`    | Deprecated                                                                                                  |
 
+### 4.a) Traits are no longer attached to `analytics.track()` events automatically 
+
+In order to prevent sending unwanted or unnecessary PII, traits collected in `analytics.identify()` events are no longer automatically attached to `analytics.track()` events. In order to achieve this, you can write a simple `before` plugin: 
+
+```swift
+import Foundation
+import Segment
+
+class InjectTraits: Plugin {
+    let type = PluginType.enrichment
+    weak var analytics: Analytics? = nil
+    
+    func execute<T: RawEvent>(event: T?) -> T? {
+        if event?.type == "identify" {
+            return event
+        }
+        
+        var workingEvent = event
+        
+        if var context = event?.context?.dictionaryValue {
+            context[keyPath: "traits"] = analytics?.traits()
+            
+            workingEvent?.context = try? JSON(context)
+        }
+        
+        return workingEvent
+    }
+}
+```
+
 ### Conclusion
 Once you’re up and running, you can take advantage of Analytics-Swift’s additional features, such as [Destination Filters](/docs/connections/sources/catalog/libraries/mobile/apple/swift-destination-plugins), [Functions](/docs/connections/functions/), and [Typewriter](/docs/connections/sources/catalog/libraries/mobile/apple/swift-typewriter) support. 

--- a/src/connections/sources/catalog/libraries/mobile/apple/migration.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/migration.md
@@ -361,7 +361,7 @@ The following options were removed in Analytics-Swift:
 
 ### 4.a) Traits are no longer attached to `analytics.track()` events automatically 
 
-In order to prevent sending unwanted or unnecessary PII, traits collected in `analytics.identify()` events are no longer automatically attached to `analytics.track()` events. In order to achieve this, you can write a simple `before` plugin: 
+To prevent sending unwanted or unnecessary PII, traits collected in `analytics.identify()` events are no longer automatically attached to `analytics.track()` events. To achieve this, you can write a `before` plugin: 
 
 ```swift
 import Foundation

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/migration.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/migration.md
@@ -439,5 +439,40 @@ Properties have been replaced by JsonElement. Since Properties are essentially a
   {% endcodeexample %}
 ### 4.c) Options Support Removed
 Options are no longer supported and should be converted into plugins.
+
+
+### 4.d) Traits are no longer attached to `analytics.track()` events automatically 
+
+In order to prevent sending unwanted or unnecessary PII, traits collected in `analytics.identify()` events are no longer automatically attached to `analytics.track()` events. In order to achieve this, you can write a simple `before` plugin: 
+
+```kotlin
+import com.segment.analytics.kotlin.core.Analytics
+import com.segment.analytics.kotlin.core.Plugin
+import com.segment.analytics.kotlin.core.PluginType
+import com.segment.analytics.kotlin.core.platform.Plugin
+import com.segment.analytics.kotlin.core.events.RawEvent
+
+class InjectTraits : Plugin {
+
+    override val type: PluginType = PluginType.Enrichment
+    var analytics: Analytics? = null
+
+    override fun <T : RawEvent> execute(event: T?): T? {
+        if (event?.type == "identify") {
+            return event
+        }
+
+        var workingEvent = event
+        val context = event?.context?.toMutableMap()
+
+        if (context != null) {
+            context["traits"] = analytics?.traits()
+
+            workingEvent?.context = context
+        }
+        return workingEvent
+    }
+}
+```
 ## Conclusion
 Once you’re up and running, you can take advantage of Analytics-Kotlin’s additional features, like [Destination Filters](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-destination-filters/), [Functions](https://segment.com/docs/connections/functions/), and [Typewriter](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/kotlin-android-typewriter/) support.

--- a/src/connections/sources/catalog/libraries/mobile/kotlin-android/migration.md
+++ b/src/connections/sources/catalog/libraries/mobile/kotlin-android/migration.md
@@ -443,7 +443,7 @@ Options are no longer supported and should be converted into plugins.
 
 ### 4.d) Traits are no longer attached to `analytics.track()` events automatically 
 
-In order to prevent sending unwanted or unnecessary PII, traits collected in `analytics.identify()` events are no longer automatically attached to `analytics.track()` events. In order to achieve this, you can write a simple `before` plugin: 
+To prevent sending unwanted or unnecessary PII, traits collected in `analytics.identify()` events are no longer automatically attached to `analytics.track()` events. To achieve this, you can write a `before` plugin: 
 
 ```kotlin
 import com.segment.analytics.kotlin.core.Analytics


### PR DESCRIPTION
### Proposed changes

- adds a note in the migration guides for `Analytics-Swift` and `Analytics-Kotlin` about adding traits to track events 

<!-- When should this get merged/published?
- ASAP once approved