### PR TITLE
Update profile-api.md - response default trait limit is 10, not 20

### DIFF
--- a/src/unify/profile-api.md
+++ b/src/unify/profile-api.md
@@ -115,7 +115,7 @@ You can query a user's traits (such as `first_name`, `last_name`, and more):
 
 `https://profiles.segment.com/v1/spaces/<space_id>/collections/users/profiles/<external_id>/traits`
 
-By default, the response includes 20 traits. You can return up to 200 traits by appending `?limit=200` to the querystring. If you wish to return a specific trait, append `?include={trait}` to the querystring (for example `?include=age`). You can also use the ``?class=audience​`` or ``?class=computed_trait​`` URL parameters to retrieve audiences or computed traits specifically.
+By default, the response includes 10 traits. You can return up to 200 traits by appending `?limit=200` to the querystring. If you wish to return a specific trait, append `?include={trait}` to the querystring (for example `?include=age`). You can also use the ``?class=audience​`` or ``?class=computed_trait​`` URL parameters to retrieve audiences or computed traits specifically.
 
 **Metadata**
 You can query all of a user's metadata (such as `created_at`, `updated_at`, and more):


### PR DESCRIPTION
### Proposed changes

The current Profile API documentation indicates that the default response includes 20 traits. However, the actual default limit is 10. I have updated the documentation to reflect this accurate limit.
<img width="568" alt="image" src="https://github.com/user-attachments/assets/cfcd89a1-830d-4cf2-9cce-91dbed50f401">


### Merge timing
- ASAP once approved

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
