### PR TITLE
Add FAQ for IPv6 Collection in Analytics.js

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/faq.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/faq.md
@@ -3,6 +3,10 @@ title: Analytics.js Frequently Asked Questions
 strat: ajs
 ---
 
+## Is it possible to configure Analytics.js to automatically collect IPv6 when available?
+
+Currently, Analytics.js does not automatically collect IPv6 addresses. If IPv6 is available on the user’s device or network, the IPv6 address must be manually sent to Segment. You’ll need to configure your setup to capture and pass the IPv6 address in your event payloads, as our library doesn’t collect it by default.
+
 ## Is there a size limit on requests?
 
 Yes, the limit is 32KB per event message. Events with a payload larger than 32KB are accepted by Analytics.js and Segment servers return a `200` response , but the event is silently dropped once it enters Segment's pipeline. 

--- a/src/connections/sources/catalog/libraries/website/javascript/faq.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/faq.md
@@ -5,7 +5,7 @@ strat: ajs
 
 ## Is it possible to configure Analytics.js to automatically collect IPv6 when available?
 
-Analytics.js doesn't automatically collect IPv6 addresses. If IPv6 is available on the user’s device or network, you must [manually send](/docs/connections/sources/catalog/libraries/website/javascript/identity/#anonymizing-ip) the IPv6 address to Segment. You need to configure your setup to capture and pass the IPv6 address in your event payloads, as the library doesn’t collect it by default.
+Analytics.js doesn't automatically collect IPv6 addresses. If IPv6 is available on the user’s device or network, you must [manually send](/docs/connections/sources/catalog/libraries/website/javascript/identity/#anonymizing-ip) the IPv6 address to Segment. Configure your setup to capture and pass the IPv6 address in your event payloads, as the library doesn’t collect it by default.
 
 ## Is there a size limit on requests?
 

--- a/src/connections/sources/catalog/libraries/website/javascript/faq.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/faq.md
@@ -5,7 +5,7 @@ strat: ajs
 
 ## Is it possible to configure Analytics.js to automatically collect IPv6 when available?
 
-Currently, Analytics.js does not automatically collect IPv6 addresses. If IPv6 is available on the user’s device or network, the IPv6 address must be manually sent to Segment. You’ll need to configure your setup to capture and pass the IPv6 address in your event payloads, as our library doesn’t collect it by default.
+Analytics.js doesn't automatically collect IPv6 addresses. If IPv6 is available on the user’s device or network, you must [manually send](/docs/connections/sources/catalog/libraries/website/javascript/identity/#anonymizing-ip) the IPv6 address to Segment. You need to configure your setup to capture and pass the IPv6 address in your event payloads, as the library doesn’t collect it by default.
 
 ## Is there a size limit on requests?
 


### PR DESCRIPTION
### Proposed changes
This PR adds an FAQ explaining that Analytics.js doesn’t automatically collect IPv6 and provides guidance on manually configuring IPv6 collection when available.

### Merge timing
ASAP once approved

