### PR TITLE
Remove mentions to Customer AI from the UP docs

### DIFF
--- a/src/unified-profiles/connect-a-workspace.md
+++ b/src/unified-profiles/connect-a-workspace.md
@@ -14,7 +14,7 @@ If you already have a Segment workspace, you can use a new or pre-existing [Segm
 
 ## Prerequisites
 
-- You must have requested access from the [CustomerAI](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} page in your Flex Console and been accepted into the Agent Copilot and Unified Profiles beta program.
+- You must have requested access from the [AI in Flex](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} page in your Flex Console and been accepted into the Agent Copilot and Unified Profiles beta program.
 - Your Segment workspace must be on the Business Tier plan with a Unify Plus entitlement. To upgrade to the Business Tier plan, communicate with your sales contact or [request a demo](https://segment.com/demo/){:target="_blank"} from Segment's sales team.
 
 ## Step 1: Set up your Unify space

--- a/src/unified-profiles/index.md
+++ b/src/unified-profiles/index.md
@@ -8,13 +8,13 @@ hidden: true
 > info "Public Beta"
 > Unified Profiles is currently available as a limited Public Beta product and the information contained in this document is subject to change. This means that some features are not yet implemented and others may be changed before the product is declared as Generally Available. Public Beta products are not covered by a Twilio SLA.
 
-To try out Unified Profiles, request access from the [CustomerAI](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} page in your Flex Console. After you sign up, a Twilio Flex team member will contact you.
+To try Unified Profiles, request access from the [AI page](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} in your Flex Console. After you sign up, a Twilio Flex team member will contact you.
 
 Although Unified Profiles itself does not use machine learning technology, Unified Profiles can incorporate certain third-party machine learning technologies through Agent Copilot and Predictive Traits. For detailed information about each feature’s AI qualities, see the [AI Nutrition Facts for Agent Copilot](https://www.twilio.com/docs/flex/admin-guide/setup/copilot/nutritionfacts){:target="_blank"} and the [Predictions Nutrition Facts Label](/docs/unify/traits/predictions/predictions-nutrition-facts/){:target="_blank"}.
 
-Twilio’s AI Nutrition Facts provide an overview of the AI features you’re using so you can better understand how AI works with your data. For more information, including the glossary for the AI Nutrition Facts Label, see [Twilio’s AI Nutrition Facts page](https://nutrition-facts.ai/){:target="_blank"} and [Twilio’s approach to trusted CustomerAI](https://www.twilio.com/en-us/blog/customer-ai-trust-principles-privacy-framework){:target="_blank"}. 
+Twilio’s AI Nutrition Facts provide an overview of the AI features you’re using so you can better understand how AI works with your data. For more information, including the glossary for the AI Nutrition Facts Label, see [Twilio’s AI Nutrition Facts page](https://nutrition-facts.ai/){:target="_blank"}. 
 
-For more information about Unified Profiles, see the [CustomerAI](https://www.twilio.com/docs/flex/customer-ai){:target="_blank"} documentation.
+For more information about Unified Profiles, see the [AI in Flex](https://www.twilio.com/docs/flex/customer-ai){:target="_blank"} documentation.
 
 <div class="double">
   {% include components/reference-button.html

--- a/src/unified-profiles/unified-profiles-workspace.md
+++ b/src/unified-profiles/unified-profiles-workspace.md
@@ -9,7 +9,7 @@ For entitlements and limitations associated with a Unified Profiles workspace, s
 
 ## Prerequisites
 
-Before creating a Unified Profiles workspace, you must have requested access from the [CustomerAI](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} page in your Flex Console and been accepted into the Agent Copilot and Unified Profiles beta program.
+Before creating a Unified Profiles workspace, you must have requested access from the [AI in Flex](https://console.twilio.com/us1/develop/flex/customerai/overview){:target="_blank"} page in your Flex Console and been accepted into the Agent Copilot and Unified Profiles beta program.
 
 ## Step 1: Select your data source
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
At request of Flex marketing, removing some requests to Customer AI from the Unified Profiles docs

### Merge timing
After approval

### Related issues (optional)
