### PR TITLE
Segment Startup Program Closed Down

### DIFF
--- a/src/_data/sidenav/main.yml
+++ b/src/_data/sidenav/main.yml
@@ -102,8 +102,6 @@ sections:
       title: 'MTUs, Throughput and Billing'
     - path: /guides/usage-and-billing/discounts-for-startups-npos
       title: Discounts or Coupons
-    - path: /guides/usage-and-billing/startup-program
-      title: Segment Startup Program
 - section_title: Connections
   section:
   - path: /connections

--- a/src/guides/usage-and-billing/startup-program.md
+++ b/src/guides/usage-and-billing/startup-program.md
@@ -4,9 +4,9 @@ hidden: true
 ---
 
 > info "Startup program discontinued"
-> As of January 6, 2025, Segment no longer accepts new or second-year renewal applications for the Segment Startup Program. 
+> As of January 6, 2025, Segment discontinued its Startup Program. Segment no longer accepts new or second-year renewal applications for the Program.
 
-Segment offers a **Startup Program** to enable early startups to track data correctly and test the marketing and analytics tools necessary to grow their business. The program is open to any early-stage startup that meets the following eligibility requirements:
+Segment offered a **Startup Program** to enable early startups to track data correctly and test the marketing and analytics tools necessary to grow their business. The program is open to any early-stage startup that meets the following eligibility requirements:
 
 - Incorporated less than two years ago
 - Raised no more than $5MM in total funding

--- a/src/guides/usage-and-billing/startup-program.md
+++ b/src/guides/usage-and-billing/startup-program.md
@@ -1,30 +1,27 @@
 ---
 title: Segment Startup Program
+hidden: true
 ---
+
+> info "Startup program discontinued"
+> As of January 6, 2025, Segment no longer accepts new or second-year renewal applications for the Segment Startup Program. 
 
 Segment offers a **Startup Program** to enable early startups to track data correctly and test the marketing and analytics tools necessary to grow their business. The program is open to any early-stage startup that meets the following eligibility requirements:
 
-
 - Incorporated less than two years ago
 - Raised no more than $5MM in total funding
-- Located in Google Cloud [eligible territory](https://cloud.google.com/terms/cloud-sales-list)
+- Located in Google Cloud [eligible territory](https://cloud.google.com/terms/cloud-sales-list){:target="_blank"}
 - haven't previously received other Segment discounts
 
 The Segment Startup Program includes three components:
 
-- Segment's **Startup Deal** - Participating startups receive $25,000* in annual credit toward our monthly [Team plan](https://segment.com/pricing/) for as long as they meet our eligibility requirements (up to 2 years).
+- Segment's **Startup Deal** - Participating startups receive $25,000* in annual credit toward our monthly [Team plan](https://segment.com/pricing/){:target="_blank"} for as long as they meet our eligibility requirements (up to 2 years).
 - Partner **Startup Deals** - Segment partners with other technology companies that offer valuable tools for startups to offer exclusive deals and promotions from marketing, data warehouse, and analytics tools.
 - **Startup Resources** - Segment offers learning materials on topics like analytics, product-market fit, and more for founders to become experts on data analytics and making the most of Segment's technology.
 
 Interested companies can apply on the [Startup Program](http://segment.com/industry/startups){:target="_blank”} site.
 
-> info "Application deadline"
-> Effective January 6, 2025, Segment will no longer accept applications for the Segment Startup Program. Applications submitted before 11:59 PM PT on December 5, 2024 will be reviewed and honored. However, any applications received after this deadline will not be accepted. There will be no exceptions.
-
-*Can vary based on affiliated accelerator and VC partners.
-
-
-## Frequently Asked Questions
+## Frequently asked questions
 
 **How are the Segment credits applied?**
 Credits are applied to your monthly bill, covering up to $25,000* in total usage per year. Any additional usage costs are not covered by the program.

--- a/src/guides/usage-and-billing/startup-program.md
+++ b/src/guides/usage-and-billing/startup-program.md
@@ -23,6 +23,9 @@ Interested companies can apply on the [Startup Program](http://segment.com/indus
 
 ## Frequently asked questions
 
+**Is the Segment Startup Program still active?**
+No. As of January 2025, Segment no longer accepts applications for the Segment Startup Program.
+
 **How are the Segment credits applied?**
 Credits are applied to your monthly bill, covering up to $25,000* in total usage per year. Any additional usage costs are not covered by the program.
 
@@ -33,9 +36,9 @@ Eligible startups can [apply directly](http://segment.com/industry/startups) for
 If you've been accepted to the program, you'll receive an email with a welcome message and next steps. If you haven't received an email, you can also check in your Segment workspace and look for a Startup Program icon in the top right corner.
 
 **Where can I view the credits applied to my Segment account?**
-The Startup Program credits are reflected in the Workspace usage and billing page.
+Startup Program credits are reflected in the Workspace usage and billing page.
 
-**Do I have to be a "new" customer to receive a coupon?**
+**Do I have to be a new customer to receive a coupon?**
 New and current Segment users who have not previously received any other coupon are eligible to apply.
 
 **What happens if I go over my total credit applied?**

--- a/src/guides/usage-and-billing/startup-program.md
+++ b/src/guides/usage-and-billing/startup-program.md
@@ -11,7 +11,7 @@ Segment offered a **Startup Program** to enable early startups to track data cor
 - Incorporated less than two years ago
 - Raised no more than $5MM in total funding
 - Located in Google Cloud [eligible territory](https://cloud.google.com/terms/cloud-sales-list){:target="_blank"}
-- haven't previously received other Segment discounts
+- Hasn't previously received other Segment discounts
 
 The Segment Startup Program includes three components:
 


### PR DESCRIPTION
### Proposed changes

- Segment has shut down the Segment Startup Program, effective 6 January 2025.
- This PR changes the info box to say that the program is no longer open to new or renewal applications.
- It also adds an FAQ reinforcing that the program is closed.
- For now, we're going to just hide the page (though we may remove it at some point). To that end, I removed it from the side navigation.

### Merge timing

- ASAP once approved.

### Related issues (optional)

#7347 
