### PR TITLE
Fixed the Back-to-top button

### DIFF
--- a/src/_sass/components/_back-scrolling.scss
+++ b/src/_sass/components/_back-scrolling.scss
@@ -2,7 +2,7 @@
   position: fixed;
   z-index: 1;
   bottom: 20px;
-  right: 20px;
+  left: 20px;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
The new Twilio chatbot thing *totally* covers the back-to-top button, which is not accessible. 
<img width="222" height="95" alt="Screenshot 2025-07-25 at 10 17 30 AM" src="https://github.com/user-attachments/assets/a1db6bd6-49c4-4a40-bf85-a29c496a4f26" />
<img width="311" height="161" alt="Screenshot 2025-07-25 at 10 17 13 AM" src="https://github.com/user-attachments/assets/4c22120a-e811-4671-ae7c-15eba5486f94" />

I've moved the button to the other side of the page to prevent this from happening
<img width="773" height="295" alt="Screenshot 2025-07-25 at 10 30 44 AM" src="https://github.com/user-attachments/assets/b8fb9dcd-67de-4677-8c85-de77431340fc" />




### Merge timing
before the next deploy!

### Related issues (optional)

