### PR TITLE
Fixed syntax error in the code under What's new in v3 heading

### DIFF
--- a/src/connections/sources/catalog/libraries/server/go/index.md
+++ b/src/connections/sources/catalog/libraries/server/go/index.md
@@ -492,8 +492,8 @@ client.Enqueue(analytics.Track{
   UserId: "f4ca124298",
   Event:  "Signed Up",
   Properties: analytics.NewProperties().
-    SetCategory("Enterprise"),
-    SetCoupon("synapse"),
+    SetCategory("Enterprise").
+    SetCoupon("synapse").
     SetDiscount(10),
 })
 ```


### PR DESCRIPTION
Under the heading https://segment.com/docs/connections/sources/catalog/libraries/server/go/#whats-new-in-v3

The below code is having a syntax error:

```
client.Enqueue(analytics.Track{
  UserId: "f4ca124298",
  Event:  "Signed Up",
  Properties: analytics.NewProperties().
    SetCategory("Enterprise"),
    SetCoupon("synapse"),
    SetDiscount(10),
})
```

Changed it to:

```
client.Enqueue(analytics.Track{
  UserId: "f4ca124298",
  Event:  "Signed Up",
  Properties: analytics.NewProperties().
    SetCategory("Enterprise").
    SetCoupon("synapse").
    SetDiscount(10),
})
```