### PR TITLE
Updating missed copy/moving alert info from Audience overview page to custom alerts page

### DIFF
--- a/src/monitor/alerts/custom-alerts.md
+++ b/src/monitor/alerts/custom-alerts.md
@@ -98,3 +98,25 @@ To create an Activation event health spikes or drops alert:
 To make changes to an Activation event health spikes or drops alert, select the icon in the Actions column for the alert and click **Edit**. 
 
 To delete a Activation event health spikes or drops alert, select the icon in the Actions column for the alert and click **Delete**.
+
+## Audience size change
+You can create an Audience size change alert that notifies you when your audience increases or decreases by a certain threshold. For example, if you set a change percentage of 4% and your destination had 100 members over the first 24 hours, Segment would notify you the following day if your audience had fewer than 96 or more than 104 members.
+
+> info "Audience size change alerts currently only support Linked Audiences"
+> Audience size change alerts are in public beta, and Segment is actively working on this feature. During the public beta, Audience size change alerts only support Linked Audiences. Some functionality may change before it becomes generally available.
+
+To create an Audience size change alert:
+
+1. From your Segment workspace’s home page, navigate to **Engage > Audiences**.
+2. Select the Linked Audience you want to create an alert for, select the Alerts tab, and click **Create alert**.
+3. On the Create alert sidesheet, select the Audience size change alert and pick a destination for which you’d like to monitor event health.
+4. Enter a percentage threshold to trigger audience size change notifications.
+5. Select one or more of the following alert channels:
+  - **Email**: Select this to receive notifications at the provided email address.
+  - **Slack**: Select this to send alerts to one or more channels in your workspace. You can post messages to your channel with either a webhook or a workflow.
+  - **In-app**: Select this to receive notifications in the Segment app. To view your notifications, select the bell next to your user icon in the Segment app.
+6. Click **Save**.
+
+To make changes to an Audience size change alert, select the icon in the Actions column for the alert and click **Edit**.
+
+To delete a Audience size change alert, select the icon in the Actions column for the alert and click **Delete.**

--- a/src/monitor/alerts/default-alerts.md
+++ b/src/monitor/alerts/default-alerts.md
@@ -49,7 +49,7 @@ View a brief description of each alert type. 
 - **Source Settings Modified**: A user in your workspace modified the settings for one of your sources.
 
 > info "Custom Source alerts"
-> During the Monitor public beta, you can configure custom [source volume alerts](/docs/connections/alerting/#source-volume-alerts), but these alerts won't appear in the Monitor tab. 
+> During the Monitor public beta, you can also configure custom [source volume alerts](/docs/monitor/alerts/custom-alerts/#source-volume-alert).
 
 ## Destination alerts
 - **Destination Disabled**: A user in your workspace disabled a destination. 
@@ -62,7 +62,7 @@ View a brief description of each alert type. 
 - **Destination Modified**: A user in your workspace made changes to a destination. 
 
 > info "Custom Destination alerts"
-> During the Monitor public beta, you can configure custom [Successful delivery rate alerts](/docs/connections/alerting/#successful-delivery-rate-alerts), but these alerts won't appear in the Monitor tab. 
+> During the Monitor public beta, you can also configure custom [Successful delivery rate alerts](/docs/monitor/alerts/custom-alerts/#successful-delivery-rate-alert) and 
 
 ## Storage Destination alerts
 - **Storage Destination Created**: A user in your workspace created a new instance of a storage destination. 
@@ -117,7 +117,7 @@ your identity-resolved profiles to your data warehouse.
 - **Audience Run Failed**: Segment was unable to compute your Audience. To resolve this error, please [contact Segment support](https://segment.com/help/contact/){:target="_blank”}.
 
 > info "Custom Engage alerts"
-> During the Monitor public beta, you can configure custom [Activation event health spikes or drops](/docs/engage/audiences/#activation-event-health-spikes-or-drops) and [Audience size change](/docs/engage/audiences/#audience-size-change) alerts, but these alerts won't appear in the Monitor tab. 
+> During the Monitor public beta, you can also configure custom [Activation event health spikes or drops](/docs/engage/audiences/#activation-event-health-spikes-or-drops) alerts.
 
 ## Users alerts
 - **Access Request Created**: A user in your workspace requested access to a resource that they don't currently have permission to view. For more information, see the [Request Access](/docs/segment-app/iam/membership/#request-access) documentation. 
@@ -137,7 +137,7 @@ your identity-resolved profiles to your data warehouse.
 - **Reverse ETL Sync Partial Success**: Segment was able to sync some, but not all, of your records from your data warehouse with your downstream destination. 
 
 > info "Custom Reverse ETL alerts"
-> During the Monitor public beta, you can configure custom Reverse ETL alerts for [mapping-level successful delivery rate fluctuations](/docs/connections/reverse-etl/manage-retl/#mapping-level-successful-delivery-rate-fluctuations), but these alerts won't appear in the Monitor tab. 
+> During the Monitor public beta, you can also configure custom Reverse ETL alerts for [mapping-level successful delivery rate fluctuations](/docs/monitor/alerts/custom-alerts/#mapping-level-successful-delivery-rate-fluctuations). 
 
 ## Data Graph alerts
 - **Data Graph Breaking Change**: A change in your warehouse broke components of your Data Graph. For more information about breaking changes, see the [Data Graph docs](/docs/unify/data-graph/#detect-warehouse-breaking-changes). 

--- a/src/monitor/alerts/index.md
+++ b/src/monitor/alerts/index.md
@@ -4,7 +4,7 @@ title: Alerts
 Segment's alerting features allow you to receive in-app, email, and Slack notifications related to the status, performance, and throughput of your Segment integrations. 
 
 > info "Public beta"
-> The Monitor hub is in Public Beta. Some functionality may change before it becomes generally available. During the public beta, only default alerts are located in the Monitor tab. 
+> The Monitor hub is in Public Beta. Some functionality may change before it becomes generally available.
 
 Segment has two kinds of alerts: 
 - **Default alerts**: Alerts that have a preset threshold and are often used to detect changes users make to the integrations in your workspace. For example, a _Source created_ alert is a default alert. 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
See title. I removed callouts referencing a former iteration of the product and moved audience size change from audience overview page to custom alerts tab

### Merge timing
ASAP

### Related issues (optional)
#7536 
