### PR TITLE
Update index.md - computed trait availability in audience builder

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -52,7 +52,8 @@ You can also build audiences using Custom Traits, Computed Traits, SQL Traits, a
 
 #### Computed Traits
 
-You can also use computed traits in an audience definition. For example, you can create a `total_revenue` computed trait and use it to generate an audience of `big_spender` customers that exceed a certain threshold.
+You can also use computed traits in an audience definition. For example, you can create a `total_revenue` computed trait and use it to generate an audience of `big_spender` customers that exceed a certain threshold. A computed trait must be configured to "Send Identify" calls in order to be available for selection in the audience definition.
+
 
 > info ""
 > Engage supports nested traits, but the Audience builder doesn’t support accessing objects nested in arrays. When you send arrays of objects, they are flattened into strings. As a result, the same conditions that work on strings will work on the array. Within the builder, you can only use string operations like `contains` and `does not contain` to look for individual characters or a set of characters in the flattened array.


### PR DESCRIPTION
### Proposed changes

I updated the 'Computed Trait' section to mention that a computed trait must be configured to 'Send Identify' calls to be available for selection in the Audience builder.

### Merge timing
- ASAP once approved


### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
