### PR TITLE
Typo fix

### DIFF
--- a/src/connections/destinations/catalog/actions-amplitude/index.md
+++ b/src/connections/destinations/catalog/actions-amplitude/index.md
@@ -51,7 +51,7 @@ To manually add the Log Purchases Action:
 
 ### Connection Modes for Amplitude (Actions) destination
 
-The Amplitude (Actions) destination does not offer a device-mode connection mode. Previous deployments of the Amplitude Segment destination required the device-mode connection to use the `session_id` tracking feature. However, the Amplitude (Actions) destination now includes session ID tracking by default when you use Segment's ([Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/) library.
+The Amplitude (Actions) destination does not offer a device-mode connection mode. Previous deployments of the Amplitude Segment destination required the device-mode connection to use the `session_id` tracking feature. However, the Amplitude (Actions) destination now includes session ID tracking by default when you use Segment's [Analytics.js 2.0](/docs/connections/sources/catalog/libraries/website/javascript/) library.
 
 ### Track sessions
 


### PR DESCRIPTION
Remove "(" from sentence where it isn't needed

### Proposed changes
<img width="693" alt="Screenshot 2025-01-10 at 4 26 20 PM" src="https://github.com/user-attachments/assets/c0588c56-daa0-40f8-b560-84d2c169b17f" />

### Merge timing
- ASAP once approved

### Related issues (optional)

