### PR TITLE
Entity property values in Linked audience builder are case-sensitive

### DIFF
--- a/src/engage/audiences/linked-audiences.md
+++ b/src/engage/audiences/linked-audiences.md
@@ -61,7 +61,8 @@ After creating your Linked Audience, you will be brought to the Overview page wi
 
 The linked audiences builder sources profile trait and event keys from the data warehouse. This data must be synced to the data warehouse through [Profiles Sync](/docs/unify/profiles-sync/overview/) before you can reference it in the linked audience builder. If there is a profile trait that exists in the Segment Profile that hasn’t successfully synced to the data warehouse yet, it will be grayed out so that it can’t be selected.
 
-The linked audience builder also returns a subset of available entity property key values, event property and context key values, and profile trait key values that you can select in the input field drop-down so that you don’t need to type in the exact value that you want to filter on. If you don’t see the value you’re looking for, you can manually enter it into the input field, and it is case-sensitive. 
+The linked audience builder also returns a subset of available entity property key values, event property and context key values, and profile trait key values that you can select in the input field drop-down. This eliminates the need to type in the exact value you want to filter on. If the value you’re looking for isn’t listed, you can manually enter it into the input field. Manually entered values are case-sensitive.
+
 Segment displays: 
 
 * the first 100 unique string entity property values from the data warehouse.

--- a/src/engage/audiences/linked-audiences.md
+++ b/src/engage/audiences/linked-audiences.md
@@ -61,7 +61,7 @@ After creating your Linked Audience, you will be brought to the Overview page wi
 
 The linked audiences builder sources profile trait and event keys from the data warehouse. This data must be synced to the data warehouse through [Profiles Sync](/docs/unify/profiles-sync/overview/) before you can reference it in the linked audience builder. If there is a profile trait that exists in the Segment Profile that hasn’t successfully synced to the data warehouse yet, it will be grayed out so that it can’t be selected.
 
-The linked audience builder also returns a subset of available entity property key values, event property and context key values, and profile trait key values that you can select in the input field drop-down so that you don’t need to type in the exact value that you want to filter on. If you don’t see the value you’re looking for, you can manually enter it into the input field. 
+The linked audience builder also returns a subset of available entity property key values, event property and context key values, and profile trait key values that you can select in the input field drop-down so that you don’t need to type in the exact value that you want to filter on. If you don’t see the value you’re looking for, you can manually enter it into the input field, and it is case-sensitive. 
 Segment displays: 
 
 * the first 100 unique string entity property values from the data warehouse.


### PR DESCRIPTION
### Proposed changes

If you don’t see the value you’re looking for, you can manually enter it into the input field, and it is case-sensitive.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
