### PR TITLE
Add note linking to role in attribution

### DIFF
--- a/src/connections/destinations/catalog/appsflyer/index.md
+++ b/src/connections/destinations/catalog/appsflyer/index.md
@@ -265,8 +265,8 @@ For example, an attribution event coming from an attribution partner would look 
 }];
 ```
 
-> info ""
-> Attribution and install counts can differ between Segment and attribution providers like AppsFlyer. You can read more about this in our guide [Segment's Role in Attribution](https://segment.com/docs/guides/how-to-guides/segment-and-attribution/){:target="_blank"}
+> info "Attribution and install counts might differ between Segment and attribution providers like AppsFlyer"
+> For more information about the factors that contribute to these differences, see the [Segment's Role in Attribution](/docs/guides/how-to-guides/segment-and-attribution/) documentation.
 
 ## Other Features
 

--- a/src/connections/destinations/catalog/appsflyer/index.md
+++ b/src/connections/destinations/catalog/appsflyer/index.md
@@ -265,6 +265,9 @@ For example, an attribution event coming from an attribution partner would look 
 }];
 ```
 
+> info ""
+> Attribution and install counts can differ between Segment and attribution providers like AppsFlyer. You can read more about this in our guide [Segment's Role in Attribution](https://segment.com/docs/guides/how-to-guides/segment-and-attribution/){:target="_blank"}
+
 ## Other Features
 
 ### Revenue Tracking


### PR DESCRIPTION

### Proposed changes

Added an info box linking to the documentation on Segment's role in attribution. Customers occasionally write in asking about difference in counts between segment and downstream attribution tools. 

### Merge timing
- ASAP once approved

### Related issues (optional)

n/a
