### PR TITLE
Ajs: events exceeding 32 KB limit gets 400 error response

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/faq.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/faq.md
@@ -9,7 +9,7 @@ Analytics.js doesn't automatically collect IPv6 addresses. If IPv6 is available 
 
 ## Is there a size limit on requests?
 
-Yes, the limit is 32KB per event message. Events with a payload larger than 32KB are accepted by Analytics.js and Segment servers return a `200` response , but the event is silently dropped once it enters Segment's pipeline. 
+Yes, the limit is 32KB per event message. Events with a payload larger than 32KB are not accepted by Analytics.js, and Segment servers will return a 400 response with the error message: "Exceed payload limit".
 
 ## If Analytics.js fails to load, are callbacks not fired?
 

--- a/src/connections/sources/catalog/libraries/website/javascript/faq.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/faq.md
@@ -9,7 +9,7 @@ Analytics.js doesn't automatically collect IPv6 addresses. If IPv6 is available 
 
 ## Is there a size limit on requests?
 
-Yes, the limit is 32KB per event message. Events with a payload larger than 32KB are not accepted by Analytics.js, and Segment servers will return a 400 response with the error message: "Exceed payload limit".
+Yes, the limit is 32KB per event message. Events with a payload larger than 32KB are not accepted by Analytics.js. Segment servers return a 400 response with the error message: `Exceed payload limit`.
 
 ## If Analytics.js fails to load, are callbacks not fired?
 


### PR DESCRIPTION
### Proposed changes
Clarified that events exceeding the 32 KB limit are now dropped with a 400 error response.

### Merge timing
ASAP once approved

![image](https://github.com/user-attachments/assets/21a980b2-8093-4387-8d9d-fa36f1f9334d)
