### PR TITLE
Change Release Notes to Product Updates

### DIFF
--- a/src/_includes/menu/menu.html
+++ b/src/_includes/menu/menu.html
@@ -14,12 +14,12 @@
         </li>
 
         <li class="menu-item">
-          <a class="menu-item__link menu-item__link--highlight menu-item__link--icon flex flex--middle" href="https://segment.com/release-notes/" target="_blank">
+          <a class="menu-item__link menu-item__link--highlight menu-item__link--icon flex flex--middle" href="https://community.segment.com/product-updates" target="_blank">
             <div class="menu-item__icon flex__column">
               {% include icons/megaphone.svg %}
             </div>
 
-            <div class="flex__column">Release Notes</div>
+            <div class="flex__column">Product Updates</div>
           </a>
         </li>
 


### PR DESCRIPTION
### Proposed changes

- Segment Release Notes will now be called Product Updates.
- Those Product Updates will be hosted on the [Community Platform](https://community.segment.com/product-updates).
- This PR changes the Release Notes menu link to Product Updates, and changes the URL from the previous LaunchNotes site to the new Community page.  

### Merge timing

- ASAP once approved.
