### PR TITLE
clarify where traits appear with ID Sync on Track calls

### DIFF
--- a/src/engage/trait-activation/id-sync.md
+++ b/src/engage/trait-activation/id-sync.md
@@ -73,3 +73,6 @@ Audiences without ID Sync aren't allowed to select any strategy, and by default 
 
 #### Can I edit config once the audience has synced? 
 Yes, you can edit configuration in the Destination **Settings** tab at any time. However, changes will only take place in subsequent audience syncs, or in new audiences connected to the destination.
+
+#### Where are traits added onto Track calls?
+When you use ID Sync with a Track call, all custom identifiers and traits will be added to the `properties` object except the `email` field. The `email` field, if it exists, will populate in the `context.traits` object.


### PR DESCRIPTION
### Proposed changes

This update clarifies where traits will appear when added to Track calls with ID sync per this explanation: https://twilio.slack.com/archives/C7F3N3RV4/p1734325433264419. 

### Merge timing
ASAP is fine