### PR TITLE
Outdated prereq removed [DOC-1155]

### DIFF
--- a/src/connections/destinations/catalog/actions-segment-profiles/salesforce-source.md
+++ b/src/connections/destinations/catalog/actions-segment-profiles/salesforce-source.md
@@ -16,9 +16,8 @@ Once configured, this integration lets you send Salesforce data directly to Segm
 
 Before you begin, make sure that you have the following:
 
-- a Segment workspace with [Unify](/docs/unify/) enabled and [Identity Resolution](/docs/unify/identity-resolution/) set up
-- Administrator access to your Salesforce account
-- Salesforce Unify Direct Integration enabled for your workspace. [Contact Segment](https://segment.com/help/contact/){:target="_blank"} if you don't yet have the integration enabled.
+- a Segment workspace with [Unify](/docs/unify/) enabled and [Identity Resolution](/docs/unify/identity-resolution/) set up.
+- Administrator access to your Salesforce account.
 
 ## Integration steps
 


### PR DESCRIPTION
### Proposed changes

Removed 'Salesforce Unify Direct Integration enabled' prerequisite. The feature has been available for all workspaces since Sept 2024. 

### Merge timing

- ASAP
