### PR TITLE
Add Source Function FAQ on Infinite Looping Error

### DIFF
--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -438,3 +438,7 @@ The test function interface has a 4KB console logging limit. Outputs surpassing 
 #### Can I send a custom response from my Source Function to an external tool?
 
 No, Source Functions can't send custom responses to the tool that triggered the Function's webhook. Source Functions can only send a success or failure response, not a custom one.
+
+#### When I try to save my Source Function, why am I seeing this error message: "Functions are unable to send data or events back to their originating source. Please ensure the URL used for outgoing data from the function is correct."?
+
+To prevent possible infinite looping, Segment checks your Function code to ensure that you don't have `https://fn.segmentapis.com` included. That URL is used to send data to a Source Function. Including that URL in your Function code is a sign that an infinite loop may occur so Segment ensures you can't save your Function if that URL is included. To fix this, please remove that URL from your Function code.

--- a/src/connections/functions/source-functions.md
+++ b/src/connections/functions/source-functions.md
@@ -439,6 +439,8 @@ The test function interface has a 4KB console logging limit. Outputs surpassing 
 
 No, Source Functions can't send custom responses to the tool that triggered the Function's webhook. Source Functions can only send a success or failure response, not a custom one.
 
-#### When I try to save my Source Function, why am I seeing this error message: "Functions are unable to send data or events back to their originating source. Please ensure the URL used for outgoing data from the function is correct."?
+#### Why am I seeing the error "Functions are unable to send data or events back to their originating source" when trying to save my Source Function?
 
-To prevent possible infinite looping, Segment checks your Function code to ensure that you don't have `https://fn.segmentapis.com` included. That URL is used to send data to a Source Function. Including that URL in your Function code is a sign that an infinite loop may occur so Segment ensures you can't save your Function if that URL is included. To fix this, please remove that URL from your Function code.
+This error occurs because Segment prevents Source Functions from sending data back to their own webhook endpoint (`https://fn.segmentapis.com`). Allowing this could create an infinite loop where the function continuously triggers itself.
+
+To resolve this error, check your Function code and ensure the URL `https://fn.segmentapis.com` is not included. This URL is used to send data to a Source Function and shouldn't appear in your outgoing requests. Once you remove this URL from your code, you’ll be able to save the Function successfully.


### PR DESCRIPTION
### Proposed changes

The Source Function code was recently updated to ensure that customers can't save references to the Function in the code to prevent infinite looping. This update explains the error message a customer might see in this scenario. 

### Merge timing
ASAP is fine