### PR TITLE
Redirect broken Extensible Webhooks link 

### DIFF
--- a/src/connections/destinations/catalog/actions-webhook-extensible/index.md
+++ b/src/connections/destinations/catalog/actions-webhook-extensible/index.md
@@ -3,6 +3,7 @@ title: Extensible Webhooks Destination
 id: 66b1f528d26440823fb27af9
 beta: true
 hidden: true
+redirect_from: '/connections/destinations/catalog/extensible-webhook/'
 ---
 
 {% include content/plan-grid.md name="actions" %}

--- a/src/connections/destinations/catalog/actions-webhook-extensible/index.md
+++ b/src/connections/destinations/catalog/actions-webhook-extensible/index.md
@@ -3,7 +3,7 @@ title: Extensible Webhooks Destination
 id: 66b1f528d26440823fb27af9
 beta: true
 hidden: true
-redirect_from: '/connections/destinations/catalog/extensible-webhook/'
+redirect_from: '/connections/destinations/catalog/extensible-webhook/' 
 ---
 
 {% include content/plan-grid.md name="actions" %}


### PR DESCRIPTION
### Proposed changes

Fixed broken [link](https://segment.com/docs/connections/destinations/catalog/extensible-webhook/) by redirecting to existing [one](https://segment.com/docs/connections/destinations/catalog/actions-webhook-extensible/).

### Merge timing

- ASAP once approved

### Related issues (optional)

