### PR TITLE
Redshift/BigQuery Linked Audiences GA + Materialized view requirements [DOC-1094]

### DIFF
--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -22,7 +22,7 @@ To use the Data Graph, you'll need the following:
 - Workspace Owner or Unify Read-only/Admin and Entities Admin permissions
 - For Linked Audiences, set up [Profiles Sync](/docs/unify/profiles-sync/) in a Unify space with ready-to-use [data models and tables](/docs/unify/profiles-sync/tables/) in your warehouse. When setting up selective sync, Segment recommends the following settings: 
   - Under **Profile materialized tables**, select all the tables (`user_identifier`, `user_traits`, `profile_merges`) for faster and more cost-efficient Linked Audiences computations in your data warehouse.
-  - **Make sure to include the unmaterialized tables, too**. Segment needs them during setup to understand your schema.
+  - **Make sure to include the unmaterialized tables as well**. Segment needs them during setup to understand your schema.
   - Under **Track event tables**, select **Sync all Track Call Tables** to enable filtering on event history for Linked Audiences conditions.
 
 > info ""

--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -207,10 +207,10 @@ data_graph {
 
 Next, define the profile. This is a special class of entity that represents Segment Profiles, which corresponds to the Profiles Sync tables and models. For Linked Audiences, this allows marketers to filter on profile traits, event history, etc. There can only be one profile for a Data Graph. 
 
-| Parameters     | Definition                                                           |
-| ----------- | --------------------------------------------------------------------- |
-| `profile_folder`      | Define the fully qualified path of the folder or schema location for the profile tables.     |
-| `type`     | Identify the materialization method of the profile tables defined in your Profiles Sync configuration under [Selective Sync settings](/docs/unify/profiles-sync/profiles-sync-setup/#step-3-set-up-selective-sync): `segment:unmaterialized` or `segment:materialized`.|
+| Parameters       | Definition                                                                                                                                                                                                                                                                                          |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `profile_folder` | Define the fully qualified path of the folder or schema location for the profile tables.                                                                                                                                                                                                            |
+| `type`           | Use `segment:materialized` to sync materialized views with Profiles Sync. Segment recommends this configuration for all Linked Audiences and Data Graph setups. If you can't sync materialized views, [reach out to Segment support](https://segment.com/help/contact/){:target="_blank"} for help. |
 
 **Example:**
 
@@ -248,17 +248,18 @@ This is the first level of relationships and a unique type of relationship betwe
 
 To define a profile-to-entity relationship, reference your entity table and depending on your table columns, choose to join on one of the following: 
 
-**Option 1 (Most common) - Join on an external ID:** Use the `external_id` block to join the profile entity with an entity table using external IDs from your [Unify ID resolution](/docs/unify/identity-resolution/externalids/) settings. Typically these identifiers are  `user_id`, `email`, or `phone` depending on the column in the entity table that you want to join with.
-- `type`: Represents the [external ID type](/docs/unify/identity-resolution/externalids/#default-externalids) (`email`, `phone`, `user_id`) in your id-res settings. Depending on if you are using materialized or unmaterialized profiles, these correspond to different columns in your Profiles Sync warehouse tables:
-  - [Materialized](/docs/unify/profiles-sync/tables/#the-user_identifiers-table) (Recommended): This corresponds to the `type` column in your Profiles Sync `user_identifiers` table.
-  - [Unmaterialized](/docs/unify/profiles-sync/tables/#the-external_id_mapping_updates-table): This corresponds to the `external_id_type` column in your Profiles Sync `external_id_mapping_updates` table. 
-- `join_key`: This is the column on the entity table that you are matching to the external identifier.
+**Option 1 (Most common) - Join on an external ID:** Use the `external_id` block to join the profile entity with an entity table using external IDs from your [Unify ID resolution](/docs/unify/identity-resolution/externalids/) settings. Typically these identifiers are  `user_id`, `email`, or `phone` depending on the structure of your entity table.
+- `type`: Represents the [external ID type](/docs/unify/identity-resolution/externalids/#default-externalids) (`email`, `phone`, `user_id`) in your ID resolution settings.
+  - This maps to the `type` column in the `user_identifiers` table when using materialized views.
+- `join_key`: The column on the entity table that matches the external ID.
+
+> note ""
+> Segment recommends using materialized views with Profiles Sync. However, Segment may still reference unmaterialized tables during setup for schema detection.
 
 **Option 2 - Join on a profile trait:** Use the `trait` block to join the profile entity with an entity table using [Profile Traits](/docs/unify/#enrich-profiles-with-traits). 
-- `name`: Represents a trait name in your Unify profiles. Depending on if you are using materialized or unmaterialized profiles, these correspond to different columns in your Profiles Sync warehouse tables:
-  - [Materialized](/docs/unify/profiles-sync/tables/#the-profile_traits-table) (Recommended): The trait name corresponds to a unique value of the `name` column in your Profiles Sync `user_traits` table. 
-  - [Unmaterialized](/docs/unify/profiles-sync/tables/#the-profile_traits_updates-table): This corresponds to a column in the Profile Sync `profile_trait_updates` table.
-- `join_key`: This is the column on the entity table that you are matching to the trait.
+- `name`: Represents a trait name in your Unify profiles. 
+   - This maps to the `name` column in the `user_traits` table when using materialized views.
+- `join_key`: The column on the entity table that you're matching to the trait.
 
 **Example:**
 ```python

--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -130,14 +130,14 @@ data_graph {
         }
   
         # Define 1:many relationship between accounts and carts
-        # e.g. an account can be associated with many carts
+        # for example, an account can be associated with many carts
         relationship "user-carts" {
           name = "Shopping Carts"
           related_entity = "cart-entity"
           join_on = "account-entity.ID = cart-entity.ACCOUNT_ID"
     
           # Define many:many relationship between carts and products
-          # e.g. there can be multiple carts, and each cart can be associated with multiple products
+          # for example, there can be multiple carts, and each cart can be associated with multiple products
           relationship "products" { 
             name = "Purchased Products"
             related_entity = "product-entity"
@@ -161,7 +161,7 @@ data_graph {
         }
   
         # Define 1:many relationship between households and subscriptions
-        # e.g. a household can be associated with multiple subscriptions
+        # for example, a household can be associated with multiple subscriptions
         relationship "user-subscriptions" {
           name = "Subscriptions"
           related_entity = "subscription-entity"
@@ -242,7 +242,7 @@ This is the first level of relationships and a unique type of relationship betwe
 
 | Parameters       | Definition                                                                                                                                                                                                 |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `relationship`   | An immutable slug for the relationship, and will be treated as a delete if you make changes. The slug must be in all lowercase, and supports dashes or underscores (e.g. `user-account` or `user_account`) |
+| `relationship`   | An immutable slug for the relationship, and will be treated as a delete if you make changes. The slug must be in all lowercase, and supports dashes or underscores (like `user-account` or `user_account`) |
 | `name`           | A label displayed throughout your Segment space for Linked Events, Linked Audiences, etc. This name can be modified at any time                                                                            |
 | `related_entity` | References your already defined entity                                                                                                                                                                     |
 
@@ -282,7 +282,7 @@ data_graph {
         name = "Premium Accounts"
         related_entity = "account-entity"
   
-        # Option 1: Join the profile entity with an identifier (e.g. email) on the related entity table
+        # Option 1: Join the profile entity with an identifier (like email) on the related entity table
         external_id {
           type = "email"
           join_key = "EMAIL_ID"
@@ -303,7 +303,7 @@ For 1:many relationships, define the join on between the two entity tables using
 
 | Parameters       | Definition                                                                                                                                                                                                                                         |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `relationship`   | An immutable slug for the relationship, and will be treated as a delete if you make changes. The slug must be in all lowercase, and supports dashes or underscores (e.g. `user-account` or `user_account`)                                         |
+| `relationship`   | An immutable slug for the relationship, and will be treated as a delete if you make changes. The slug must be in all lowercase, and supports dashes or underscores (like `user-account` or `user_account`)                                         |
 | `name`           | A label displayed throughout your Segment space for Linked Events, Linked Audiences, and so on. This name can be modified at any time                                                                                                              |
 | `related_entity` | References your already defined entity                                                                                                                                                                                                             |
 | `join_on`        | Defines relationship between the two entity tables `[lefty entity slug].[column name] = [right entity slug].[column name]`. Note that since you’re referencing the entity slug for the join on, you do not need to define the full table reference |
@@ -348,7 +348,7 @@ For many:many relationships, define the join on between the two entity tables wi
 
 | Parameters       | Definition                                                                                                                                                                                                 |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `relationship`   | An immutable slug for the relationship, and will be treated as a delete if you make changes. The slug must be in all lowercase, and supports dashes or underscores (e.g. `user-account` or `user_account`) |
+| `relationship`   | An immutable slug for the relationship, and will be treated as a delete if you make changes. The slug must be in all lowercase, and supports dashes or underscores (like `user-account` or `user_account`) |
 | `name`           | A label displayed throughout your Segment space for Linked Events, Linked Audiences, and so on. This name can be modified at any time                                                                      |
 | `related_entity` | References your already defined entity                                                                                                                                                                     |
 

--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -13,7 +13,7 @@ The Data Graph acts as a semantic layer that allows businesses to define relatio
 
 ## Prerequisites
 
-> info "Why you need both materialized and unmaterialized tables right now"
+> info "Why you need both materialized and unmaterialized tables"
 > Segment recommends using materialized views for Profiles Sync to optimize performance and reduce query costs with Linked Audiences. However, due to schema inference requirements, you'll still need to select the matching **unmaterialized tables**, too. Segment relies on them during setup, even if they’re not used when queries actually run.
 
 To use the Data Graph, you'll need the following:

--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -111,8 +111,8 @@ data_graph {
       primary_key = "SUB_ID"
     }
   
-    # Define the profile entity, which corresponds to Segment Profiles tables synced via Profiles Sync
-    # Recommend setting up Profiles Sync materialized views to optimize warehouse compute costs
+    # Define the profile entity, which corresponds to Segment Profiles tables synced with Profiles Sync
+    # Use materialized views in Profiles Sync to reduce query costs and speed things up
     profile {
       profile_folder = "PRODUCTION.SEGMENT"
       type = "segment:materialized"
@@ -122,7 +122,7 @@ data_graph {
       relationship "user-accounts" {
         name = "Premium Accounts"
         related_entity = "account-entity"
-        # Join the profile entity with an identifier (e.g. email) on the related entity table
+        # Join the profile entity with an identifier (like email) on the related entity table
         # Option to replace with the trait block below to join with a profile trait on the entity table instead
         external_id {
           type = "email"

--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -13,6 +13,9 @@ The Data Graph acts as a semantic layer that allows businesses to define relatio
 
 ## Prerequisites
 
+> info "Segment recommends materialized views, but selection requirements apply"
+> Segment recommends using materialized views for Profiles Sync to optimize performance and reduce query costs with Linked Audiences. However, due to schema inference requirements, you must also select the corresponding **unmaterialized** tables when you configure Profiles Sync. Segment references these tables during setup, even if materialized views are used for computation.
+
 To use the Data Graph, you'll need the following:
 
 - A supported data warehouse with the appropriate Data Graph permissions

--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -33,7 +33,7 @@ To use the Data Graph, you'll need the following:
 > Data Graph, Reverse ETL, and Profiles Sync require different warehouse permissions.
 
 To get started with the Data Graph, set up the required permissions in your warehouse. Segment supports the following: 
-- Linked Audiences: [BigQuery](/docs/unify/data-graph/setup-guides/BigQuery-setup/), [Databricks](/docs/unify/data-graph/setup-guides/databricks-setup/), [Redshift](/docs/unify/data-graph/setup-guides/redshift-setup/), and [Snowflake](/docs/unify/data-graph/setup-guides/snowflake-setup/) 
+- Linked Audiences: [BigQuery](/docs/unify/data-graph/setup-guides/BigQuery-setup/), [Databricks](/docs/unify/data-graph/setup-guides/databricks-setup/), [Redshift](/docs/unify/data-graph/setup-guides/redshift-setup/), and [Snowflake](/docs/unify/data-graph/setup-guides/snowflake-setup/)
 - Linked Events: [BigQuery](/docs/unify/data-graph/setup-guides/BigQuery-setup/), [Databricks](/docs/unify/data-graph/setup-guides/databricks-setup/), [Redshift](/docs/unify/data-graph/setup-guides/redshift-setup/), and [Snowflake](/docs/unify/data-graph/setup-guides/snowflake-setup/) 
 
 To track the data sent to Segment on previous syncs, Segment uses [Reverse ETL](/docs/connections/reverse-etl/) infrastructure to store diffs in tables within a dedicated schema called `_segment_reverse_etl` in your data warehouse. You can choose which database or project in your warehouse this data lives in. 

--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -33,7 +33,7 @@ To use the Data Graph, you'll need the following:
 > Data Graph, Reverse ETL, and Profiles Sync require different warehouse permissions.
 
 To get started with the Data Graph, set up the required permissions in your warehouse. Segment supports the following: 
-- Linked Audiences: [BigQuery](/docs/unify/data-graph/setup-guides/BigQuery-setup/), [Databricks](/docs/unify/data-graph/setup-guides/databricks-setup/), and [Snowflake](/docs/unify/data-graph/setup-guides/snowflake-setup/) 
+- Linked Audiences: [BigQuery](/docs/unify/data-graph/setup-guides/BigQuery-setup/), [Databricks](/docs/unify/data-graph/setup-guides/databricks-setup/), [Redshift](/docs/unify/data-graph/setup-guides/redshift-setup/), and [Snowflake](/docs/unify/data-graph/setup-guides/snowflake-setup/) 
 - Linked Events: [BigQuery](/docs/unify/data-graph/setup-guides/BigQuery-setup/), [Databricks](/docs/unify/data-graph/setup-guides/databricks-setup/), [Redshift](/docs/unify/data-graph/setup-guides/redshift-setup/), and [Snowflake](/docs/unify/data-graph/setup-guides/snowflake-setup/) 
 
 To track the data sent to Segment on previous syncs, Segment uses [Reverse ETL](/docs/connections/reverse-etl/) infrastructure to store diffs in tables within a dedicated schema called `_segment_reverse_etl` in your data warehouse. You can choose which database or project in your warehouse this data lives in. 

--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -13,8 +13,8 @@ The Data Graph acts as a semantic layer that allows businesses to define relatio
 
 ## Prerequisites
 
-> info "Segment recommends materialized views, but selection requirements apply"
-> Segment recommends using materialized views for Profiles Sync to optimize performance and reduce query costs with Linked Audiences. However, due to schema inference requirements, you must also select the corresponding **unmaterialized** tables when you configure Profiles Sync. Segment references these tables during setup, even if materialized views are used for computation.
+> info "Why you need both materialized and unmaterialized tables right now"
+> Segment recommends using materialized views for Profiles Sync to optimize performance and reduce query costs with Linked Audiences. However, due to schema inference requirements, you'll still need to select the matching **unmaterialized tables**, too. Segment relies on them during setup, even if they’re not used when queries actually run.
 
 To use the Data Graph, you'll need the following:
 
@@ -22,6 +22,7 @@ To use the Data Graph, you'll need the following:
 - Workspace Owner or Unify Read-only/Admin and Entities Admin permissions
 - For Linked Audiences, set up [Profiles Sync](/docs/unify/profiles-sync/) in a Unify space with ready-to-use [data models and tables](/docs/unify/profiles-sync/tables/) in your warehouse. When setting up selective sync, Segment recommends the following settings: 
   - Under **Profile materialized tables**, select all the tables (`user_identifier`, `user_traits`, `profile_merges`) for faster and more cost-efficient Linked Audiences computations in your data warehouse.
+  - **Make sure to include the unmaterialized tables, too**. Segment needs them during setup to understand your schema.
   - Under **Track event tables**, select **Sync all Track Call Tables** to enable filtering on event history for Linked Audiences conditions.
 
 > info ""

--- a/src/unify/data-graph/index.md
+++ b/src/unify/data-graph/index.md
@@ -14,7 +14,7 @@ The Data Graph acts as a semantic layer that allows businesses to define relatio
 ## Prerequisites
 
 > info "Why you need both materialized and unmaterialized tables"
-> Segment recommends using materialized views for Profiles Sync to optimize performance and reduce query costs with Linked Audiences. However, due to schema inference requirements, you'll still need to select the matching **unmaterialized tables**, too. Segment relies on them during setup, even if they’re not used when queries actually run.
+> Segment recommends using materialized views for Profiles Sync to optimize performance and reduce query costs with Linked Audiences. However, due to schema inference requirements, you still need to select the matching **unmaterialized tables** as well. Segment relies on the unmaterialized tables during setup, even if they’re not used when queries run.
 
 To use the Data Graph, you'll need the following:
 

--- a/src/unify/data-graph/setup-guides/BigQuery-setup.md
+++ b/src/unify/data-graph/setup-guides/BigQuery-setup.md
@@ -6,11 +6,7 @@ redirect_from:
   - '/unify/linked-profiles/setup-guides/BigQuery-setup'
 ---
 
-> info ""
-> BigQuery for Data Graph is in beta and Segment is actively working on this feature. Some functionality may change before it becomes generally available. This feature is governed by Segment’s [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}.
-
 Set up your BigQuery data warehouse to Segment for the [Data Graph](/docs/unify/data-graph/data-graph/).  
-
 
 ## Step 1: Roles and permissions
 > warning ""

--- a/src/unify/data-graph/setup-guides/BigQuery-setup.md
+++ b/src/unify/data-graph/setup-guides/BigQuery-setup.md
@@ -6,6 +6,9 @@ redirect_from:
   - '/unify/linked-profiles/setup-guides/BigQuery-setup'
 ---
 
+> warning ""
+> Data Graph, Reverse ETL, and Profiles Sync require different warehouse permissions.
+
 Set up your BigQuery data warehouse to Segment for the [Data Graph](/docs/unify/data-graph/data-graph/).  
 
 ## Step 1: Roles and permissions

--- a/src/unify/data-graph/setup-guides/databricks-setup.md
+++ b/src/unify/data-graph/setup-guides/databricks-setup.md
@@ -5,6 +5,9 @@ redirect_from:
   - '/unify/linked-profiles/setup-guides/databricks-setup'
 ---
 
+> warning ""
+> Data Graph, Reverse ETL, and Profiles Sync require different warehouse permissions.
+
 On this page, you'll learn how to connect your Databricks data warehouse to Segment for the [Data Graph](/docs/unify/data-graph/data-graph/). 
 
 ## Databricks credentials

--- a/src/unify/data-graph/setup-guides/redshift-setup.md
+++ b/src/unify/data-graph/setup-guides/redshift-setup.md
@@ -6,6 +6,9 @@ redirect_from:
   - '/unify/linked-profiles/setup-guides/redshift-setup'
 ---
 
+> warning ""
+> Data Graph, Reverse ETL, and Profiles Sync require different warehouse permissions.
+
 Set up your Redshift data warehouse to Segment for the [Data Graph](/docs/unify/data-graph/).
 
 ## Prerequisite

--- a/src/unify/data-graph/setup-guides/redshift-setup.md
+++ b/src/unify/data-graph/setup-guides/redshift-setup.md
@@ -6,14 +6,9 @@ redirect_from:
   - '/unify/linked-profiles/setup-guides/redshift-setup'
 ---
 
-> info ""
-> Redshift for Data Graph is in beta and Segment is actively working on this feature. Some functionality may change before it becomes generally available. This feature is governed by Twilio Segment’s [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}.
-
 Set up your Redshift data warehouse to Segment for the [Data Graph](/docs/unify/data-graph/).
 
 ## Prerequisite
-
-To use Linked Audiences with Redshift, the Data Graph only supports [materialized views](/docs/unify/profiles-sync/tables/#tables-segment-materializes). 
 
 If you're setting up Profiles Sync for the first time in the Unify space, go through the setup flow for Selective sync. If Profiles Sync is already set up for your Unify space, follow these steps to configure Profiles Sync for your Unify space:
 

--- a/src/unify/data-graph/setup-guides/snowflake-setup.md
+++ b/src/unify/data-graph/setup-guides/snowflake-setup.md
@@ -5,7 +5,7 @@ redirect_from:
   - '/unify/linked-profiles/setup-guides/snowflake-setup'
 ---
 > warning ""
-> Data Graph, Reverse ETL, Profiles Sync require different warehouse permissions.
+> Data Graph, Reverse ETL, and Profiles Sync require different warehouse permissions.
 
 On this page, you'll learn how to connect your Snowflake data warehouse to Segment for the [Data Graph](/docs/unify/data-graph/data-graph/). 
 


### PR DESCRIPTION
### Proposed changes

- Removed beta callouts for Redshift and BigQuery setup docs. They will be GA on 11 April 2025.
- Added a callout to the Data Graph Prerequisites section clarifying that both materialized and unmaterialized tables must be selected in Profiles Sync (due to current schema inference behavior).
- Updated recommendation language throughout the page to formally guide users toward materialized views.
- Removed passive or neutral framing around unmaterialized views. We don't want to present it as an equivalent/recommended option.
- Rewrote the type parameter description to only show `segment:materialized`, with a fallback note to contact support.

### Merge timing

- ASAP once approved