### PR TITLE
Add recommendation to ID Syncs page about Segment prop > destination prop mappings

### DIFF
--- a/src/engage/trait-activation/id-sync.md
+++ b/src/engage/trait-activation/id-sync.md
@@ -57,7 +57,7 @@ With Customized setup, you can choose which identifiers you want to map downstre
 - ID Sync used on existing audience destinations or destination functions won't resync the entire audience. Only new data flowing into Segment follows your ID Sync configuration. 
 - Segment doesn't maintain ID Sync history, which means that any changes are irreversible. 
 - You can only select a maximum of three identifiers with an `All` strategy.
-- Segment recommends that you map Segment properties to destination properties using [Destination Actions](/docs/connections/destinations/actions/#components-of-a-destination-action) instead of ID Sync.
+- Segment recommends that you map Segment properties to destination properties using [Destination Actions](/docs/connections/destinations/actions/#components-of-a-destination-action) instead of ID Sync. If you use ID Sync to map properties, Segment adds the property values as traits and identifiers to your Profiles. 
 
 
 ## FAQs

--- a/src/engage/trait-activation/id-sync.md
+++ b/src/engage/trait-activation/id-sync.md
@@ -57,6 +57,7 @@ With Customized setup, you can choose which identifiers you want to map downstre
 - ID Sync used on existing audience destinations or destination functions won't resync the entire audience. Only new data flowing into Segment follows your ID Sync configuration. 
 - Segment doesn't maintain ID Sync history, which means that any changes are irreversible. 
 - You can only select a maximum of three identifiers with an `All` strategy.
+- Segment recommends that you map Segment properties to destination properties using [Destination Actions](/docs/connections/destinations/actions/#components-of-a-destination-action) instead of ID Sync.
 
 
 ## FAQs


### PR DESCRIPTION
### Proposed changes
Added a note to the Limits and best practices section of the ID sync docs at the request of PMs recommending that customers use Actions dests rather than ID sync to map properties from Segment > downstream destinations

### Merge timing
asap!

### Related issues (optional)
PD-2617
