### PR TITLE
STRATCONN-6101/wrong-description

### DIFF
--- a/src/_includes/content/destination-footer.md
+++ b/src/_includes/content/destination-footer.md
@@ -36,7 +36,7 @@ Segment lets you change these destination settings from the Segment app without 
   {% unless item.deprecated == true %}
 <tr>
 <td class="def" id="{{item.label | slugify}}">{{item.label}}{% if item.required == true %}<br /><i>(required)</i>{%endif%}</td>
-<td markdown="span"><code>{{item.type}}</code>{% if item.defaultValue != null and item.defaultValue != "" and item.defaultValue != '{}' and item.defaultValue != '[]'%}, defaults to {%if item.type == "array" %}{{item.defaultValue | join: ", " }}{%elsif item.type == "string"%}<code>{{item.defaultValue}}</code> {%elsif item.type == "boolean" %} <code>{{item.defaultValue | upcase }}</code> {%else%} {{item.defaultValue}}{%endif%}. <br /> <br /> {%else%}. {% endif %}{{item.description}}</td>
+<td markdown="span"><code>{{ item.type }}</code>{% unless item.defaultValue != nil and item.defaultValue != "" and item.defaultValue.size != 0 %}, has no default value. <br /><br /> {% else %}, defaults to {% if item.type == "array" %}{{ item.defaultValue | join: ", " }}{% elsif item.type == "string" %}<code>{{ item.defaultValue }}</code>{% elsif item.type == "boolean" %}<code>{{ item.defaultValue | upcase }}</code>{% endif %}.<br /><br />{% endunless %}{{ item.description }}</td>
 </tr>
 
 

--- a/src/_includes/content/destination-footer.md
+++ b/src/_includes/content/destination-footer.md
@@ -36,7 +36,7 @@ Segment lets you change these destination settings from the Segment app without 
   {% unless item.deprecated == true %}
 <tr>
 <td class="def" id="{{item.label | slugify}}">{{item.label}}{% if item.required == true %}<br /><i>(required)</i>{%endif%}</td>
-<td markdown="span"><code>{{item.type}}</code>{% if item.defaultValue != null and item.defaultValue != "" and item.defaultValue != '{}'%}, defaults to {%if item.type == "array" %}{{item.defaultValue | join: ", " }}{%elsif item.type == "string"%}<code>{{item.defaultValue}}</code> {%elsif item.type == "boolean" %} <code>{{item.defaultValue | upcase }}</code> {%else%} {{item.defaultValue}}{%endif%}. <br /> <br /> {%else%}. {% endif %}{{item.description}}</td>
+<td markdown="span"><code>{{item.type}}</code>{% if item.defaultValue != null and item.defaultValue != "" and item.defaultValue != '{}' and item.defaultValue != '[]'%}, defaults to {%if item.type == "array" %}{{item.defaultValue | join: ", " }}{%elsif item.type == "string"%}<code>{{item.defaultValue}}</code> {%elsif item.type == "boolean" %} <code>{{item.defaultValue | upcase }}</code> {%else%} {{item.defaultValue}}{%endif%}. <br /> <br /> {%else%}. {% endif %}{{item.description}}</td>
 </tr>
 
 


### PR DESCRIPTION
### Proposed changes

A customer reached out letting us know that the Kinesis Firehose destination is missing a [description](https://segment.com/docs/connections/destinations/catalog/amazon-kinesis-firehose/#settings:~:text=touch%20any%20code.-,SETTING,%2C%20defaults%20to%20.,-Please%20input%20the) for the mixed setting. [Raised the question in the #questions-destinations Slack channel](https://twilio.slack.com/archives/CC97A542H/p1753452294593029) 

Added empty array check to defaultValue condition in destination footer

- Add check for '[]' to prevent displaying "defaults to" text for empty arrays

### Merge timing
- ASAP once approved

Closes #5673 