### PR TITLE
Add Source Function Custom Response FAQ

### DIFF
--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -434,3 +434,7 @@ No. Tracking Pixels operate client-side only and need to be loaded onto your web
 ##### What is the maximum data size that can be displayed in console.logs() when testing a Function?
 
 The test function interface has a 4KB console logging limit. Outputs surpassing this limit will not be visible in the user interface.
+
+#### Can I send a custom response out from my Source Function to an external tool?
+
+No, at this time Source Functions do not allow for custom responses to be sent to the tool that made a request to the Function's webhook. This is because of the way Functions leverage AWS Lambda on the backend. Functions will either respond with a success or failure response and cannot emit a custom response.

--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -435,6 +435,6 @@ No. Tracking Pixels operate client-side only and need to be loaded onto your web
 
 The test function interface has a 4KB console logging limit. Outputs surpassing this limit will not be visible in the user interface.
 
-#### Can I send a custom response out from my Source Function to an external tool?
+#### Can I send a custom response from my Source Function to an external tool?
 
-No, at this time Source Functions do not allow for custom responses to be sent to the tool that made a request to the Function's webhook. This is because of the way Functions leverage AWS Lambda on the backend. Functions will either respond with a success or failure response and cannot emit a custom response.
+No, Source Functions can't send custom responses to the tool that triggered the Function's webhook. Source Functions can only send a success or failure response, not a custom one.


### PR DESCRIPTION
### Proposed changes

Source Functions cannot emit a custom response. This change clarifies that point.

### Merge timing
ASAP is fine