### PR TITLE
Remove Action Destination API Limitation

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -32,7 +32,6 @@ Destination Actions are available to all customers on all Segment plans. You do 
 - You can use the [Event Tester](/docs/connections/test-connections) with Destination Actions. Event delivery metrics are collected and available in the destination information pages.
 - If you are using [Protocols](/docs/protocols/), Destination Actions actions are applied **after** [schema filters](/docs/protocols/enforce/schema-configuration/) and [transformations](/docs/protocols/transform/). 
 - If you are using [Destination Filters](/docs/connections/destinations/destination-filters/), Actions are applied after the filters. They are not applied to data that is filtered out.
-- Destination Actions can't be accessed or modified using the Segment APIs.
 
 ## Components of a Destination Action
 


### PR DESCRIPTION
### Proposed changes
Action Destinations & Mappings have a number of Public API endpoints:
- CREATE / GET / UPDATE / REMOVE Destination
- CREATE / GET / UPDATE / REMOVE Subscription (Mapping)
- https://docs.segmentapis.com/tag/Destinations

### Merge timing
- ASAP once approved?