### PR TITLE
Unable to view/edit the mapping as expected, and it is throwing a 'Co…

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -305,3 +305,7 @@ Threfore, if you see a 401 error in a sample response, it is likely that you’l
 ### Is it possible to map a field from one event to another?
 
 Segment integrations process events through mappings individially. This means that no context is held that would allow you to map a value from one event to the field of a subsequent event. Each event itself must contain all of the data you'd like to send downstream in regards to it. For example, you cannot send `email` in on an Identify call and then access that same `email` field on a Track call that comes in later if that Track call doesn't also have `email` set on it. 
+
+### Unable to view/edit the mapping as expected, and it is throwing a 'Couldn't load page' error.
+
+It might be due to the browser cache or the event property name containing a "/". To resolve this, try clearing the browser cache or accessing the mapping page in an Incognito window. Additionally, check if the property name mapped in the mapping contains a "/". If so, please try renaming the property name without the "/" and map it in the mapping to avoid this error.


### PR DESCRIPTION
### Proposed changes

Unable to view/edit the mapping as expected, and it is throwing a 'Couldn't load page' error.

It might be due to the browser cache or the event property name containing a "/". To resolve this, try clearing the browser cache or accessing the mapping page in an Incognito window. Additionally, check if the property name mapped in the mapping contains a "/". If so, please try renaming the property name without the "/" and map it in the mapping to avoid this error.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
