### PR TITLE
Add FAQ on omitted properties

### DIFF
--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -150,7 +150,9 @@ Blocked events are blocked from sending to all Segment Destinations, including w
 
 ### If I omit unplanned properties or properties that generate JSON schema violations, what happens to them?
 
-Properties that are omitted due to JSON Schema Violations or being unplanned are not stored in Segment logs. Segment only stores fully blocked events for 30 days. Omitted properties are dropped from the events and can only be found in the `context.violations` object of an event payload. If Violations are forwarded to a new source, then the omitted properties can also be seen in the Violation Generated event under `violationField` in the `properties` object of the event. 
+Segment doesn't store unplanned properties and properties omitted due to JSON Schema Violations in Segment logs. Segment drops omitted properties from the events. You can find the omitted properties in the `context.violations` object of an event payload. If you forward Violations to a new source, then you can also see the omitted properties in the Violation Generated event under `violationField` in the `properties` object. 
+
+Segment only stores fully blocked events for 30 days. 
 
 ### Why am I seeing unplanned properties/traits in the payload when violations are triggered, despite using schema controls to omit them?
 

--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -148,6 +148,10 @@ That being said, there are plenty of scenarios where the reactive Schema functio
 
 Blocked events are blocked from sending to all Segment Destinations, including warehouses and streaming Destinations. When an Event is blocked using a Tracking Plan, it does not count towards your MTU limit. They will, however, count toward your MTU limit if you enable [blocked event forwarding](/docs/protocols/enforce/forward-blocked-events/) in your Source settings.
 
+### If I omit unplanned properties or properties that generate JSON schema violations, what happens to them?
+
+Properties that are omitted due to JSON Schema Violations or being unplanned are not stored in Segment logs. Segment only stores fully blocked events for 30 days. Omitted properties are dropped from the events and can only be found in the `context.violations` object of an event payload. If Violations are forwarded to a new source, then the omitted properties can also be seen in the Violation Generated event under `violationField` in the `properties` object of the event. 
+
 ### Why am I seeing unplanned properties/traits in the payload when violations are triggered, despite using schema controls to omit them?
 
 If you're seeing unplanned properties/traits in your payload despite using Schema Controls, you might want to select a new degree of blocking controls. 


### PR DESCRIPTION

### Proposed changes

Added an FAQ that explains that omitted properties are not kept in Segment logs and can only be found in Violation Generated events or context.violations

### Merge timing
- ASAP once approved

### Related issues (optional)
n/a
