### PR TITLE
Clarify Page and Screen calls in Audience Builder

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -28,7 +28,7 @@ You can build an Audience from existing events, traits, computed traits, or othe
 
 ### Events
 
-You can build an Audience from any events that are connected to Engage, including [Track](/docs/connections/spec/track), [Page](/docs/connections/spec/page), and [Screen](/docs/connections/spec/screen) calls. You can use the `property` button to refine the audience on specific event properties, as well. 
+You can build an Audience from any events that are connected to Engage, including [Track](/docs/connections/spec/track), [Page](/docs/connections/spec/page), and [Screen](/docs/connections/spec/screen) calls. In the Audience builder, Page calls will appear as `Page Viewed` and Screen calls will be `Screen Viewed`. You can use the `property` button to refine the audience on specific event properties as well. 
 
 > info ""
 > The Audience builder doesn't return every property value in the Constant value or Traits drop-downs. Segment displays a portion of values from the incoming data stream. However, if you don't see the value you're looking for, you can manually enter it.


### PR DESCRIPTION
### Proposed changes

This update clarifies how Page and Screen calls will appear in the Audience builder.

### Merge timing
ASAP is fine