### PR TITLE
"Understand your prediction" tab for Predicted LTV computed trait.

### DIFF
--- a/src/unify/Traits/predictions/using-predictions.md
+++ b/src/unify/Traits/predictions/using-predictions.md
@@ -38,6 +38,9 @@ The Understand your prediction dashboard displays the following model metrics:
 - **Log Loss**; the more a predicted probability diverges from the actual value, the higher the log-loss value will be. Lower log loss indicates better predictions.
 - **Top contributing events**; this graph visually describes the events factored into the model, as well as the associated weights used to create the prediction.
 
+> info ""
+> We can't view the 'Understand your prediction' tab for the 'Predicted LTV' computed trait because we only use the order completed event for the trait calculation. However, other types of predictive traits utilize multiple events.
+
 ## Predictions use cases
 
 Predictions offer more value in some situations than others. This sections covers common scenarios where predictions have high impact, as well as others where alternative approaches may be more appropriate.


### PR DESCRIPTION
### Proposed changes

> info ""
> We can't view the 'Understand your prediction' tab for the 'Predicted LTV' computed trait because we only use the order completed event for the trait calculation. However, other types of predictive traits utilize multiple events.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
