### PR TITLE
unencoded example

### DIFF
--- a/src/connections/sources/catalog/libraries/server/pixel-tracking-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/pixel-tracking-api/index.md
@@ -60,3 +60,9 @@ eyJ3cml0ZUtleSI6ICJZT1VSX1dSSVRFX0tFWSIsICJ1c2VySWQiOiAiMDI1cGlrYWNodTAyNSIsICJl
 ```html
 <img src="https://api.segment.io/v1/pixel/track?data=eyJ3cml0ZUtleSI6ICJZT1VSX1dSSVRFX0tFWSIsICJ1c2VySWQiOiAiMDI1cGlrYWNodTAyNSIsICJldmVudCI6ICJFbWFpbCBPcGVuZWQiLCAicHJvcGVydGllcyI6IHsgICAic3ViamVjdCI6ICJUaGUgRWxlY3RyaWMgRGFpbHkiLCAgICJlbWFpbCI6ICJwZWVrQXRNZUBlbWFpbC5wb2tlIiB9fQ">
 ```
+
+##### If you choose not to encode your payload, you can send it like this instead:
+
+```
+https://api.segment.io/v1/pixel/track?userId=user_123&event=Email Opened&properties.subject=The Electric Daily&properties.email=jane.kim@example.com&writeKey=<YOUR_WRITE_KEY>
+```

--- a/src/connections/sources/catalog/libraries/server/pixel-tracking-api/index.md
+++ b/src/connections/sources/catalog/libraries/server/pixel-tracking-api/index.md
@@ -55,14 +55,14 @@ Each endpoint *always* responds with a `200 <empty-gif>`, even if an error occur
 eyJ3cml0ZUtleSI6ICJZT1VSX1dSSVRFX0tFWSIsICJ1c2VySWQiOiAiMDI1cGlrYWNodTAyNSIsICJldmVudCI6ICJFbWFpbCBPcGVuZWQiLCAicHJvcGVydGllcyI6IHsgICAic3ViamVjdCI6ICJUaGUgRWxlY3RyaWMgRGFpbHkiLCAgICJlbWFpbCI6ICJwZWVrQXRNZUBlbWFpbC5wb2tlIiB9fQ
 ```
 
+##### If you choose not to encode your payload, send it like this instead:
+
+```
+https://api.segment.io/v1/pixel/track?userId=user_123&event=Email Opened&properties.subject=The Electric Daily&properties.email=jane.kim@example.com&writeKey=<YOUR_WRITE_KEY>
+```
+
 ##### Add an image tag to your email newsletter with `src` pointing to a Pixel API route:
 
 ```html
 <img src="https://api.segment.io/v1/pixel/track?data=eyJ3cml0ZUtleSI6ICJZT1VSX1dSSVRFX0tFWSIsICJ1c2VySWQiOiAiMDI1cGlrYWNodTAyNSIsICJldmVudCI6ICJFbWFpbCBPcGVuZWQiLCAicHJvcGVydGllcyI6IHsgICAic3ViamVjdCI6ICJUaGUgRWxlY3RyaWMgRGFpbHkiLCAgICJlbWFpbCI6ICJwZWVrQXRNZUBlbWFpbC5wb2tlIiB9fQ">
-```
-
-##### If you choose not to encode your payload, you can send it like this instead:
-
-```
-https://api.segment.io/v1/pixel/track?userId=user_123&event=Email Opened&properties.subject=The Electric Daily&properties.email=jane.kim@example.com&writeKey=<YOUR_WRITE_KEY>
 ```


### PR DESCRIPTION
### Proposed changes

It's not obvious how to send this data if you choose not to encode it. It look me some trial and error and some digging into our codebase to get it figured out. This update ensures that customers will easily be able to send in data unencoded.

### Merge timing
ASAP is fine