### PR TITLE
Update index.md - remove reference to limitation of mapping tester

### DIFF
--- a/src/connections/destinations/catalog/actions-segment-profiles/index.md
+++ b/src/connections/destinations/catalog/actions-segment-profiles/index.md
@@ -35,9 +35,6 @@ The Segment Profiles destination is not subject to API call or MTU costs. Any us
 ### Succesful syncs but no changes on profiles
 Make sure that the Endpoint Region setting matches the region of your workspace. If the region is correct and you don't see any profile changes, [contact Segment](https://segment.com/help/contact/){:target="_blank"}.
 
-### Test Mapping
-The **Test Mapping** feature on the Mapping page does not send events to Profiles. It will only validate the mappings and confirm that the event will be accepted by the Tracking API. To send and validate the event in profile, please run a RETL sync.
-
 ### Can I view samples of events received in Engage by the Segment Profiles Destination?
 
 Records sent to the Segment Profiles Destination are managed through a Unify Spaces' Profile Sources. Samples of these events may be reviewed in a [Profile Source Debugger](https://segment.com/docs/unify/debugger/). For a more comprehensive analysis of the events received in Unify & Engage, consider utilizing [Profiles Sync](https://segment.com/docs/unify/profiles-sync/overview/) connected to your Data Warehouse.


### PR DESCRIPTION
### Proposed changes

The engineering team has enhanced the Segment Profiles integration to now successfully process 'test events' sent through the Mapping Tester. Previously, the Mapping Tester only provided a preview of the event's appearance without actually processing it via the Tracking API.

As such, I have removed the section that outlined this limitation.

### Merge timing
- ASAP once approved

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
