### PR TITLE
fix: Duplicate partner owned notes

### DIFF
--- a/src/_includes/content/cloud-app-note.md
+++ b/src/_includes/content/cloud-app-note.md
@@ -9,13 +9,8 @@
     <ul class="qi">
       <li><p markdown=1>The {{ page.title }} is an **Event Cloud** source. This means that it sends data as events, which are behaviors or occurrences tied to a user and a point in time. Data from these sources can be loaded into your Segment warehouses, and **also** sent to  Segment streaming destinations. [Learn more about cloud sources.](/docs/connections/sources/#cloud-apps)</p></li>
       {% if currentIntegration.status == "PUBLIC_BETA" %}<li>This source is in <span class="release-pill">Beta</span></li>{%endif%}
-    </ul>
-    {% if currentIntegration.partnerOwned %}
-    <h6>Partner Owned</h6>
-    <ul class="qi">
-      <li>This integration is partner owned. Please reach out to the partner's support for any issues.</li>
-    </ul>
-    {% endif %}
+      {% if currentIntegration.partnerOwned %}<li>This integration is partner owned. Please reach out to the partner's support for any issues.</li>{% endif %}
+    </ul> 
   </div>
 </div>
 
@@ -26,10 +21,7 @@
     <ul class="qi">
       <li><p markdown=1>The {{ page.title }} is a Segment [Public API](/docs/api/public-api/){:target="_blank"} integration. It facilitates privacy requests using Segment’s API, including erasure and tracking opt-out for Segment users.</p></li>
       {% if currentIntegration.status == "PUBLIC_BETA" %}<li>This source is in <span class="release-pill">Beta</span></li>{% endif %}
-    </ul>
-    <h6>Partner Owned</h6>
-    <ul class="qi">
-      <li>This integration is partner owned. Please reach out to the partner's support for any issues.</li>
+      {% if currentIntegration.partnerOwned %}<li>This integration is partner owned. Please reach out to the partner's support for any issues.</li>{% endif %}
     </ul>
   </div>
 </div>
@@ -41,13 +33,8 @@
     <ul class="qi">
       <li><p markdown=1>The {{ page.title }} is an **Object Cloud** source. This means that it sends information (traits) about a thing that exists and persists over time, such as a person or company, and which can be updated over time. Data from this source can only be exported directly to a warehouse, but it can then be used for further analysis. [Learn more about cloud sources.](/docs/connections/sources/#cloud-apps)</p></li>
       {% if currentIntegration.status == "PUBLIC_BETA" %}<li>This source is in <span class="release-pill">Beta</span></li>{%endif%}
+      {% if currentIntegration.partnerOwned %}<li>This integration is partner owned. Please reach out to the partner's support for any issues.</li>{% endif %}
     </ul>
-    {% if currentIntegration.partnerOwned %}
-    <h6>Partner Owned</h6>
-    <ul class="qi">
-      <li>This integration is partner owned. Please reach out to the partner's support for any issues.</li>
-    </ul>
-    {% endif %}
   </div>
 </div>
 {% endif %}

--- a/src/_includes/content/destination-dossier.html
+++ b/src/_includes/content/destination-dossier.html
@@ -59,9 +59,9 @@
       <li>This destination is not compatible with <a href="/docs/connections/functions/insert-functions/">Destination Insert Functions.</a></li>
       {% endunless %}    
     {% endif %}
-  {% if destinationInfo.partnerOwned == true %}
+  {% unless page.id == '66b1f528d26440823fb27af9' %}{% if destinationInfo.partnerOwned == true %}
     <li>This integration is <strong>partner owned</strong>. Please reach out to the partner's support for any issues.</li>
-    {% endif %}
+    {% endif %}{% endunless %}
   {% if thisDestination == '64c031541451bb784943f809' or thisDestination == '63e42d44b0a59908dc4cacc6' or thisDestination == '642440d46b66b3eeac42b581' %} <li>This destination is <b>not</b> supported in EU workspaces. For more information, see the <a href="/docs/guides/regional-segment/">Regional Segment</a> documentation.</li> {% endif %}
   {% if destinationInfo.status == "PUBLIC_BETA" %}<li>This destination is in <span class="release-pill">Beta</span></li>{% endif %}
   {% if page.engage == true %}<li>This destination is <b>only</b> compatible with <a href="/docs/engage">Twilio Engage</a>.</li>{% endif %}
@@ -108,17 +108,6 @@
 </div>
 {% endunless %}
 {% endif %}
-
-{% unless page.id == '66b1f528d26440823fb27af9' %}
-{% if destinationInfo.partnerOwned == true %}
-<div>
-  <h6>Partner Owned</h6>
-  <ul class="qi">
-    <li>This integration is partner owned. Please reach out to the partner's support for any issues.</li>
-  </ul>
-</div>
-{% endif %}
-{% endunless %}
 </div>
 
 {% endif %}


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Some destinations had duplicate "partner owned" notes: 
<img width="724" height="331" alt="Screenshot 2025-07-25 at 2 26 41 PM" src="https://github.com/user-attachments/assets/91131fd3-bc7e-4a8d-be05-fcde43b8a00c" />


This PR fixes that: 
<img width="733" height="284" alt="Screenshot 2025-07-25 at 2 26 56 PM" src="https://github.com/user-attachments/assets/d3b71c29-40b0-4b92-a028-01fc7d0080a6" />

### Merge timing
asap!

### Related issues (optional)
#6915 
