### PR TITLE
Note added on Timestamp column being null during backfill

### DIFF
--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -107,7 +107,7 @@ With raw tables, you have full control over the materialization of Profiles in y
 
 Raw tables contain complete historical data when using historical backfill. 
 
-Note: `Timestamp` column will be empty for backfilled data. This is because during backfill, we infer historical profile changes from the current state of the profile, and do not refer to the actual change history.
+The `Timestamp` column will be empty for backfilled data because, during backfill, historical profile changes are inferred from the current state of the profile and do not reflect the actual change history.
 
 ### The id_graph_updates table
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -107,7 +107,7 @@ With raw tables, you have full control over the materialization of Profiles in y
 
 Raw tables contain complete historical data when using historical backfill. 
 
-Note: `Timestamp` column will be empty for backfilled data. This is because we reverse engineer historical profile changes from the current state of the profile, and do not have access to the actual event timestamps.
+Note: `Timestamp` column will be empty for backfilled data. This is because we reverse engineer historical profile changes from the current state of the profile, and do not have access to the actual change timestamps.
 
 ### The id_graph_updates table
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -107,7 +107,7 @@ With raw tables, you have full control over the materialization of Profiles in y
 
 Raw tables contain complete historical data when using historical backfill. 
 
-Note: `Timestamp` column will be empty for backfilled data. This is because reverse engineer historical profile changes from the current state of the profile, and do not have access to the actual event timestamps.
+Note: `Timestamp` column will be empty for backfilled data. This is because we reverse engineer historical profile changes from the current state of the profile, and do not have access to the actual event timestamps.
 
 ### The id_graph_updates table
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -107,7 +107,7 @@ With raw tables, you have full control over the materialization of Profiles in y
 
 Raw tables contain complete historical data when using historical backfill. 
 
-Note: `Timestamp` column will be empty for backfilled data. This is because we infer historical profile changes from the current state of the profile, and do not refer to the actual change history.
+Note: `Timestamp` column will be empty for backfilled data. This is because during backfill, we infer historical profile changes from the current state of the profile, and do not refer to the actual change history.
 
 ### The id_graph_updates table
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -298,7 +298,7 @@ If you're not using materialized views for Profile Sync and would like to switch
 2. **Request a Full Profiles and Events Backfill**
    - After enabling the materialized views, you'll need to ensure historical data is populated in the materialized tables.
    - Write to [friends@segment.com](mailto:friends@segment.com) and request:
-     - A full **Profiles Backfill** to populate historical profiles data. Materialized views will have nil `Timestamp` for the same reason as in Profile events table, discussed above.
+     - A full **Profiles Backfill** to populate historical profiles data. Materialized views will have null `Timestamp` for the same reason as in Profile events table, discussed above.
      - An **Events Backfill** to include any relevant historical events, including a date range for Segment to pull data in for the events backfill. 
 
 3. **Verify Your Data**

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -107,7 +107,7 @@ With raw tables, you have full control over the materialization of Profiles in y
 
 Raw tables contain complete historical data when using historical backfill. 
 
-Note: `Timestamp` column will be empty for backfilled data. This is because we reverse engineer historical profile changes from the current state of the profile, and do not use the actual change timestamps.
+Note: `Timestamp` column will be empty for backfilled data. This is because we reverse engineer historical profile changes from the current state of the profile, and do not refer to the actual change history.
 
 ### The id_graph_updates table
 

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -105,7 +105,9 @@ Profile raw tables contain records of changes to your Segment profiles and Ident
 
 With raw tables, you have full control over the materialization of Profiles in your warehouse, as well as increased observibility.
 
-Raw tables contain complete historical data when using historical backfill.
+Raw tables contain complete historical data when using historical backfill. 
+
+Note: `Timestamp` column will be empty for backfilled data. This is because reverse engineer historical profile changes from the current state of the profile.
 
 ### The id_graph_updates table
 
@@ -296,7 +298,7 @@ If you're not using materialized views for Profile Sync and would like to switch
 2. **Request a Full Profiles and Events Backfill**
    - After enabling the materialized views, you'll need to ensure historical data is populated in the materialized tables.
    - Write to [friends@segment.com](mailto:friends@segment.com) and request:
