### PR TITLE
Add data retention policy to side navigation

### DIFF
--- a/src/_data/sidenav/main.yml
+++ b/src/_data/sidenav/main.yml
@@ -591,6 +591,8 @@ sections:
       title: Consent in Reverse ETL
     - path: /privacy/consent-management/consent-faq
       title: Consent FAQs
+  - path: /privacy/data-retention-policy
+    title: Data Retention and Deletion Policy
   - path: /privacy/account-deletion
     title: Account & Data Deletion
   - path: /privacy/hipaa-eligible-segment


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Add Data Retention and Deletion Policy to sidebar at direction of the PM. Was previously hidden to allow for a lowkey final review before being sent out with customer comms

### Merge timing
3/11 at 7 AM PST 

### Related issues (optional)
#7377 
