### PR TITLE
PM-requested Reverse ETL/alerting fixes

### DIFF
--- a/src/connections/reverse-etl/faq.md
+++ b/src/connections/reverse-etl/faq.md
@@ -9,14 +9,16 @@ Get answers to some frequently asked Reverse ETL questions.
 It's expected that when you select **Updated records**, the records do not change after the first sync. During the first sync, the reverse ETL system calculates a snapshot of all the results and creates records in the `_segment_reverse_etl` schema. All the records are considered as *Added records* instead of *Updated records* at this time. The records can only meet the *Updated records* condition when the underlying values change after the first sync completes.
 
 ## Can I be notified when Reverse ETL syncs fail?
-Yes, you can sign up for Reverse ETL sync notifications.
+Yes, you can sign up for Reverse ETL sync notifications for failed or partially successful syncs. Segment sends notifications for every sync failure. 
 
 To receive Reverse ETL sync notifications: 
-1. Navigate to **Settings > User Preferences**.
-2. Select **Reverse ETL** in the **Activity Notifications** section.
-3. Enable the toggle for **Reverse ETL Sync Failed**.
+1. From your workspace's homepage, navigate to the Monitor tab and select **Alerts**. 
+2. On the **Default** tab, select **Reverse ETL**.
+3. Identify the event you'd like to be alerted for and select the menu icon under the **Actions** tab. 
+4. Click **Enable alert** and select the notification channels for which you'd like to receive alerts. 
+5. Click **Save**. 
 
-In case of consecutive failures, Segment sends notifications for every sync failure. Segment doesn't send notifications for partial failures.
+For more information about Reverse ETL alerting, refer to the [Monitor documentation](/docs/monitor/alerts/default-alerts/#reverse-etl-alerts). 
 
 ## Does Segment use Transport Layer Security (TLS) for the connection between Snowflake and Segment?
 Segment uses the [gosnowflake library](https://pkg.go.dev/github.com/snowflakedb/gosnowflake#pkg-variables){:target="_blank"} to connect with Snowflake, which internally uses TLS for the HTTP transport.

--- a/src/connections/reverse-etl/manage-retl.md
+++ b/src/connections/reverse-etl/manage-retl.md
@@ -71,25 +71,22 @@ Once you cancel a sync, the record count under **Extraction Results** reflects t
 You can choose to replay syncs. To replay a specific sync, contact [friends@segment.com](mailto:friends@segment.com). Keep in mind that triggering a replay resyncs all records for a given sync.
 
 ## Alerting
-You can opt in to receive email, Slack, and in-app alerts about Reverse ETL sync failures and fluctuations in the volume of events successfully delivered to your mapping. 
+You can opt in to receive email, Slack, and in-app alerts about Reverse ETL sync failures and fluctuations in the volume of events successfully delivered to your mapping. Segment sends notifications for every sync failure, even if the failures happen consecutively. 
 
 The notification channels that you select for one alert will apply to all alerts in your workspace. 
 
 ### Failed or partially successful syncs
-To subscribe to alerts for a failed or partially successful sync: 
-1. Navigate to **Settings > User Preferences**. 
-2. Select **Reverse ETL** in the **Activity Notifications** section.
-3. Click the Reverse ETL sync status that you'd like to receive notifications for. You can select one or more of the following sync statuses:
-    - **Reverse ETL sync failed**: Receive a notification when your Reverse ETL sync fails.
-    - **Reverse ETL sync partial success**: Receive a notification when your Reverse ETL sync is partially successful.
-4. Select one or more of the following alert options: 
-    - **Enable email notifications**: Enter an email address or alias that should receive alerts.
-    - **Enable Slack notifications**: Enter a webhook URL and Slack channel name. You can post messages to your channel with either a [webhook](https://api.slack.com/messaging/webhooks){:target="_blank”} or a [workflow](https://slack.com/help/articles/360041352714-Build-a-workflow--Create-a-workflow-that-starts-outside-of-Slack){:target="_blank”}.
-    - **Enable in-app notifications**: Select this option to see an in-app notification.
-5. Click **Create alert**.
 
-> success ""
-> If you opted to receive notifications by email, you can click **View active email addresses** to see the email addresses that are currently signed up to receive notifications. 
+To receive notifications for failed or partially successful syncs: 
+1. From your workspace's homepage, navigate to the Monitor tab and select **Alerts**. 
+2. On the **Default** tab, select **Reverse ETL**.
+3. Identify the event you'd like to be alerted for and select the menu icon under the **Actions** tab. 
+4. Click **Enable alert** and select the notification channels for which you'd like to receive alerts. 
+5. Click **Save**. 
+
+<!--- IG 5/2025 - alerting still not consolidated. When it is I'll add this back 
+For more information about Reverse ETL alerting, refer to the [Monitor documentation](/docs/monitor/alerts/default-alerts/#reverse-etl-alerts). 
+--->
 
 <!--- IG 9/2024 - not yet working
 ### Model-level volume spike alerts

--- a/src/monitor/alerts/default-alerts.md
+++ b/src/monitor/alerts/default-alerts.md
@@ -135,7 +135,7 @@ your identity-resolved profiles to your data warehouse.
 - **Reverse ETL Sync Partial Success**: Segment was able to sync some, but not all, of your records from your data warehouse with your downstream destination. 
 
 > info "Custom Reverse ETL alerts"
-> During the Monitor public beta, you can configure custom Reverse ETL alerts for [failed or partially successful syncs](/docs/connections/reverse-etl/manage-retl/#failed-or-partially-successful-syncs) and [mapping-level successful delivery rate fluctuations](/docs/connections/reverse-etl/manage-retl/#mapping-level-successful-delivery-rate-fluctuations), but these alerts won't appear in the Monitor tab. 
+> During the Monitor public beta, you can configure custom Reverse ETL alerts for [mapping-level successful delivery rate fluctuations](/docs/connections/reverse-etl/manage-retl/#mapping-level-successful-delivery-rate-fluctuations), but these alerts won't appear in the Monitor tab. 
 
 ## Data Graph alerts
 - **Data Graph Breaking Change**: A change in your warehouse broke components of your Data Graph. For more information about breaking changes, see the [Data Graph docs](/docs/unify/data-graph/#detect-warehouse-breaking-changes). 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
The Reverse ETL FAQ and Manage Reverse ETL pages hadn't been updated to reflect the Alerting hub release - this PR fixes that (and also fixes a misleading callout on the Default Alerts page). 

### Merge timing
asap!

### Related issues (optional)
#7504 
