### PR TITLE
Fixed broken Braze links

### DIFF
--- a/src/connections/destinations/catalog/actions-braze-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-braze-cloud/index.md
@@ -3,9 +3,11 @@ title: Braze Cloud Mode (Actions) Destination
 hide-boilerplate: true
 hide-dossier: false
 id: 60f9d0d048950c356be2e4da
+redirect_from: 
+  - '/connections/destinations/catalog/braze-cloud-mode-actions/'
 versions:
   - name: 'Braze Web Mode (Actions)'
-    link: '/docs/connections/destinations/catalog/braze-web-device-mode-actions/'
+    link: '/docs/connections/destinations/catalog/actions-braze-web/'
   - name: 'Braze (Classic)'
     link: '/docs/connections/destinations/catalog/braze'
 ---

--- a/src/connections/destinations/catalog/actions-braze-web/index.md
+++ b/src/connections/destinations/catalog/actions-braze-web/index.md
@@ -4,10 +4,11 @@ hide-boilerplate: true
 hide-dossier: false
 redirect_from:
   - '/connections/destinations/catalog/vendor-braze/'
+  - '/connections/destinations/catalog/braze-web-device-mode-actions/'
 id: 60fb01aec459242d3b6f20c1
 versions:
   - name: 'Braze Cloud Mode (Actions)'
-    link: '/docs/connections/destinations/catalog/braze-cloud-mode-actions'
+    link: '/docs/connections/destinations/catalog/actions-braze-cloud'
   - name: 'Braze (Classic)'
     link: '/docs/connections/destinations/catalog/braze'
 ---

--- a/src/connections/destinations/catalog/braze/index.md
+++ b/src/connections/destinations/catalog/braze/index.md
@@ -5,7 +5,7 @@ hide-personas-partial: true
 hide-integrations-object: true
 maintenance: true
 maintenance-content: >
-  Future updates to this destination are limited to security updates and bug fixes. New versions of this destination are available. See [Braze Cloud Mode (Actions)](/docs/connections/destinations/catalog/braze-cloud-mode-actions) for a server-side integration and [Braze Web Mode (Actions)](/docs/connections/destinations/catalog/braze-web-device-mode-actions) for a device-mode integration with access to Braze SDK features.
+  Future updates to this destination are limited to security updates and bug fixes. New versions of this destination are available. See [Braze Cloud Mode (Actions)](/docs/connections/destinations/catalog/actions-braze-cloud) for a server-side integration and [Braze Web Mode (Actions)](/docs/connections/destinations/catalog/actions-braze-web) for a device-mode integration with access to Braze SDK features.
   <br />
   If you use a Braze mobile [device-mode connection](/docs/connections/destinations/#connection-modes), for example to use Braze Content Cards or In-App Messaging, use the Braze (Classic) Destination. Segment will continue to make updates to the Segment Braze mobile device-mode SDK.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added redirects/fixed the slugs for two different Braze destinations, Braze Web Mode (Actions) and Braze Cloud Mode (Actions). [Slack thread for ref](https://twilio.slack.com/archives/CD3LFFTFZ/p1729003630105959)

### Merge timing
asap!

### Related issues (optional)

