### PR TITLE
Remove CustomerAI References 

### DIFF
--- a/src/_includes/content/functions-copilot-nutrition-facts.html
+++ b/src/_includes/content/functions-copilot-nutrition-facts.html
@@ -57,7 +57,7 @@
       <p class="c14"><span class="c25">AI Nutrition Facts</span>
           <br />
           <br />
-      <span class="c0">Customer AI Functions Copilot</span></p>
+      <span class="c0">Functions Copilot</span></p>
       </td>
   </tr><tr class="c4">
           <td class="c26" colspan="1" rowspan="1">
@@ -145,7 +145,7 @@
                   <td class="c9" colspan="1" rowspan="1"><p class="c10"><span class="c8">Other Resources</span>
                     <br />
                     <br />
-                    <span class="c12 c1">Learn more at: <a href="https://twilio.com/en-us/customer-ai" target="_blank">https://twilio.com/en-us/customer-ai</a> </span></p>
+                    <span class="c12 c1">Learn more at: <a href="https://twilioalpha.com/" target="_blank">https://twilioalpha.com/</a> </span></p>
                   </td>
               </tr>
     </table>

--- a/src/_includes/content/predictions-nutrition-facts.html
+++ b/src/_includes/content/predictions-nutrition-facts.html
@@ -57,7 +57,7 @@
       <p class="c14"><span class="c25">AI Nutrition Facts</span>
           <br />
           <br />
-      <span class="c0">Customer AI Predictions</span></p>
+      <span class="c0">Predictions</span></p>
       </td>
   </tr><tr class="c4">
           <td class="c26" colspan="1" rowspan="1">
@@ -145,7 +145,7 @@
                   <td class="c9" colspan="1" rowspan="1"><p class="c10"><span class="c8">Other Resources</span>
                     <br />
                     <br />
-                    <span class="c12 c1">Learn more at: <a href="https://twilio.com/en-us/customer-ai" target="_blank">https://twilio.com/en-us/customer-ai</a> </span></p>
+                    <span class="c12 c1">Learn more at: <a href="https://twilioalpha.com/" target="_blank">https://twilioalpha.com/</a> </span></p>
                   </td>
               </tr>
     </table>

--- a/src/_includes/content/product-based-audiences-nutrition-facts.html
+++ b/src/_includes/content/product-based-audiences-nutrition-facts.html
@@ -57,7 +57,7 @@
           <p class="c14"><span class="c25">AI Nutrition Facts</span>
               <br />
               <br />
-          <span class="c0">Customer AI Product Based Audiences</span></p>
+          <span class="c0">Product Based Recommendation Audiences</span></p>
           </td>
       </tr><tr class="c4">
               <td class="c26" colspan="1" rowspan="1">

--- a/src/_includes/content/product-based-audiences-nutrition-facts.html
+++ b/src/_includes/content/product-based-audiences-nutrition-facts.html
@@ -64,7 +64,7 @@
                   <p class="c10"><span class="c8">Description</span>
                   <br />
                   <br />
-                  <span class="c1">CustomerAI Product Based Audiences lets customers improve marketing campaigns by segmenting users based on preferences like product, category, or brand to automate the creation and maintenance of personalized recommendations for businesses in the retail, media, and entertainment industries. </span></p>
+                  <span class="c1">Product Based Audiences lets customers improve marketing campaigns by segmenting users based on preferences like product, category, or brand to automate the creation and maintenance of personalized recommendations for businesses in the retail, media, and entertainment industries. </span></p>
               </td>
               </tr>
                   <tr class="c4">

--- a/src/connections/functions/copilot.md
+++ b/src/connections/functions/copilot.md
@@ -30,7 +30,7 @@ This table lists example prompts you can use with Functions Copilot:
 Follow this guidance when you use Functions Copilot:
 
 - Avoid using personally identifiable information (PII) or sensitive data.
-- Write specific prompts. Specificity leads to more accurate CustomerAI function generation. Use the names of existing events, related attributes, and properties.
+- Write specific prompts. Specificity leads to more accurate function generation. Use the names of existing events, related attributes, and properties.
 - Iterate on your prompts. If you don't get the result you're looking for, try rewriting the prompt.
 
 ###  Limitations

