### PR TITLE
Add note about adjusted `sent_at` timestamps [DOC-1128]

### DIFF
--- a/src/connections/spec/common.md
+++ b/src/connections/spec/common.md
@@ -278,7 +278,7 @@ The `sentAt` timestamp specifies the clock time for the client's device when the
 
 **Note:** The `sentAt` timestamp is not useful for any analysis since it's tainted by user's clock skew.
 
-> warning "Segment now adds `sentAt` to a payload when the batch is complete and initially tried to the Segment API for the Swift, Kotlin, and C# mobile libraries"
+> warning "Segment now adds sentAt to a payload when the batch is complete and initially tried to the Segment API for the Swift, Kotlin, and C# mobile libraries"
 > This update changes the value of the Segment-calculated `timestamp` to align closer with the `receivedAt` value rather than the `originalTimestamp` value. For most users who are online when events are sent, this does not significantly impact their data. However, if your application utilizes an offline mode where events are queued up for any period of time, the `timestamp` value for those users now more closely reflects when Segment received the events rather than the time they occurred on the users' devices. 
 
 

--- a/src/connections/storage/warehouses/schema.md
+++ b/src/connections/storage/warehouses/schema.md
@@ -450,7 +450,7 @@ All four timestamps pass through to your Warehouse for every ETL'd event. In mos
 
 `original_timestamp` is the original timestamp set by the Segment library at the time the event is created.  Keep in mind, this timestamp can be affected by device clock skew. You can override this value by manually passing in a value for `timestamp` which will then be relabeled as `original_timestamp`. Generally, this timestamp should be ignored in favor of the `timestamp` column.
 
-`sent_at` is the UTC timestamp set by library when the Segment API call was sent.  This timestamp can also be affected by device clock skew.
+`sent_at` is the UTC timestamp set by library when the Segment API call was sent.  This timestamp can also be affected by device clock skew. Segment adjusts the `sent_at` timestamp when loading events into your data warehouse to better account for batch scenarios where events are queued over a period of time. For more information about how Segment adjusts this timestamp, refer to the [Spec: Common](/docs/connections/spec/common/#sentat) documentation. 
 
 `received_at` is UTC timestamp set by the Segment API when the API receives the payload from client or server. All tables use `received_at` for the sort key.
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added a note to the warehouse docs about why Segment adjusts the `sent_at` timestamps

### Merge timing
after approval!

### Related issues (optional)
DOC-1128
