### PR TITLE
Add workaround for multiple emails on the same alert, general cleanup [DOC-1233]

### DIFF
--- a/src/monitor/alerts/custom-alerts.md
+++ b/src/monitor/alerts/custom-alerts.md
@@ -15,10 +15,23 @@ You can create alerts for the following product areas:
 - [Reverse ETL](#mapping-level-successful-delivery-rate-fluctuations)
 - [Twilio Engage](#activation-event-health-spikes-or-drops)
 
+The Alerting table includes the following information about each alert: 
+- **Alert name**: The type of alert; for example, "Source volume" or "Successful delivery rate".
+- **Threshold**: The volume of event fluctuation, represented as a change percentage, at which point you'd like to be notified.  
+- **Source**: The source that's sending your data downstream.
+- **Destination**: The destination receiving your data. 
+- **Created by**: The name of the user that created the alert and the date the alert was created.
+- **Status**: Either **enabled**, if the alert is currently configured in your workspace, or **disabled**, if you're not configured to receive alerts for an event.
+- **Notification channels**: Icons describing what notification channels you'll receive the alerts on - through a Slack webhook, Slack workflow, email, or in-app notification.
+- **Actions**: By selecting the menu icon for an individual alert, you can edit or delete it from the Alerting page. Only users with the Workspace Owner role can delete alerts created by other users.
+
+> info "Slack and mailing list notification channels require additional setup"
+> Before sending an alert to Slack, you must first create a Slack webhook. For more information about Slack webhooks, see Slack's [Sending messages using incoming webhooks](https://api.slack.com/messaging/webhooks){:target="_blank”} documentation.
+>
+> While you can only enter one email address per alert when signing up for email alerts, you can send the alert to multiple users by entering the email address of a mailing list. To create a mailing list, refer to the documentation for your email provider, like Google's [Create a group & choose group settings](https://support.google.com/groups/answer/2464926?hl=en){:target="_blank”} for Gmail or Microsoft's [Create and manage distribution groups](https://support.microsoft.com/en-us/office/distribution-groups-e8ba58a8-fab2-4aaf-8aa1-2a304052d2de#bkmk_create){:target="_blank”} for Outlook. 
+
 ## Source volume alert
 You can create an alert that notifies you when the volume of events received by your source in the last 24 hours changes beyond a threshold you set. For example, if you set a threshold of 4% and your source received 100 events over the first 24 hours, Segment would notify you the following day if your source ingested fewer than 96 or more than 104 events.
-
-To receive a source volume alert in a Slack channel, you must first create a Slack webhook. For more information about Slack webhooks, see the [Sending messages using incoming webhooks](https://api.slack.com/messaging/webhooks){:target="_blank”} documentation.
 
 <img src="/docs/connections/images/alerting-source-alert.png" alt="A screenshot of the Source Volume alert creation sidesheet." width="470px" height="540px">
 
@@ -33,38 +46,24 @@ To create a source volume alert:
   - **In-app**: Select this to receive notifications in the Segment app. To view your notifications, select the bell next to your user icon in the Segment app. 
 5. Click **Save**.
 
-To make changes to a source volume alert, select the icon in the Actions column for the alert and click **Edit**. 
-
-To delete a source volume alert, select the icon in the Actions column for the alert and click **Delete**.
-
-> info "Deleting alerts created by other users requires Workspace Owner permissions"
-> All users can delete source volume alerts that they created, but only those with Workspace Owner permissions can delete alerts created by other users. 
-
 ## Successful delivery rate alert
 
 You can create an alert that notifies you when the volume of events successfully received by your destination in the last 24 hours falls below a threshold you set. For example, if you set a threshold of 99%, Segment notifies you if your destination had a successful delivery rate of 98% or below. 
-
-To receive a successful delivery rate alert in a Slack channel, you must first create a Slack webhook. For more information about Slack webhooks, see the [Sending messages using incoming webhooks](https://api.slack.com/messaging/webhooks){:target="_blank”} documentation.
 
 To create a successful delivery rate alert: 
 1. Navigate to the [cloud-mode destinations](/docs/connections/destinations/#:~:text=Cloud%2Dmode%3A%20The%20sources%20send%20data%20directly%20to%20the%20Segment%20servers%2C%20which%20then%20translate%20it%20for%20each%20connected%20downstream%20destination%2C%20and%20send%20it%20on.) you'd like to configure alerts for. 
 2. Select the Alerts tab and click **Create alert**. 
 3. On the Create alert sidesheet, enter a percentage. You will receive events if your successful delivery rate falls below this threshold. 
 4. Select one of the following alert channels:
-  - **Email**: Select this to receive notifications at either the email address associated with your account or another email address that you enter into this field. 
+  - **Email**: Select this to receive notifications at one email address. 
   - **Slack**: Select this and enter a Slack webhook URL and channel name to send alerts to a channel in your Slack workspace.
   - **In-app**: Select this to receive notifications in the Segment app. To view your notifications, select the bell next to your user icon in the Segment app. 
 5. Click **Save**.
 
-To make changes to a successful delivery rate alert, select the icon in the Actions column for the alert and click **Edit**. 
-
-To delete a successful delivery rate alert, select the icon in the Actions column for the alert and click **Delete**. 
 
 ## Mapping-level successful delivery rate fluctuations
 
 You can create an alert that notifies you when the volume of events successfully received by your mapping in the last 24 hours falls below a threshold you set. For example, if you set a threshold of 99%, Segment notifies you if your destination had a successful delivery rate of 98% or below. 
-
-To receive a successful delivery rate fluctuation alert in a Slack channel, you must first create a Slack webhook. For more information about Slack webhooks, see Slack's [Sending messages using incoming webhooks](https://api.slack.com/messaging/webhooks){:target="_blank”} documentation.
 
 ![A screenshot of the Alerts tab for a Mapping, with the new mapping sidesheet partially filled out.](/docs/connections/reverse-etl/images/mapping-alerting.jpeg)
 
@@ -77,8 +76,6 @@ To subscribe to alerts for successful delivery fluctuations at the mapping level
     - **Slack notification**: Enter a Webhook URL and a Slack channel name to receive alerts in a Slack channel. 
     - **In-app notifications**: Select this to receive notifications in the Segment app. To view your notifications, select the bell next to your user icon in the Segment app.
 5. Toggle the **Enable alert** setting on and click **Create**. 
-
-To edit or disable your alert, navigate to your mapping's Alerts tab and select the Actions menu for the alert you'd like to edit.  
 
 ## Activation event health spikes or drops
 
@@ -94,10 +91,6 @@ To create an Activation event health spikes or drops alert:
   - **Slack**: Select this to send alerts to one or more channels in your workspace. 
   - **In-app**: Select this to receive notifications in the Segment app. To view your notifications, select the bell next to your user icon in the Segment app. 
 6. Click **Save**.
-
-To make changes to an Activation event health spikes or drops alert, select the icon in the Actions column for the alert and click **Edit**. 
-
-To delete a Activation event health spikes or drops alert, select the icon in the Actions column for the alert and click **Delete**.
 
 ## Audience size change
 You can create an Audience size change alert that notifies you when your audience increases or decreases by a certain threshold. For example, if you set a change percentage of 4% and your destination had 100 members over the first 24 hours, Segment would notify you the following day if your audience had fewer than 96 or more than 104 members.
@@ -116,7 +109,3 @@ To create an Audience size change alert:
   - **Slack**: Select this to send alerts to one or more channels in your workspace. You can post messages to your channel with either a webhook or a workflow.
   - **In-app**: Select this to receive notifications in the Segment app. To view your notifications, select the bell next to your user icon in the Segment app.
 6. Click **Save**.
-
-To make changes to an Audience size change alert, select the icon in the Actions column for the alert and click **Edit**.
-
-To delete a Audience size change alert, select the icon in the Actions column for the alert and click **Delete.**

--- a/src/monitor/alerts/default-alerts.md
+++ b/src/monitor/alerts/default-alerts.md
@@ -22,7 +22,7 @@ You can create alerts for the following product areas:
 - [Data Graph](#data-graph-alerts)
 
 The Alerting table includes the following information about each event: 
-- **Alert name**: The type of alert, for example, "Audience created" or "Audience deleted".
+- **Alert name**: The type of alert; for example, "Audience created" or "Audience deleted".
 - **Last triggered**: The most recent date and time, in your local time zone, that the alert was triggered. Some alerts, like **Violations Detected**, trigger only once per day. 
 - **Status**: Either **enabled**, if the alert is currently configured in your workspace, or **disabled**, if you're not configured to receive alerts for an event.
 - **Notification channels**: Icons describing what notification channels you'll receive the alerts on - through a Slack webhook, Slack workflow, email, or in-app notification.
@@ -34,6 +34,11 @@ To create a new alert:
 1. From the Segment app, navigate to the **Monitor** tab and select **Alerts**. 
 2. On the **Default** tab, identify the event you'd like to be alerted for and select the menu icon under the **Actions** tab. 
 3. Click **Enable alert**. 
+
+> info "Slack and mailing list notification channels require additional setup"
+> Before sending an alert to Slack, you must first create a Slack webhook. For more information about Slack webhooks, see Slack's [Sending messages using incoming webhooks](https://api.slack.com/messaging/webhooks){:target="_blank”} documentation.
+>
+> While you can only enter one email address at a time when signing up for email alerts, you can send the alert to multiple users by entering the email address of a mailing list. To create a mailing list, refer to the documentation for your email provider, like Google's [Create a group & choose group settings](https://support.google.com/groups/answer/2464926?hl=en){:target="_blank”} for Gmail or Microsoft's [Create and manage distribution groups](https://support.microsoft.com/en-us/office/distribution-groups-e8ba58a8-fab2-4aaf-8aa1-2a304052d2de#bkmk_create){:target="_blank”} for Outlook. 
 
 ## Alert descriptions
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added workaround for multiple emails linked to one alert, cleaned up custom alerts page + default alerts

### Merge timing
After approval!

### Related issues (optional)