### PR TITLE
Document GET limit for HubSpot

### DIFF
--- a/src/connections/destinations/catalog/hubspot/index.md
+++ b/src/connections/destinations/catalog/hubspot/index.md
@@ -196,6 +196,8 @@ HubSpot Plan: API Add-On (Any Tier)
 * Maximum Number of API Calls per 10 Seconds, per Key or Token: **120**
 * Maximum Number of API Calls per Day, per Key or Token: **1,000,000**
 
+### Maximum Data Size Returned from HubSpot
+For some processes, Segment will pull contact/company fields from HubSpot. On Segment's end there is a limit of 1MB on the data that Segment allows to return from HubSpot's platform. If that limit is exceeded, the request/response process will stop and the event you were attempting to send to HubSpot will not be sent. To ensure this doesn't happen, please keep your datasets clean and concise. It's important to ensure that you're not amassing fields that you're not using both for data cleanliness and to be sure that the returned traits from HubSpot won't be too large for Segment to complete its processes.
 
 ### Sending Dates as Property Values
 


### PR DESCRIPTION
### Proposed changes

For some processes, Segment makes GET requests to HubSpot's API. If the response is too large, Segment will stop attempting to send the associated event through the pipeline to HubSpot and the event will be dropped. This update clarifies that for customers.

### Merge timing
ASAP is fine