### PR TITLE
Add note about order of ops to Braze Cohorts docs

### DIFF
--- a/src/connections/destinations/catalog/actions-braze-cohorts/index.md
+++ b/src/connections/destinations/catalog/actions-braze-cohorts/index.md
@@ -12,7 +12,9 @@ Segment's Braze Cohorts destination syncs Engage audiences to Braze as cohorts. 
 
 ## Getting started
 
-Before connecting to the Braze Cohorts destination, you must have a [Braze](https://dashboard-01.braze.com/sign_in){:target="_blank"} account and an Ad Account ID.
+Before connecting to the Braze Cohorts destination, you must have a [Braze](https://dashboard-01.braze.com/sign_in){:target="_blank"} account and an Ad Account ID. 
+
+_(Optional)_: You can create a [cohort in Braze](https://www.braze.com/docs/partners/data_and_infrastructure_agility/customer_data_platform/segment/segment_engage/#step-4-create-a-braze-segment-from-the-engage-audience){:target="_blank"} before setting up the Braze Cohorts destination if you'd like. If you don't create a cohort in advance, the Braze Cohorts destination creates one on your behalf. 
 
 To connect the Braze Cohorts destination:
 

--- a/src/connections/destinations/catalog/actions-braze-cohorts/index.md
+++ b/src/connections/destinations/catalog/actions-braze-cohorts/index.md
@@ -14,7 +14,7 @@ Segment's Braze Cohorts destination syncs Engage audiences to Braze as cohorts. 
 
 Before connecting to the Braze Cohorts destination, you must have a [Braze](https://dashboard-01.braze.com/sign_in){:target="_blank"} account and an Ad Account ID. 
 
-_(Optional)_: You can create a [cohort in Braze](https://www.braze.com/docs/partners/data_and_infrastructure_agility/customer_data_platform/segment/segment_engage/#step-4-create-a-braze-segment-from-the-engage-audience){:target="_blank"} before setting up the Braze Cohorts destination if you'd like. If you don't create a cohort in advance, the Braze Cohorts destination creates one on your behalf. 
+_(Optional)_: You can create a [cohort in Braze](https://www.braze.com/docs/partners/data_and_infrastructure_agility/customer_data_platform/segment/segment_engage/#step-4-create-a-braze-segment-from-the-engage-audience){:target="_blank"} before setting up the Braze Cohorts destination. If you don't create a cohort in advance, the Braze Cohorts destination creates one on your behalf. 
 
 To connect the Braze Cohorts destination:
 


### PR DESCRIPTION
### Proposed changes
A customer raised a docs issue asserting that the Braze Cohorts destination doesn't create a cohort in Braze automatically. I confirmed with customer success that the destination will create a cohort in Braze, _if you __haven't__ already created a cohort_, and that it is optional for customers to create a cohort before they implement the destination. 

### Merge timing
ASAP!

### Related issues (optional)
Closes #7213 
