### PR TITLE
Reverse ETL: dbt Cloud schedule limitation

### DIFF
--- a/src/connections/reverse-etl/setup.md
+++ b/src/connections/reverse-etl/setup.md
@@ -50,8 +50,8 @@ Models define sets of data you want to sync to your Reverse ETL destinations. A 
 ### dbt model
 Use Segment's dbt extension to centralize model management and versioning. Users who set up a BigQuery, Databricks, Postgres, Redshift, or Snowflake source can use Segment's [dbt extension](/docs/segment-app/extensions/dbt/) to centralize model management and versioning, reduce redundancies, and run CI checks to prevent breaking changes. 
 
-> warning "Limitation"
-> Please be aware that if there are **5** mappings with a dbt Cloud schedule for a model, you will not be able to create additional mappings with the same dbt Cloud schedule type, regardless of the account or job selected. The limit applies per model.
+> success " "
+> If you use dbt Cloud with Reverse ETL, you can [create up to 5 mappings](#step-4-create-mappings) that use the sync strategy **dbt Cloud**, which extracts data from your warehouse and syncs it with your destination after a job in dbt Cloud is complete. 
 
 
 ## Step 3: Add a destination

--- a/src/connections/reverse-etl/setup.md
+++ b/src/connections/reverse-etl/setup.md
@@ -50,6 +50,10 @@ Models define sets of data you want to sync to your Reverse ETL destinations. A 
 ### dbt model
 Use Segment's dbt extension to centralize model management and versioning. Users who set up a BigQuery, Databricks, Postgres, Redshift, or Snowflake source can use Segment's [dbt extension](/docs/segment-app/extensions/dbt/) to centralize model management and versioning, reduce redundancies, and run CI checks to prevent breaking changes. 
 
+> warning "Limitation"
+> Please be aware that if there are **5** mappings with a dbt Cloud schedule for a model, you will not be able to create additional mappings with the same dbt Cloud schedule type, regardless of the account or job selected. The limit applies per model.
+
+
 ## Step 3: Add a destination
 In Reverse ETL, destinations are the business tools or apps you use that Segment syncs the data from your warehouse to. A model can have multiple destinations.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
We have a limit check for dbt Cloud schedules in place - https://github.com/segmentio/app/pull/21029 

Checking with engineers, they confirm that if there are 5 mappings with dbt Cloud schedule against a model, then users cannot create more mappings having the same dbt Cloud schedule type (regardless which account/job they pick). The limit is per model. 

### Merge timing
ASAP once approved

### Related issues (optional)
https://segment.atlassian.net/browse/KCS-1765