### PR TITLE
[STRATCONN-5303] Mapping tester not supported for actions-the-trade-desk-crm & actions-liveramp-audiences

### DIFF
--- a/src/connections/destinations/catalog/actions-liveramp-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-liveramp-audiences/index.md
@@ -41,6 +41,10 @@ The LiveRamp Audiences destination can be connected to **Twilio Engage sources o
 7. In the settings that appear in the side panel, toggle the Send Track option on and do not change the Audience Entered/Audience Exited event names. Click Save Settings
 8. File a [support case](https://docs.liveramp.com/connect/en/considerations-when-uploading-the-first-file-to-an-audience.html#creating-a-support-case){:target="_blank"} with the LiveRamp team to configure and enable ingestion.
 
+
+**Note**: Mapping tester will not be available for this destination. Batched events are required to activate the destination.
+
+
 {% include components/actions-fields.html settings="false"%}
 
 ## Limitations 

--- a/src/connections/destinations/catalog/actions-liveramp-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-liveramp-audiences/index.md
@@ -42,7 +42,7 @@ The LiveRamp Audiences destination can be connected to **Twilio Engage sources o
 8. File a [support case](https://docs.liveramp.com/connect/en/considerations-when-uploading-the-first-file-to-an-audience.html#creating-a-support-case){:target="_blank"} with the LiveRamp team to configure and enable ingestion.
 
 
-**Note**: Mapping tester will not be available for this destination. Batched events are required to activate the destination.
+**Note**: Mapping tester will not be available for this destination. Batched events are required to activate the destination. The destination can only be tested end-to-end with a source attached to it.
 
 
 {% include components/actions-fields.html settings="false"%}

--- a/src/connections/destinations/catalog/actions-liveramp-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-liveramp-audiences/index.md
@@ -41,9 +41,8 @@ The LiveRamp Audiences destination can be connected to **Twilio Engage sources o
 7. In the settings that appear in the side panel, toggle the Send Track option on and do not change the Audience Entered/Audience Exited event names. Click Save Settings
 8. File a [support case](https://docs.liveramp.com/connect/en/considerations-when-uploading-the-first-file-to-an-audience.html#creating-a-support-case){:target="_blank"} with the LiveRamp team to configure and enable ingestion.
 
-
-**Note**: Mapping tester will not be available for this destination. Batched events are required to activate the destination. The destination can only be tested end-to-end with a source attached to it.
-
+> info "Mapping tester availability"
+> The Mapping Tester isn't available for this destination. Since this destination requires batched events for activation, testing can only be performed end-to-end with a connected source.
 
 {% include components/actions-fields.html settings="false"%}
 

--- a/src/connections/destinations/catalog/actions-the-trade-desk-crm/index.md
+++ b/src/connections/destinations/catalog/actions-the-trade-desk-crm/index.md
@@ -45,12 +45,15 @@ Setup is now complete, and the audience starts syncing to The Trade Desk.
 
 To sync additional Audiences from your Engage space, create a separate instance of The Trade Desk CRM Destination.
 
+**Note**: Mapping tester will not be available for this destination. Batched events are required to activate the destination.
+
+
 {% include components/actions-fields.html settings="true"%}
 
 
 ## Limitations
 
-* An audience must have at least 1500 unique members; otherwise, the destination fails, and the data won't sync.
+* An audience must have at least 1500 unique members; otherwise, the destination fails, and the data won't sync. 
 * Audience attempts to sync once per day.
 * Audience sync is a full sync.
 

--- a/src/connections/destinations/catalog/actions-the-trade-desk-crm/index.md
+++ b/src/connections/destinations/catalog/actions-the-trade-desk-crm/index.md
@@ -45,8 +45,8 @@ Setup is now complete, and the audience starts syncing to The Trade Desk.
 
 To sync additional Audiences from your Engage space, create a separate instance of The Trade Desk CRM Destination.
 
-**Note**: Mapping tester will not be available for this destination. Batched events are required to activate the destination. The destination can only be tested end-to-end with a source attached to it.
-
+> info "Mapping tester availability"
+> The Mapping Tester is not available for The Trade Desk CRM destination. Since this destination requires batched events for activation, testing can only be performed end-to-end with a connected source.
 
 {% include components/actions-fields.html settings="true"%}
 

--- a/src/connections/destinations/catalog/actions-the-trade-desk-crm/index.md
+++ b/src/connections/destinations/catalog/actions-the-trade-desk-crm/index.md
@@ -45,7 +45,7 @@ Setup is now complete, and the audience starts syncing to The Trade Desk.
 
 To sync additional Audiences from your Engage space, create a separate instance of The Trade Desk CRM Destination.
 
-**Note**: Mapping tester will not be available for this destination. Batched events are required to activate the destination.
+**Note**: Mapping tester will not be available for this destination. Batched events are required to activate the destination. The destination can only be tested end-to-end with a source attached to it.
 
 
 {% include components/actions-fields.html settings="true"%}

--- a/src/connections/destinations/catalog/actions-the-trade-desk-crm/index.md
+++ b/src/connections/destinations/catalog/actions-the-trade-desk-crm/index.md
@@ -46,7 +46,7 @@ Setup is now complete, and the audience starts syncing to The Trade Desk.
 To sync additional Audiences from your Engage space, create a separate instance of The Trade Desk CRM Destination.
 
 > info "Mapping tester availability"
-> The Mapping Tester is not available for The Trade Desk CRM destination. Since this destination requires batched events for activation, testing can only be performed end-to-end with a connected source.
+> The Mapping Tester isn't available for this destination. Since this destination requires batched events for activation, testing can only be performed end-to-end with a connected source.
 
 {% include components/actions-fields.html settings="true"%}
 


### PR DESCRIPTION
### Proposed changes

The destinations, `actions-the-trade-desk-crm` & `actions-liveramp-audiences` aren't meant to support mapping tester as they use int outbound controller to batch data.

JIRA: https://segment.atlassian.net/browse/STRATCONN-5303

Updating docs accordingly.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

https://github.com/segmentio/app/pull/22444
