### PR TITLE
Add details on how Page/Screen name property surface in Audience builder

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -28,10 +28,12 @@ You can build an Audience from existing events, traits, computed traits, or othe
 
 ### Events
 
-You can build an Audience from any events that are connected to Engage, including [Track](/docs/connections/spec/track), [Page](/docs/connections/spec/page), and [Screen](/docs/connections/spec/screen) calls. In the Audience builder, Page calls will appear as `Page Viewed` and Screen calls will be `Screen Viewed`. You can use the `property` button to refine the audience on specific event properties as well. 
+You can build an Audience from any events that are connected to Engage, including [Track](/docs/connections/spec/track), [Page](/docs/connections/spec/page), and [Screen](/docs/connections/spec/screen) calls. In the Audience builder, Page calls will appear as `Page Viewed` and Screen calls will be `Screen Viewed`.
 
 > info ""
-> The Audience builder doesn't return every property value in the Constant value or Traits drop-downs. Segment displays a portion of values from the incoming data stream. However, if you don't see the value you're looking for, you can manually enter it.
+> You can use the `+ property` button to refine the audience on specific event properties as well.
+> - The `name` property for Page and Screen calls will be surfaced in the Audience builder as `page_name` and `screen_name`, respectively. 
+> - The Audience builder doesn't return every property value in the Constant value or Traits drop-downs. Segment displays a portion of values from the incoming data stream. However, if you don't see the value you're looking for, you can manually enter it.
 
 Select `and not who` to indicate users that have not performed an event. For example, you might want to look at all users that have viewed a product above a certain price point but not completed the order.
 

--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -28,12 +28,11 @@ You can build an Audience from existing events, traits, computed traits, or othe
 
 ### Events
 
-You can build an Audience from any events that are connected to Engage, including [Track](/docs/connections/spec/track), [Page](/docs/connections/spec/page), and [Screen](/docs/connections/spec/screen) calls. In the Audience builder, Page calls will appear as `Page Viewed` and Screen calls will be `Screen Viewed`.
+You can build an Audience from any events connected to Engage, including [Track](/docs/connections/spec/track), [Page](/docs/connections/spec/page), and [Screen](/docs/connections/spec/screen) calls. In the Audience builder, Page calls appear as `Page Viewed` and Screen calls appear as `Screen Viewed`.
 
-> info ""
-> You can use the `+ property` button to refine the audience on specific event properties as well.
-> - The `name` property for Page and Screen calls will be surfaced in the Audience builder as `page_name` and `screen_name`, respectively. 
-> - The Audience builder doesn't return every property value in the Constant value or Traits drop-downs. Segment displays a portion of values from the incoming data stream. However, if you don't see the value you're looking for, you can manually enter it.
+To refine the audience based on event properties, use the `+property` button:
+- The `name` property for Page and Screen calls appears in the Audience builder as `page_name` and `screen_name`, respectively. 
+- The Audience builder doesn't return every property value in the Constant value or Traits drop-downs. Segment shows a subset of values from the incoming data stream. If you don't see the value you're looking for, you can manually enter it.
 
 Select `and not who` to indicate users that have not performed an event. For example, you might want to look at all users that have viewed a product above a certain price point but not completed the order.
 


### PR DESCRIPTION
In the audience builder, the name property for page and screen calls will show up as page_name and screen_name, respectively, instead of name (which is what shows up in the actual event).  This update is to call out to customers about this distinction.


### Merge timing
<!-- When should this get merged/published?
ASAP :) 

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
