### PR TITLE
Update default Traits return count

### DIFF
--- a/src/unify/profile-api.md
+++ b/src/unify/profile-api.md
@@ -115,7 +115,7 @@ You can query a user's traits (such as `first_name`, `last_name`, and more):
 
 `https://profiles.segment.com/v1/spaces/<space_id>/collections/users/profiles/<external_id>/traits`
 
-By default, the response includes 20 traits. You can return up to 200 traits by appending `?limit=200` to the querystring. If you wish to return a specific trait, append `?include={trait}` to the querystring (for example `?include=age`). You can also use the ``?class=audience​`` or ``?class=computed_trait​`` URL parameters to retrieve audiences or computed traits specifically.
+By default, the response includes 10 traits. You can return up to 200 traits by appending `?limit=200` to the querystring. If you wish to return a specific trait, append `?include={trait}` to the querystring (for example `?include=age`). You can also use the ``?class=audience​`` or ``?class=computed_trait​`` URL parameters to retrieve audiences or computed traits specifically.
 
 **Metadata**
 You can query all of a user's metadata (such as `created_at`, `updated_at`, and more):


### PR DESCRIPTION
### Proposed changes

Update the default limit of returned traits from the Profile API `/traits` endpoint from `20` → `10`

### Merge timing
- ASAP once approved

### Related issues (optional)
[This was most recently discussed & confirmed by Engineering in this Slack Thread](https://twilio.slack.com/archives/CPTA3GE2H/p1731097035052389?thread_ts=1731095987.309049&cid=CPTA3GE2H)