### PR TITLE
Unplanned event blocking: device-mode on Web only

### DIFF
--- a/src/protocols/enforce/schema-configuration.md
+++ b/src/protocols/enforce/schema-configuration.md
@@ -45,7 +45,7 @@ For example, if you include a `Subscription Cancelled` event in your Tracking Pl
     analytics.track('subscription_cancelled')
 ```
 
-**IMPORTANT: Unplanned event blocking is supported across all device-mode and cloud-mode Destinations.**
+**IMPORTANT: Unplanned event blocking is supported for: All Analytics.js Destinations (both device-mode and cloud-mode) and Mobile libraries (only in cloud-mode).**
 
 ## Track Calls - Unplanned Properties
 


### PR DESCRIPTION
### Proposed changes
Clarifying that unplanned event blocking is supported in device-mode on web, but not on mobile

### Merge timing
ASAP once approved