-     - A full **Profiles Backfill** to populate historical profiles data.
+     - A full **Profiles Backfill** to populate historical profiles data. Materialized views will have nil `Timestamp` for the same reason as Profile events table, discussed above.
      - An **Events Backfill** to include any relevant historical events, including a date range for Segment to pull data in for the events backfill. 
 
 3. **Verify Your Data**

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -107,7 +107,7 @@ With raw tables, you have full control over the materialization of Profiles in y
 
 Raw tables contain complete historical data when using historical backfill. 
 
-Note: `Timestamp` column will be empty for backfilled data. This is because reverse engineer historical profile changes from the current state of the profile.
+Note: `Timestamp` column will be empty for backfilled data. This is because reverse engineer historical profile changes from the current state of the profile, and do not have access to the actual event timestamps.
 
 ### The id_graph_updates table
 
@@ -298,7 +298,7 @@ If you're not using materialized views for Profile Sync and would like to switch
 2. **Request a Full Profiles and Events Backfill**
    - After enabling the materialized views, you'll need to ensure historical data is populated in the materialized tables.
    - Write to [friends@segment.com](mailto:friends@segment.com) and request:
-     - A full **Profiles Backfill** to populate historical profiles data. Materialized views will have nil `Timestamp` for the same reason as Profile events table, discussed above.
+     - A full **Profiles Backfill** to populate historical profiles data. Materialized views will have nil `Timestamp` for the same reason as in Profile events table, discussed above.
      - An **Events Backfill** to include any relevant historical events, including a date range for Segment to pull data in for the events backfill. 
 
 3. **Verify Your Data**

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -107,7 +107,7 @@ With raw tables, you have full control over the materialization of Profiles in y
 
 Raw tables contain complete historical data when using historical backfill. 
 
-Note: `Timestamp` column will be empty for backfilled data. This is because we reverse engineer historical profile changes from the current state of the profile, and do not refer to the actual change history.
+Note: `Timestamp` column will be empty for backfilled data. This is because we infer historical profile changes from the current state of the profile, and do not refer to the actual change history.
 
 ### The id_graph_updates table
 
@@ -298,7 +298,7 @@ If you're not using materialized views for Profile Sync and would like to switch
 2. **Request a Full Profiles and Events Backfill**
    - After enabling the materialized views, you'll need to ensure historical data is populated in the materialized tables.
    - Write to [friends@segment.com](mailto:friends@segment.com) and request:
-     - A full **Profiles Backfill** to populate historical profiles data. Materialized views will have null `Timestamp` for the same reason as in Profile events table, discussed above.
+     - A full **Profiles Backfill** to populate historical profiles data.
      - An **Events Backfill** to include any relevant historical events, including a date range for Segment to pull data in for the events backfill. 
 
 3. **Verify Your Data**

--- a/src/unify/profiles-sync/tables.md
+++ b/src/unify/profiles-sync/tables.md
@@ -107,7 +107,7 @@ With raw tables, you have full control over the materialization of Profiles in y
 
 Raw tables contain complete historical data when using historical backfill. 
 
-Note: `Timestamp` column will be empty for backfilled data. This is because we reverse engineer historical profile changes from the current state of the profile, and do not have access to the actual change timestamps.
+Note: `Timestamp` column will be empty for backfilled data. This is because we reverse engineer historical profile changes from the current state of the profile, and do not use the actual change timestamps.
 
 ### The id_graph_updates table
 


### PR DESCRIPTION
### Proposed changes

Adding note on ```Timestamp``` column being null in Profiles tables in case of backfill. This is expected behaviour and happens because we infer historical profile changes from the current state of the profile.

Verified that ```Timestamp``` is null by running backfill in Staging.

More context: [Slack thread](https://twilio.slack.com/archives/C03NG5VGADT/p1724347504130539).

CSE requested change in documentation here: [JIRA](https://twilio-engineering.atlassian.net/browse/PS-403).

### Merge timing

ASAP once approved.

### Related issues (optional)

JIRA ticket: [link](https://twilio-engineering.atlassian.net/browse/PS-403).
