### PR TITLE
Add required permissions to dbt sync doc

### DIFF
--- a/src/segment-app/extensions/dbt.md
+++ b/src/segment-app/extensions/dbt.md
@@ -28,7 +28,7 @@ To set up the dbt extension, you'll need:
 
 - an existing dbt account with a Git repository
 - for job syncs, dbt cloud with jobs already created
-- a user with "Workspace Owner" permissions in Segment
+- a user with Workspace Owner permissions in Segment
 
 ### Git repository and dbt Models setup
 

--- a/src/segment-app/extensions/dbt.md
+++ b/src/segment-app/extensions/dbt.md
@@ -28,6 +28,7 @@ To set up the dbt extension, you'll need:
 
 - an existing dbt account with a Git repository
 - for job syncs, dbt cloud with jobs already created
+- a user with "Workspace Owner" permissions in Segment
 
 ### Git repository and dbt Models setup
 


### PR DESCRIPTION
mention about required permissions for dbt extensions 

### Proposed changes

Added a line to mention that you need Workspace owner permissions in Segment

### Merge timing
- ASAP once approved

### Related issues (optional)
https://segment.zendesk.com/agent/tickets/566063