### PR TITLE
Deprecate docs for the two Ripe destinations

### DIFF
--- a/src/connections/destinations/catalog/actions-ripe-cloud/index.md
+++ b/src/connections/destinations/catalog/actions-ripe-cloud/index.md
@@ -3,6 +3,8 @@ title: Ripe Cloud Mode (Actions) Destination
 hide-boilerplate: true
 hide-dossier: true
 id: 63cade592992cf7052ce2e3e
+deprecated: true
+hidden: true
 ---
 
 [Ripe](https://www.getripe.com/){:target="_blank"} is a sales conversion tool that enables B2B revenue teams to surface and meet their best leads at the best possible time - when they are using your product.

--- a/src/connections/destinations/catalog/actions-ripe/index.md
+++ b/src/connections/destinations/catalog/actions-ripe/index.md
@@ -3,6 +3,8 @@ title: Ripe Device Mode (Actions) Destination
 hide-boilerplate: true
 hide-dossier: true
 id: 63913b2bf906ea939f153851
+hidden: true
+deprecated: true
 ---
 
 [Ripe](https://www.getripe.com/){:target="_blank"} is a sales conversion tool that enables B2B revenue teams to surface and meet their best leads at the best possible time - when they are using your product.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added `deprecated: true` and `hidden: true` to the frontmatter for two deprecated destinations. Example of a deprecated destination: https://segment.com/docs/connections/destinations/catalog/hull/

More context in this [Slack thread](https://twilio.slack.com/archives/CD3LFFTFZ/p1748347959516439https://twilio.slack.com/archives/CD3LFFTFZ/p1748347959516439).  

### Merge timing
today! 

### Related issues (optional)