### PR TITLE
Update LinkedIn Audiences

### DIFF
--- a/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
@@ -60,7 +60,7 @@ If you're using Linked Audiences, you must set *Add* or *Remove* as the value fo
 This error occurs when the **DMP User Action** field is not set to "Add" or "Remove" in the mapping. Or it's set to "Auto Detect," which comes with a couple of caveats:
 
 - For Linked Audiences, you must set *Add* or *Remove* as the value for the **DMP User Action** field, as the **Auto Detect** option isn't supported.
-- For Profile Audiences, it must match the default "Enter Event" names set in the destination settings at the Audience level. Those defaults are "Audience Entered" and "Audience Exited."
+- For Profile Audiences, it must match the default *Enter Event* names set in the destination settings at the Audience level. Those defaults are *Audience Entered* and *Audience Exited*.
 
 ### Access & Refresh Tokens
 LinkedIn's OAuth access tokens have a time to live (TTL) of 60 days; refresh tokens have a TTL of one year. Segment automatically updates your access token as long as your refresh token is valid. You won't see any errors or interruptions in data delivery if your access token expires while your refresh token is valid.

--- a/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
@@ -59,7 +59,7 @@ If you're using Linked Audiences, you must set *Add* or *Remove* as the value fo
 
 This error occurs when the **DMP User Action** field is not set to "Add" or "Remove" in the mapping. Or it's set to "Auto Detect," which comes with a couple of caveats:
 
-- For Linked Audiences, you must set "Add" or "Remove" as the value for the **DMP User Action** field, as the **Auto Detect** option is not supported.
+- For Linked Audiences, you must set *Add* or *Remove* as the value for the **DMP User Action** field, as the **Auto Detect** option isn't supported.
 - For Profile Audiences, it must match the default "Enter Event" names set in the destination settings at the Audience level. Those defaults are "Audience Entered" and "Audience Exited."
 
 ### Access & Refresh Tokens

--- a/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
@@ -49,7 +49,18 @@ To sync additional Audiences from your Engage space, create a separate mapping i
 
 {% include components/actions-fields.html settings="true"%}
 
+## Note for Segment Linked Audiences
+
+For Linked Audiences, you must set "Add" or "Remove" as the value for the **DMP User Action** field, as the **Auto Detect** option is not supported.
+
 ## Troubleshooting
+
+### Error: Action :: field is required but not found
+
+This error occurs when the **DMP User Action** field is not set to "Add" or "Remove" in the mapping. Or it's set to "Auto Detect," which comes with a couple of caveats:
+
+- For Linked Audiences, you must set "Add" or "Remove" as the value for the **DMP User Action** field, as the **Auto Detect** option is not supported.
+- For Profile Audiences, it must match the default "Enter Event" names set in the destination settings at the Audience level. Those defaults are "Audience Entered" and "Audience Exited."
 
 ### Access & Refresh Tokens
 LinkedIn's OAuth access tokens have a time to live (TTL) of 60 days; refresh tokens have a TTL of one year. Segment automatically updates your access token as long as your refresh token is valid. You won't see any errors or interruptions in data delivery if your access token expires while your refresh token is valid.

--- a/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
@@ -49,7 +49,7 @@ To sync additional Audiences from your Engage space, create a separate mapping i
 
 {% include components/actions-fields.html settings="true"%}
 
-## Note for Segment Linked Audiences
+## Linked Audiences
 
 For Linked Audiences, you must set "Add" or "Remove" as the value for the **DMP User Action** field, as the **Auto Detect** option is not supported.
 

--- a/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
@@ -51,7 +51,7 @@ To sync additional Audiences from your Engage space, create a separate mapping i
 
 ## Linked Audiences
 
-For Linked Audiences, you must set "Add" or "Remove" as the value for the **DMP User Action** field, as the **Auto Detect** option is not supported.
+If you're using Linked Audiences, you must set *Add* or *Remove* as the value for the **DMP User Action** field, as Linked Audiences doesn't support the **Auto Detect** option.
 
 ## Troubleshooting
 

--- a/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-linkedin-audiences/index.md
@@ -57,7 +57,7 @@ If you're using Linked Audiences, you must set *Add* or *Remove* as the value fo
 
 ### Error: Action :: field is required but not found
 
-This error occurs when the **DMP User Action** field is not set to "Add" or "Remove" in the mapping. Or it's set to "Auto Detect," which comes with a couple of caveats:
+This error occurs when the **DMP User Action** field isn't set to *Add* or *Remove* in the mapping, or it's set to *Auto Detect,* which comes with a couple of caveats:
 
 - For Linked Audiences, you must set *Add* or *Remove* as the value for the **DMP User Action** field, as the **Auto Detect** option isn't supported.
 - For Profile Audiences, it must match the default *Enter Event* names set in the destination settings at the Audience level. Those defaults are *Audience Entered* and *Audience Exited*.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

- Added a note specific to Linked Audiences + LinkedIn Audiences to clarify that Auto Detect is not supported for DMP User Action, and users must manually set this field to "Add" or "Remove."

- Included an additional note for Profile Audiences to provide further guidance on configuration.

### Merge timing

- ASAP once approved

### Related issues (optional)

https://segment.atlassian.net/browse/STRATCONN-4304?atlOrigin=eyJpIjoiMGMzYzIxMjI1NjE5NDRkZWIxZDcwZjFkZWY4YzRlMzUiLCJwIjoiaiJ9
