### PR TITLE
rm Amplitude (Actions) from the integrations object callout

### DIFF
--- a/src/_includes/content/destination-dossier.html
+++ b/src/_includes/content/destination-dossier.html
@@ -49,7 +49,7 @@
 <ul class="qi">
   {% if destMethods.size > 0 %}{% unless page.id == '645d5fc12eb891cf0a93fe4b' %}<li>Accepts {% for method in destMethods%}{% if destMethods.size == 1 %}{{method}} calls.{% else %}{% unless forloop.last == true %}{{method}}, {% endunless %}{% if forloop.last == true%}and {{method}} calls{%endif%}{% endif %}{% endfor %}</li>{% endunless %}{% endif %}
   {% if previous_names.size == 1 or components.size == 0 %}
-    <li>Refer to it as <strong>{{previous_names | join: '</strong>, or <strong>' }}</strong> in the <a href="/docs/guides/filtering-data/#filtering-with-the-integrations-object">Integrations object</a></li>
+    <li>Refer to it as {% if page.id == '5f7dd6d21ad74f3842b1fc47' %}<strong>Actions Amplitude</strong> {% else %}<strong>{{previous_names | join: '</strong>, or <strong>' }}</strong>{% endif %} in the <a href="/docs/guides/filtering-data/#filtering-with-the-integrations-object">Integrations object</a></li>
   {% else %}
    {% if connectionModes.cloud.web == true or connectionModes.cloud.mobile == true or connectionModes.cloud.server == true %} <li>In Cloud-mode, refer to it as <strong>{{previous_names | join: '</strong>, or <strong>' }}</strong> in the <a href="/docs/guides/filtering-data/#filtering-with-the-integrations-object">Integrations object</a></li>{%endif%}
    {% if connectionModes.device.web == true or connectionModes.device.mobile == true or connectionModes.device.server == true %} <li>In Device-mode, refer to it as <strong>{{previous_names | first}}</strong> in the <a href="/docs/guides/filtering-data/#filtering-with-the-integrations-object">Integrations object</a> </li>{%endif%}


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
If users refer to Amplitude (Actions) as `Amplitude (Actions)` in the integrations object, it breaks. This fixes the mention in the destination dossier. TBD w/ eng if this is a pattern or a one-off example. 

Before
<img width="724" height="230" alt="Screenshot 2025-08-08 at 9 58 46 AM" src="https://github.com/user-attachments/assets/7108002b-4810-45cf-900a-62210f694f96" />

After
<img width="718" height="227" alt="Screenshot 2025-08-08 at 9 58 39 AM" src="https://github.com/user-attachments/assets/986368bf-a92b-41c3-9bfb-3f7b36d6f7b4" />



### Merge timing
ASAP!

### Related issues (optional)
STRATCONN-3629
DOC-1105
