### PR TITLE
Update supported Actions trigger operators

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -231,7 +231,7 @@ Mapping fields are case-sensitive. The following type filters and operators are 
 
 - **Event type** (`is`/`is not`). This allows you to filter by the [event types in the Segment Spec](/docs/connections/spec).
 - **Event name** (`is`, `is not`, `contains`, `does not contain`, `starts with`, `ends with`). Use these filters to find events that match a specific name, regardless of the event type.
-- **Event property** (`is`, `is not`, `less than`, `less than or equal to`, `greater than`, `greater than or equal to`, `contains`,  `does not contain`, `starts with`, `ends with`, `exists`, `does not exist`).  Use these filters to trigger the action only when an event with a specific property occurs. 
+- **Event property** (`is`, `is equals to`, `is not`, `is not equals to`, `less than`, `less than or equal to`, `greater than`, `greater than or equal to`, `contains`,  `does not contain`, `starts with`, `ends with`, `exists`, `does not exist`).  Use these filters to trigger the action only when an event with a specific property occurs. 
 
     You can specify nested properties using dot notation, for example `context.app.name`. If the property might appear in more than one format or location, you can use an ANY statement and add conditions for each of those formats. For example, you might filter for both `context.device.type = ios`  as well as `context.os.name = "iPhone OS``"`
     The `does` `not exist` operator matches both a `null` value or a missing property.
@@ -244,8 +244,8 @@ Mapping fields are case-sensitive. The following type filters and operators are 
 > Operators support matching on values with a **string** data type:
 > - `is`, `is not`, `contains`,  `does not contain`, `starts with`, `ends with`
 > 
-> Operators that support matching on values with either a **string** or **numeric** data type:
-> - `is less than`, `is less than or equal to`, `is greater than`, `is greater than or equal to`
+> Operators that support matching on values with **numeric** data type:
+> - `is equals to`, `is not equals to`, `is less than`, `is less than or equal to`, `is greater than`, `is greater than or equal to`
 > 
 > Operators that support matching on values with a **boolean** data type:
 > - `is true`, `is false`


### PR DESCRIPTION
Updated the list of supported Action Trigger operators, and added `is equals to`, and `is not equals to`. 

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

[STRATCONN-3772](https://segment.atlassian.net/browse/STRATCONN-3772) added 2 new operators supporting Integer values: "is equals to", and "is not equals to".
### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->
ASAP once approved

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
See [STRATCONN-3772](https://segment.atlassian.net/browse/STRATCONN-3772)

[STRATCONN-3772]: https://segment.atlassian.net/browse/STRATCONN-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STRATCONN-3772]: https://segment.atlassian.net/browse/STRATCONN-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