### PR TITLE
Ortto slug override hotfix

### DIFF
--- a/src/_data/catalog/slugs.yml
+++ b/src/_data/catalog/slugs.yml
@@ -325,4 +325,6 @@ destinations:
     override: "ninetailed"
   - original: "topsort"
     override: "actions-topsort"
+  - original: "ortto-actions"
+    override: "actions-ortto"
 


### PR DESCRIPTION
### Proposed changes
A partner flagged that their destination wasn't appearing in the docs' Destination Catalog, so this slug override fixes that. 

### Merge timing
ASAP

### Related issues (optional)
#7625 
