### PR TITLE
Update process for requesting account-level Audiences

### DIFF
--- a/src/engage/audiences/account-audiences.md
+++ b/src/engage/audiences/account-audiences.md
@@ -23,8 +23,10 @@ You can use account-level audiences to accomplish the following use cases:
 
 ## Enable account-level audiences
 
-1. Contact [friends@segment.com](mailto:friends@segment.com) and provide your workspace ID to have account-level audiences enabled for your workspace. Navigate to **Settings > Workspace Settings > General Settings** to view your workspace ID.
-2. Ensure that `group_id` is configured as an identifier in Engage Identity Resolution settings. For more information, see [Identity Resolution Settings](/docs/unify/identity-resolution/identity-resolution-settings/).
+1. Contact [friends@segment.com](mailto:friends@segment.com) to request the feature. Include the following information in your request:
+   - Your Workspace ID: Navigate to **Settings > Workspace Settings > General Settings** to view your workspace ID.
+   - A brief description of your intended use cases for account-level audiences.
+2. If your workspace has the feature enabled, ensure that `group_id` is configured as an identifier in Engage Identity Resolution settings. For more information, see [Identity Resolution Settings](/docs/unify/identity-resolution/identity-resolution-settings/).
 3. Instrument [group](/docs/connections/spec/group/) calls to send account information to Segment.
 
 ## Account-level audience conditions

--- a/src/engage/audiences/account-audiences.md
+++ b/src/engage/audiences/account-audiences.md
@@ -27,7 +27,7 @@ You can use account-level audiences to accomplish the following use cases:
    - **Your Workspace ID** (which you can find in **Settings > Workspace Settings > General Settings**)
    - **Your intended use cases** for account-level audiences
 2. If your workspace has account-level audiences enabled, ensure that `group_id` is configured as an identifier in Engage [Identity Resolution settings](/docs/unify/identity-resolution/identity-resolution-settings/).
-3. Instrument [group](/docs/connections/spec/group/) calls to send account information to Segment.
+3. Instrument [Group calls](/docs/connections/spec/group/) to send account information to Segment.
 
 ## Account-level audience conditions
 

--- a/src/engage/audiences/account-audiences.md
+++ b/src/engage/audiences/account-audiences.md
@@ -23,10 +23,10 @@ You can use account-level audiences to accomplish the following use cases:
 
 ## Enable account-level audiences
 
-1. Contact [friends@segment.com](mailto:friends@segment.com) to request the feature. Include the following information in your request:
-   - Your Workspace ID: Navigate to **Settings > Workspace Settings > General Settings** to view your workspace ID.
-   - A brief description of your intended use cases for account-level audiences.
-2. If your workspace has the feature enabled, ensure that `group_id` is configured as an identifier in Engage Identity Resolution settings. For more information, see [Identity Resolution Settings](/docs/unify/identity-resolution/identity-resolution-settings/).
+1. Contact [friends@segment.com](mailto:friends@segment.com) to request account-level audiences. Include:
+   - **Your Workspace ID** (which you can find in **Settings > Workspace Settings > General Settings**)
+   - **Your intended use cases** for account-level audiences
+2. If your workspace has account-level audiences enabled, ensure that `group_id` is configured as an identifier in Engage [Identity Resolution settings](/docs/unify/identity-resolution/identity-resolution-settings/).
 3. Instrument [group](/docs/connections/spec/group/) calls to send account information to Segment.
 
 ## Account-level audience conditions


### PR DESCRIPTION
Following evaluation of account audiences, engineering has asked that we shared any new client interest with them before enabling the feature. DOC: https://docs.google.com/document/d/1hqOgLUOJduIlT8XNrWYl_lerohCQ6VMqcW3Le1l-QcE/edit?tab=t.0

Process to enable the feature has now changed: https://paper.dropbox.com/doc/Managing-personas-features--Cco8dpkjoNSQ5N1BKIFoxSrpAg-t0B5UflREC374I6Z0RHj1

### Merge timing
- ASAP once approved
