### PR TITLE
fix(docs): use `pnpm add` instead of `pnpm install`

### DIFF
--- a/src/connections/sources/catalog/libraries/server/node/index.md
+++ b/src/connections/sources/catalog/libraries/server/node/index.md
@@ -25,7 +25,7 @@ All of Segment's server-side libraries are built for high-performance, so you ca
     # yarn
     yarn add @segment/analytics-node
     # pnpm
-    pnpm install @segment/analytics-node
+    pnpm add @segment/analytics-node
     ```
 
 2. Initialize the `Analytics` constructor the module exposes with your Segment source **Write Key**, like so:


### PR DESCRIPTION
It should be `pnpm add <pkg>` instead of `pnpm install <pkg>`.

`pnpm install` is used to install all dependencies for a project while `pnpm add <pkg>` is used to install a package and any packages that it depends on.

More info (official source):

- https://pnpm.io/cli/add
- https://pnpm.io/cli/install

---

`pnpm install <pkg>` does the same as `pnpm add <pkg>` today, but it might stop functioning that way in future versions since the official docs clarify the difference between the two. It might be that `pnpm install <pkg>` was used in past versions, and the PNPM team didn't want to remove support for it right away after introducing `pnpm add <pkg>`.