### PR TITLE
Removing group_id from promoted identifiers | IDRES-20

### DIFF
--- a/src/unify/identity-resolution/externalids.md
+++ b/src/unify/identity-resolution/externalids.md
@@ -28,7 +28,6 @@ Segment automatically promotes the following traits and IDs in track and identif
 | android.push_token | context.device.token when context.device.type = 'android'                                                     |
 | anonymous_id       | anonymousId                                                                                                   |
 | ga_client_id       | context.integrations['Google Analytics'].clientId when explicitly captured by users                           |
-| group_id           | groupId                                                                                                       |
 | ios.id             | context.device.id when context.device.type = 'ios'                                                            |
 | ios.idfa           | context.device.advertisingId when context.device.type = 'ios'     |
 | ios.push_token     | context.device.token when context.device.type = 'ios'                                                         |

--- a/src/unify/identity-resolution/identity-resolution-settings.md
+++ b/src/unify/identity-resolution/identity-resolution-settings.md
@@ -42,7 +42,6 @@ By default, Segment promotes the following traits and IDs in track and identify 
 | braze_id           | context.Braze.braze_id or context.Braze.braze_id when Braze is connected as a destination                     |
 | cross_domain_id    | cross_domain_id when XID is enabled for the workspace                                                         |
 | ga_client_id       | context.integrations['Google Analytics'].clientId when explicitly captured by users                           |
-| group_id           | groupId                                                                                                       |
 | ios.id             | context.device.id when context.device.type = 'ios'                                                            |
 | ios.idfa           | context.device.advertisingId when context.device.type = 'ios' AND context.device.adTrackingEnabled = true     |
 | ios.push_token     | context.device.token when context.device.type = 'ios'                                                         |


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Removed the group_id from the list of  traits and IDs which are automatically promoted to externalIDs. The group_id was removed from the list of auto-promoted IDs [here](https://github.com/segmentio/identity/pull/568). This PR updates the documentation to align with this.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)
https://segment.atlassian.net/browse/IDRES-20

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
