### PR TITLE
Update Predictions historical data requirement to 3x target window

### DIFF
--- a/src/unify/Traits/predictions/index.md
+++ b/src/unify/Traits/predictions/index.md
@@ -83,13 +83,13 @@ To access Predictions, you must:
 
 This table lists the requirements for a trait to compute successfully:
 
-| Requirement                      | Details                                                                                     |
-|----------------------------------|---------------------------------------------------------------------------------------------|
-| Event Types                  | Track at least 5 different event types in the Feature Window.                               |
-| Historical Data              | Ensure these 5 events have data spanning 1.5 times the length of the Target Window. For example, to predict a purchase propensity over the next 60 days, at least 90 days of historical data is required. |
-| Subset Audience (if applicable) | Ensure the audience contains more than 1 non-anonymous user.                                 |
-| User Limit                   | Ensure that you are making a prediction for fewer than 10 million users. If you track more than 10 million users in your space, define a smaller audience in the **Make a Prediction For** section of the custom predictions builder. |
-| User Activity                | At least 100 users performing the Target Event and at least 100 users not performing the Target Event. |
+| Requirement                     | Details                                                                                                                                                                                                                               |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Event Types                     | Track at least 5 different event types in the Feature Window.                                                                                                                                                                         |
+| Historical Data                 | Segment requires historical data spanning at least 3 times the length of the target window. For example, a 30-day window requires 90 days of past data.                                                                               |
+| Subset Audience (if applicable) | Ensure the audience contains more than 1 non-anonymous user.                                                                                                                                                                          |
+| User Limit                      | Ensure that you are making a prediction for fewer than 10 million users. If you track more than 10 million users in your space, define a smaller audience in the **Make a Prediction For** section of the custom predictions builder. |
+| User Activity                   | At least 100 users performing the Target Event and at least 100 users not performing the Target Event.                                                                                                                                |
 
 #### Selecting events (optional)
 


### PR DESCRIPTION
### Proposed changes

- Updates the historical data requirement to reflect that Predictions now require at least three times the target window in event history. 

### Merge timing

- ASAP once approved.