### PR TITLE
Fix typo in editing real-time audiences instructions [DOC-1258]

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -246,7 +246,7 @@ To edit a realtime trait or audience:
 1. In your Engage Space, select the **Computed Traits** or **Audiences** tab.
 2. Select the realtime audience or trait you want to edit.
 3. Select the **Builder** tab and make your edits.
-4. Preview the results, then select **Create Audience** to confirm your edits.
+4. Preview the results, then select **Save audience** to confirm your edits.
 
 Engage then processes your realtime audience or trait edits. While the edit task runs, the audience remains locked and you can't make further changes. Once Engage incorporates your changes, you'll be able to access your updated audience or trait.
 


### PR DESCRIPTION
### Proposed changes

- Fixed the language in the steps that describe how to save an edited audience. The current step says "Create Audience," but it should say "Save audience."

### Merge timing

- ASAP once approved.