### PR TITLE
Updated destination dossier to note that some dests aren't supported in EU workspaces

### DIFF
--- a/src/_includes/content/destination-dossier.html
+++ b/src/_includes/content/destination-dossier.html
@@ -59,6 +59,7 @@
       <li>This destination is not compatible with <a href="/docs/connections/functions/insert-functions/">Destination Insert Functions.</a></li>
       {% endunless %}    
     {% endif %}
+  {% if thisDestination == '64c031541451bb784943f809' or thisDestination == '63e42d44b0a59908dc4cacc6' or thisDestination == '642440d46b66b3eeac42b581' %} <li>This destination is <b>not</b> supported in EU workspaces. For more information, see the <a href="/docs/guides/regional-segment/">Regional Segment</a> documentation.</li> {% endif %}
   {% if destinationInfo.status == "PUBLIC_BETA" %}<li>This destination is in <span class="release-pill">Beta</span></li>{% endif %}
   {% if page.engage == true %}<li>This destination is <b>only</b> compatible with <a href="/docs/engage">Twilio Engage</a>.</li>{% endif %}
 </ul>


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added a line to the destination dossier noting that Blackbaud Raiser's Edge NXT, Attio (Actions) and Encharge Cloud (Actions) are not supported in EU dests

![Screenshot 2024-12-04 at 2 20 45 PM](https://github.com/user-attachments/assets/fb2c5b4c-0585-4ee4-8f30-9fa401db1e8d)

### Merge timing
After approval from @joe-ayoub-segment 

### Related issues (optional)

