### PR TITLE
Explain how to find users by external ID to Profile API doc

### DIFF
--- a/src/unify/profile-api.md
+++ b/src/unify/profile-api.md
@@ -64,14 +64,12 @@ Your access token enables you to call the Profile API and access customer data.
 ### Query the user's event traits
 
 1. From the HTTP API testing application of your choice, configure the authentication as described above.
-2. [Find user by externalId](https://segment.com/docs/unify/profile-api/#find-a-users-external-id): The Profile API requires both the **type** of ID and the **value** separated by a colon. For example, anonymous_id:eml_3bca54b7fe7491add4c8d5d4d9bf6b3e085c6092.
+2. Identify the user’s external ID. 
+  - The Profile API requires both the ID type and value, separated by a colon (like `anonymous_id:eml_3bca54b7fe7491add4c8d5d4d9bf6b3e085c6092`). Learn more in [Find a user's external ID](#find-a-users-external-id).
 3. Prepare the request URL by replacing `<space_id>` and `<external_id>` in the request URL:
     `https://profiles.segment.com/v1/spaces/<space_id>/collections/users/profiles/<external_id>/traits`
-
-
-    If you're using the Profile API in the EU, use the following URL for all requests:
-
-    `https://profiles.euw1.segment.com/v1/spaces/<space_id>/collections/users/profiles/<external_id>/traits`
+  - If you're using the Profile API in the EU, use the following URL for all requests:
+   `https://profiles.euw1.segment.com/v1/spaces/<space_id>/collections/users/profiles/<external_id>/traits`
 4. Send a `GET` request to the URL.
 
 ### Explore the user's traits in the response

--- a/src/unify/profile-api.md
+++ b/src/unify/profile-api.md
@@ -64,14 +64,15 @@ Your access token enables you to call the Profile API and access customer data.
 ### Query the user's event traits
 
 1. From the HTTP API testing application of your choice, configure the authentication as described above.
-2. Prepare the request URL by replacing `<space_id>` and `<external_id>` in the request URL:
+2. [Find user by externalId](https://segment.com/docs/unify/profile-api/#find-a-users-external-id): The Profile API requires both the **type** of ID and the **value** separated by a colon. For example, anonymous_id:eml_3bca54b7fe7491add4c8d5d4d9bf6b3e085c6092.
+3. Prepare the request URL by replacing `<space_id>` and `<external_id>` in the request URL:
     `https://profiles.segment.com/v1/spaces/<space_id>/collections/users/profiles/<external_id>/traits`
 
 
     If you're using the Profile API in the EU, use the following URL for all requests:
 
     `https://profiles.euw1.segment.com/v1/spaces/<space_id>/collections/users/profiles/<external_id>/traits`
-3. Send a `GET` request to the URL.
+4. Send a `GET` request to the URL.
 
 ### Explore the user's traits in the response
 


### PR DESCRIPTION
…user by externalId
### Proposed changes

Added a link in the instructions for querying a user's event traits, noting how to locate a user by their external ID / that both the external ID type and value are required.

### Merge timing

- ASAP once approved

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
