### PR TITLE
Add explanation for session_id not automatically added to web events

### DIFF
--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -243,11 +243,38 @@ In the following example, the Amplitude User property `friendCount` equals 4.
 ```
 ## FAQ and troubleshooting
 
-### Why doesn't Segment automatically add the `session_id` to my web events?
-For Segment to automatically add the `session_id` to events, your browser must allow the following request URL to load:
+### Does Segment load the Amplitude SDK on the webpage to collect data?
+Segment does not load the Amplitude SDK directly on the webpage. Instead, Segment collects data using our Analytics.js library. Once events reach Segment’s servers, they are forwarded to Amplitude’s servers using Amplitude’s HTTP API.
 
+### How does Segment handle the Amplitude session ID?
+Although the Amplitude SDK is not loaded, the Analytics.js library includes a plugin that sets the Amplitude session ID on the device. This session ID is used to track sessions and is automatically attached to events sent to Amplitude. By default, the session ID is set to timeout after 30 minutes of inactivity. You can review the code implementation for setting the [session ID here](https://github.com/segmentio/action-destinations/blob/12255568e4a6d35cf05ee79a118ee6c1a6823f31/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts#L33){:target="_blank”}.
+
+###  How can I retrieve the Amplitude session ID set by Segment?
+Since Segment does not load the Amplitude SDK, the Amplitude native method `amplitude.getInstance()._sessionId` will not work. However, you can retrieve the session ID using the following method:
+
+``` js
+localStorage.getItem('analytics_session_id');
 ```
+
+This call accesses the session ID stored in the browser's local storage. You can review the [retrieval code here](https://github.com/segmentio/action-destinations/blob/12255568e4a6d35cf05ee79a118ee6c1a6823f31/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts#L64 ){:target="_blank”}.
+
+###  Why is Segment not automatically adding the session_id to my Web Events?
+
+For Segment to automatically add the session_id to your web events, your website must allow the following URL to load:
+
+``` js
 https://cdn.segment.com/next-integrations/actions/amplitude-plugins/..
 ```
 
-To check if you are loading this request, [inspect the network requests](https://developer.chrome.com/docs/devtools/network){:target="_blank”} on your website and look for 'Amplitude.' If the request is not loading, confirm it is allowed on your side.
+How to Check:
+
+  1. Open your browser’s developer tools and [inspect the network requests](https://developer.chrome.com/docs/devtools/network){:target="_blank”} on your website.
+  2. Look for a request related to Amplitude.
+
+If the request is missing:
+
+  -  Ensure your browser settings or network configuration allow this URL to load.
+  -  Check for any third-party script blockers or restrictions that might be preventing it.
+  
+If you still encounter issues, feel free to reach out for support!
+

--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -241,40 +241,36 @@ In the following example, the Amplitude User property `friendCount` equals 4.
 "traits" : {"$add": {"friendCount": 3} }
 "traits" : {"$add": {"friendCount": 1} }
 ```
-## FAQ and troubleshooting
+## FAQs and troubleshooting
 
 ### Does Segment load the Amplitude SDK on the webpage to collect data?
-Segment does not load the Amplitude SDK directly on the webpage. Instead, Segment collects data using our Analytics.js library. Once events reach Segment’s servers, they are forwarded to Amplitude’s servers using Amplitude’s HTTP API.
+Segment doesn't load the Amplitude SDK directly on the webpage. Instead, Segment collects data using the Analytics.js library. Once events reach Segment’s servers, they are forwarded to Amplitude’s servers using Amplitude’s HTTP API.
 
 ### How does Segment handle the Amplitude session ID?
-Although the Amplitude SDK is not loaded, the Analytics.js library includes a plugin that sets the Amplitude session ID on the device. This session ID is used to track sessions and is automatically attached to events sent to Amplitude. By default, the session ID is set to timeout after 30 minutes of inactivity. You can review the code implementation for setting the [session ID here](https://github.com/segmentio/action-destinations/blob/12255568e4a6d35cf05ee79a118ee6c1a6823f31/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts#L33){:target="_blank”}.
+The Analytics.js library includes a plugin that sets the Amplitude session ID on the device. This session ID is used to track sessions and is automatically attached to events sent to Amplitude. By default, the session ID is set to timeout after 30 minutes of inactivity. You can review the code implementation for setting the [session ID](https://github.com/segmentio/action-destinations/blob/12255568e4a6d35cf05ee79a118ee6c1a6823f31/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts#L33){:target="_blank”}.
 
 ###  How can I retrieve the Amplitude session ID set by Segment?
-Since Segment does not load the Amplitude SDK, the Amplitude native method `amplitude.getInstance()._sessionId` will not work. However, you can retrieve the session ID using the following method:
+Since Segment doesn't load the Amplitude SDK, the Amplitude native method `amplitude.getInstance()._sessionId` won't work. You can retrieve the session ID using the this method:
 
 ``` js
 localStorage.getItem('analytics_session_id');
 ```
 
-This call accesses the session ID stored in the browser's local storage. You can review the [retrieval code here](https://github.com/segmentio/action-destinations/blob/12255568e4a6d35cf05ee79a118ee6c1a6823f31/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts#L64 ){:target="_blank”}.
+This call accesses the session ID stored in the browser's local storage. You can review the [retrieval code](https://github.com/segmentio/action-destinations/blob/12255568e4a6d35cf05ee79a118ee6c1a6823f31/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts#L64){:target="_blank”}.
 
 ###  Why is Segment not automatically adding the session_id to my Web Events?
 
-For Segment to automatically add the session_id to your web events, your website must allow the following URL to load:
+For Segment to automatically add the session_id to your web events, your website must allow the following URL:
 
 ``` js
 https://cdn.segment.com/next-integrations/actions/amplitude-plugins/..
 ```
 
-How to Check:
+To check if your website allows the URL:
 
-  1. Open your browser’s developer tools and [inspect the network requests](https://developer.chrome.com/docs/devtools/network){:target="_blank”} on your website.
-  2. Look for a request related to Amplitude.
+1. Open your browser’s developer tools and [inspect the network requests](https://developer.chrome.com/docs/devtools/network){:target="_blank”} on your website.
+2. Look for a request related to Amplitude.
 
 If the request is missing:
-
-  -  Ensure your browser settings or network configuration allow this URL to load.
-  -  Check for any third-party script blockers or restrictions that might be preventing it.
-  
-If you still encounter issues, feel free to reach out for support!
-
+   * Ensure your browser settings or network configuration allow the URL to load.
+   * Check for any third-party script blockers or restrictions that might prevent it.

--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -258,7 +258,7 @@ localStorage.getItem('analytics_session_id');
 
 This call accesses the session ID stored in the browser's local storage. You can review the [retrieval code](https://github.com/segmentio/action-destinations/blob/12255568e4a6d35cf05ee79a118ee6c1a6823f31/packages/browser-destinations/destinations/amplitude-plugins/src/sessionId/index.ts#L64){:target="_blank”}.
 
-###  Why is Segment not automatically adding the session_id to my Web Events?
+###  Why doesn't Segment automatically add the session_id to my Web Events?
 
 For Segment to automatically add the session_id to your web events, your website must allow the following URL:
 


### PR DESCRIPTION
### Proposed changes

1. Added an FAQ explaining how to retrieve the Amplitude session_id set by Segment, with links to relevant code in GitHub.
2. Improved the FAQ about why Segment may not automatically add the session_id to web events, including troubleshooting steps.


### Merge timing
ASAP once approved