### PR TITLE
ID sync strategy for Audience Exit events.

### DIFF
--- a/src/engage/trait-activation/id-sync.md
+++ b/src/engage/trait-activation/id-sync.md
@@ -73,3 +73,6 @@ Audiences without ID Sync aren't allowed to select any strategy, and by default 
 
 #### Can I edit config once the audience has synced? 
 Yes, you can edit configuration in the Destination **Settings** tab at any time. However, changes will only take place in subsequent audience syncs, or in new audiences connected to the destination.
+
+#### Will the Audience Entered and Exited events obey the ID sync strategy? 
+Only the "Audience Entered" event will obey the ID sync strategy. However, for the "Audience Exited" event, the ID Sync configuration and space-level ID strategy are not applied. For Audience Exit, all ID combinations are sent in an effort to try and match any identifier that was ever sent to the downstream destination in order to remove it from the external audience.


### PR DESCRIPTION
### Proposed changes

#### Will the Audience Entered and Exited events obey the ID sync strategy?  Only the "Audience Entered" event will obey the ID sync strategy. However, for the "Audience Exited" event, the ID Sync configuration and space-level ID strategy are not applied. For Audience Exit, all ID combinations are sent in an effort to try and match any identifier that was ever sent to the downstream destination in order to remove it from the external audience.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
