### PR TITLE
Add note to Protocols FAQ about mobile device mode destinations

### DIFF
--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -146,7 +146,11 @@ That being said, there are plenty of scenarios where the reactive Schema functio
 
 ### If I enable blocking, what happens to the blocked events? Are events just blocked from specific Destinations or the entire Segment pipeline?
 
-Blocked events are blocked from sending to all Segment Destinations, including warehouses and streaming Destinations. When an Event is blocked using a Tracking Plan, it does not count towards your MTU limit. They will, however, count toward your MTU limit if you enable [blocked event forwarding](/docs/protocols/enforce/forward-blocked-events/) in your Source settings.
+Segment can block events from all Segment Destinations except for mobile device mode destinations. 
+
+Events that are delivered from a mobile source in device mode bypass the point in the Segment pipeline where Segment blocks events, so mobile events sent using device mode are not blocked and are delivered to your Destinations. If you are a Business Tier customer using Segment's [Swift](/docs/connections/sources/catalog/libraries/mobile/apple/) or [Kotlin](/docs/connections/sources/catalog/libraries/mobile/kotlin-android/) SDKs, you can use [destination filters](/docs/connections/destinations/destination-filters/) to block events. 
+
+When an event is blocked using a Tracking Plan, it does not count towards your MTU limit. If you use [blocked event forwarding](/docs/protocols/enforce/forward-blocked-events/), blocked events forwarded to a new source will count toward your MTU limit.
 
 ### If I omit unplanned properties or properties that generate JSON schema violations, what happens to them?
 

--- a/src/protocols/faq.md
+++ b/src/protocols/faq.md
@@ -144,7 +144,7 @@ The schema functionality is a _reactive_ way to clean up your data, where the Tr
 
 That being said, there are plenty of scenarios where the reactive Schema functionality solves immediate needs for customers. Often times, customers will use both Schema Controls and Tracking Plan functionality across their Segment Sources. For smaller volume Sources with less important data, the Schema functionality often works perfectly.
 
-### If I enable blocking, what happens to the blocked events? Are events just blocked from specific Destinations or the entire Segment pipeline?
+### If I enable blocking are events just blocked from specific Destinations or the entire Segment pipeline?
 
 Segment can block events from all Segment Destinations except for mobile device mode destinations. 
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
See title - mobile device mode destinations can not be blocked unless you use destination filters. I've updated answer accordingly ([Slack thread for ref](https://twilio.slack.com/archives/CALA7QMJQ/p1737043189977339))

### Merge timing
asap!

### Related issues (optional)
Closes #5469 