--- a/src/engage/audiences/generative-audiences.md
+++ b/src/engage/audiences/generative-audiences.md
@@ -4,7 +4,7 @@ beta: true
 plan: engage-foundations
 ---
 
-With Generative Audiences, part of Segment's CustomerAI, use generative AI to create Engage Audiences with natural language prompts. 
+With Generative Audiences, you can use use generative AI to create Engage Audiences with natural language prompts. 
 
 Describe your desired audience based on events performed, profile traits, or existing audiences in your workspace. Based on your prompt, Segment builds the audience with generative AI.
 
@@ -22,7 +22,7 @@ To create an audience with Generative Audiences:
 4. From the Build screen, click **Build with AI**.
 5. Enter your audience prompt in the description box. 
 - Use a minimum of 20 characters and up to 300 characters maximum. 
-6. Click **Build**. Based on your prompt, CustomerAI generates audience conditions for your review. 
+6. Click **Build**. Based on your prompt, Segment generates audience conditions for your review. 
 - Segment displays a progress bar until the audience conditions are generated.
 
 > success ""
@@ -52,7 +52,7 @@ Use the following examples to help you get started with audience prompts.
 
 ### Using negative conditions 
 
-Below are a few examples of how CustomerAI configures audience conditions for negative prompts. Negative conditions might include, for example, building an audience of users without a certain profile trait, or who haven't performed certain events.   
+This section shows a few examples of how Generative Audiences configures audience conditions for negative prompts. Negative conditions might include, for example, building an audience of users without a certain profile trait, or who haven't performed certain events.   
 
 1. **Prompt**: "Customers who have not purchased in the last 30 days." 
 - **Expected output**: Segment generates audience conditions where *the event is performed at most 0 times*.
@@ -67,8 +67,8 @@ Below are a few examples of how CustomerAI configures audience conditions for ne
 
 As you use Generative Audiences, keep the following best practices in mind:
 
-- Avoid using any customer Personal Identifiable Information (PII) or sensitive data. Personal, confidential, or sensitive information isn't required to use CustomerAI. 
-- Write specific descriptions. CustomerAI generates more accurate conditions when you use the names of existing events and traits. 
+- Avoid using any customer Personal Identifiable Information (PII) or sensitive data. Personal, confidential, or sensitive information isn't required to use Generative Audiences. 
+- Write specific descriptions. Segment's models generate more accurate conditions when you use the names of existing events and traits. 
 - Ensure that all events and traits you reference exist in your workspace.
 - Try different prompts. If you don't receive what you want on the first try, rewrite your prompt. Submitting a new prompt replaces existing conditions.
 - Preview your audience to ensure you're matching with the correct profiles prior to moving on to the next step.
@@ -82,7 +82,7 @@ You can also use the Profile explorer (**Unify** > **Profile explorer**) to view
 Learn more about [using existing events and traits](/docs/engage/audiences/) to build audiences. 
  
 > warning ""
-> Due to a [limited space schema](#limited-space-schema), CustomerAI may not recognize some events or traits that are inactive in your workspace. 
+> Due to a [limited space schema](#limited-space-schema), Segment may not recognize some events or traits that are inactive in your workspace. 
  
 ## Error handling
 

--- a/src/engage/audiences/generative-audiences.md
+++ b/src/engage/audiences/generative-audiences.md
@@ -4,7 +4,7 @@ beta: true
 plan: engage-foundations
 ---
 
-With Generative Audiences, you can use use generative AI to create Engage Audiences with natural language prompts. 
+With Generative Audiences, part of Segment's AI capabilities, you can use use generative AI to create Engage Audiences with natural language prompts. 
 
 Describe your desired audience based on events performed, profile traits, or existing audiences in your workspace. Based on your prompt, Segment builds the audience with generative AI.
 
@@ -29,7 +29,7 @@ To create an audience with Generative Audiences:
 > To help you write your prompt, view these [example prompts](#example-prompts) and [best practices](#best-practices).
 
 > success "Before you begin"
-> To use Generative Audiences, a workspace owner must first accept the Customer AI Terms and Conditions.
+> To use Generative Audiences, a workspace owner must first accept Segment's Terms and Conditions.
 
 ### Modify an audience description 
 

--- a/src/engage/audiences/product-based-audiences.md
+++ b/src/engage/audiences/product-based-audiences.md
@@ -1,12 +1,13 @@
 ---
-title: Product Based Audiences
+title: Product Based Recommendation Audiences
 plan: engage-foundations
 redirect_from:
   - '/engage/audiences/recommendation-audiences'
 ---
-Product Based Audiences lets you select a product, article, song, or other piece of content from your catalog, and then build an audience of the people that are most likely to engage with it. Segment optimized the personalized recommendations built by Product Based Audiences for user-based commerce, media, and content affinity use cases. 
 
-You can use Product Based Audiences to power the following common marketing campaigns: 
+Product Based Recommendation Audiences lets you select a product, article, song, or other piece of content from your catalog, and then build an audience of the people that are most likely to engage with it. Segment optimized the personalized recommendations built by Product Based Recommendation Audiences for user-based commerce, media, and content affinity use cases. 
+
+You can use Product Based Recommendation Audiences to power the following common marketing campaigns: 
 
 - **Cross-selling**: Identify an audience of users who recently purchased a laptop and send those customers an email with a discount on items in the "laptop accessories" category. 
 - **Upselling**: Identify an audience of users who regularly interact with your free service and send them a promotion for your premium service. 

--- a/src/engage/audiences/product-based-audiences.md
+++ b/src/engage/audiences/product-based-audiences.md
@@ -18,7 +18,7 @@ You can use Product Based Audiences to power the following common marketing camp
 ## Create a Product Based Audience
 
 ### Set up your Recommendation Catalog
-Segment utilizes your interaction events (order_completed, product_added, product_searched, song_played, article_saved) and the event metadata of those interaction events to power our CustomerAI Recommendations workflow.
+Segment uses your interaction events (`order_completed`, `product_added`, `product_searched`, `song_played`, `article_saved`) and the event metadata of those interaction events to power the Recommendations workflow.
 
 To create your Recommendation Catalog:
 1. Open your Engage space and navigate to **Engage** > **Engage Settings** > **Recommendation catalog**. 

--- a/src/unified-profiles/connect-a-workspace.md
+++ b/src/unified-profiles/connect-a-workspace.md
@@ -14,9 +14,7 @@ If you already have a Segment workspace, you can use a new or pre-existing [Segm
 
 ## Prerequisites
 
-<!--PW: 15 Nov 2024, need to figure out what to do with these Flex CustomerAI links -->
-
-- You must have requested access from the [CustomerAI](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} page in your Flex Console and been accepted into the Agent Copilot and Unified Profiles beta program.
+- You must have requested access from the [Unified Profiles in Flex page](https://console.twilio.com/us1/develop/flex/unified-profiles){:target="_blank"} page in your Flex Console and been accepted into the Agent Copilot and Unified Profiles beta program.
 - Your Segment workspace must be on the Business Tier plan with a Unify Plus entitlement. To upgrade to the Business Tier plan, communicate with your sales contact or [request a demo](https://segment.com/demo/){:target="_blank"} from Segment's sales team.
 
 ## Step 1: Set up your Unify space

--- a/src/unified-profiles/connect-a-workspace.md
+++ b/src/unified-profiles/connect-a-workspace.md
@@ -14,6 +14,8 @@ If you already have a Segment workspace, you can use a new or pre-existing [Segm
 
 ## Prerequisites
 
+<!--PW: 15 Nov 2024, need to figure out what to do with these Flex CustomerAI links -->
+
 - You must have requested access from the [CustomerAI](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} page in your Flex Console and been accepted into the Agent Copilot and Unified Profiles beta program.
 - Your Segment workspace must be on the Business Tier plan with a Unify Plus entitlement. To upgrade to the Business Tier plan, communicate with your sales contact or [request a demo](https://segment.com/demo/){:target="_blank"} from Segment's sales team.
 

--- a/src/unified-profiles/index.md
+++ b/src/unified-profiles/index.md
@@ -8,13 +8,13 @@ hidden: true
 > info "Public Beta"
 > Unified Profiles is currently available as a limited Public Beta product and the information contained in this document is subject to change. This means that some features are not yet implemented and others may be changed before the product is declared as Generally Available. Public Beta products are not covered by a Twilio SLA.
 
-To try out Unified Profiles, request access from the [CustomerAI](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} page in your Flex Console. After you sign up, a Twilio Flex team member will contact you.
+To try out Unified Profiles, request access from the [Unified Profiles in Flex page](https://console.twilio.com/us1/develop/flex/unified-profiles){:target="_blank"} page in your Twilio Console. After you sign up, a Twilio Flex team member will contact you.
 
 Although Unified Profiles itself does not use machine learning technology, Unified Profiles can incorporate certain third-party machine learning technologies through Agent Copilot and Predictive Traits. For detailed information about each feature’s AI qualities, see the [AI Nutrition Facts for Agent Copilot](https://www.twilio.com/docs/flex/admin-guide/setup/copilot/nutritionfacts){:target="_blank"} and the [Predictions Nutrition Facts Label](/docs/unify/traits/predictions/predictions-nutrition-facts/){:target="_blank"}.
 
 Twilio’s AI Nutrition Facts provide an overview of the AI features you’re using so you can better understand how AI works with your data. For more information, including the glossary for the AI Nutrition Facts Label, see [Twilio’s AI Nutrition Facts page](https://nutrition-facts.ai/){:target="_blank"} and [Twilio’s approach to AI and emerging technology](https://twilioalpha.com/){:target="_blank"}. 
 
-For more information about Unified Profiles, see the [CustomerAI](https://www.twilio.com/docs/flex/customer-ai){:target="_blank"} documentation.
+For more information about AI and Unified Profiles, see the [Flex AI overview](https://www.twilio.com/docs/flex/ai){:target="_blank"} documentation.
 
 <div class="double">
   {% include components/reference-button.html

--- a/src/unified-profiles/index.md
+++ b/src/unified-profiles/index.md
@@ -12,7 +12,7 @@ To try out Unified Profiles, request access from the [CustomerAI](https://consol
 
 Although Unified Profiles itself does not use machine learning technology, Unified Profiles can incorporate certain third-party machine learning technologies through Agent Copilot and Predictive Traits. For detailed information about each feature’s AI qualities, see the [AI Nutrition Facts for Agent Copilot](https://www.twilio.com/docs/flex/admin-guide/setup/copilot/nutritionfacts){:target="_blank"} and the [Predictions Nutrition Facts Label](/docs/unify/traits/predictions/predictions-nutrition-facts/){:target="_blank"}.
 
-Twilio’s AI Nutrition Facts provide an overview of the AI features you’re using so you can better understand how AI works with your data. For more information, including the glossary for the AI Nutrition Facts Label, see [Twilio’s AI Nutrition Facts page](https://nutrition-facts.ai/){:target="_blank"} and [Twilio’s approach to trusted CustomerAI](https://www.twilio.com/en-us/blog/customer-ai-trust-principles-privacy-framework){:target="_blank"}. 
+Twilio’s AI Nutrition Facts provide an overview of the AI features you’re using so you can better understand how AI works with your data. For more information, including the glossary for the AI Nutrition Facts Label, see [Twilio’s AI Nutrition Facts page](https://nutrition-facts.ai/){:target="_blank"} and [Twilio’s approach to AI and emerging technology](https://twilioalpha.com/){:target="_blank"}. 
 
 For more information about Unified Profiles, see the [CustomerAI](https://www.twilio.com/docs/flex/customer-ai){:target="_blank"} documentation.
 

--- a/src/unified-profiles/unified-profiles-workspace.md
+++ b/src/unified-profiles/unified-profiles-workspace.md
@@ -9,7 +9,7 @@ For entitlements and limitations associated with a Unified Profiles workspace, s
 
 ## Prerequisites
 
-Before creating a Unified Profiles workspace, you must have requested access from the [CustomerAI](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} page in your Flex Console and been accepted into the Agent Copilot and Unified Profiles beta program.
+Before creating a Unified Profiles workspace, you must have requested access from the [Unified Profiles in Flex page](https://console.twilio.com/us1/develop/flex/unified-profiles){:target="_blank"} page in your Flex Console and been accepted into the Agent Copilot and Unified Profiles beta program.
 
 ## Step 1: Select your data source
 


### PR DESCRIPTION
### Proposed changes

- We're deprecating the usage of the term CustomerAI.
- This PR removes references to CustomerAI, and updates it appropriately depending on the context.

### Merge timing

- ASAP once approved.
