### PR TITLE
Add note about `segment_id` behavior in Track event tables where ID res fails

### DIFF
--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -278,7 +278,7 @@ Segment's Identity Resolution has processed these events, which contain a `segme
 > To view and select individual track tables, edit your sync settings after you enable Profiles Sync, and wait for the initial sync to complete.
 
 > warning ""
-> These tables may have null segment_id in rare cases where ID resolution has failed, which could happen due to multiple reasons.
+> These tables may have null segment_id in situations where ID resolution has failed, which is a very rare but possible occurrence.
 
 
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -278,7 +278,7 @@ Segment's Identity Resolution has processed these events, which contain a `segme
 > To view and select individual track tables, edit your sync settings after you enable Profiles Sync, and wait for the initial sync to complete.
 
 > warning ""
-> These tables may have null segment_id in situations where ID resolution has failed, which is a very rare but possible occurrence.
+> These tables may have null segment_id in situations where ID resolution has failed, which is a rare but possible occurrence.
 
 
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -265,22 +265,11 @@ Follow the steps below to change your schema name:
 
 ## Track event tables
 
-Track event tables provide a complete event history, with one table for each unique named Track event. Segment syncs events based on the event sources you've connected to Unify. 
+Track event tables provide a complete event history, with one table for each unique Track event name. Segment syncs events based on the sources you’ve connected to Unify, and includes a column for each event property.
 
-These tables include a full set of Track event properties, with one column for each property.
+Each row also includes a `segment_id`, assigned by Identity Resolution, which you can use to join events to profile records. In rare cases where Identity Resolution fails, the `segment_id` may be `null`.
 
-Segment's Identity Resolution has processed these events, which contain a `segment_id`, enabling the data to be joined into a single profile record. 
-
-> success ""
-> These tables will have two months of historical data on backfill.
-
-> info ""
-> To view and select individual track tables, edit your sync settings after you enable Profiles Sync, and wait for the initial sync to complete.
-
-> warning ""
-> These tables may have null segment_id in situations where ID resolution has failed, which is a rare but possible occurrence.
-
-
+By default, Segment backfills these tables with two months of historical data. After the initial sync completes, you can view and manage individual track tables by editing your sync settings.
 
 ## Tables Segment materializes
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -277,6 +277,9 @@ Segment's Identity Resolution has processed these events, which contain a `segme
 > info ""
 > To view and select individual track tables, edit your sync settings after you enable Profiles Sync, and wait for the initial sync to complete.
 
+> warning ""
+> These tables may have null segment_id in rare cases where ID resolution has failed, which could happen due to multiple reasons.
+
 
 
 ## Tables Segment materializes


### PR DESCRIPTION
### Proposed changes

Adding warning for null ```segment_id``` in Track event tables in cases where ID resolution has failed. Doing this because of a request for change in documentation following this issue: [Null segment_ids in tables](https://twilio-engineering.atlassian.net/browse/PS-403).

### Merge timing

ASAP once approved.

### Related issues (optional)

JIRA link: [Null segment_ids in tables](https://twilio-engineering.atlassian.net/browse/PS-403).