### PR TITLE
Fix broken link in Consent docs

### DIFF
--- a/src/privacy/consent-management/consent-in-unify.md
+++ b/src/privacy/consent-management/consent-in-unify.md
@@ -47,7 +47,7 @@ If you use Protocols, the Segment app automatically adds the Segment Consent Pre
 
 ### Sharing consent with Actions destinations
 
-In addition to enforcing consent in Connections, you may want these preferences to flow to each destination so your destinations can be aware when an end-user revokes their consent. You can use the [Destination Actions framework](/docs/connections/destinations/destination-actions) to edit the destination's mapping and copy the consent preferences from the Segment Consent Preference Updated event to a destination-specified consent field. 
+In addition to enforcing consent in Connections, you may want these preferences to flow to each destination so your destinations can be aware when an end-user revokes their consent. You can use the [Destination Actions framework](/docs/connections/destinations/actions) to edit the destination's mapping and copy the consent preferences from the Segment Consent Preference Updated event to a destination-specified consent field. 
 
 If you use Destination Actions to send consent information to your destinations, the Segment Consent Preference Updated event should **only** include information about a user's consent preferences because this event is sent regardless of an end-user's consent preferences. 
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Fixed a broken link that points to the Destination Actions page in the Consent in Unify docs.

### Merge timing
asap!

### Related issues (optional)
Closes #7440 
