### PR TITLE
Adds link to liquidjs docs, section for whitespace

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -240,12 +240,10 @@ You can't concatenate event variables and plain text with static values and func
 ![Mapping UI showing two concatenated fields: "+1 phone" and "context.page.url context.page.path"](images/mapping-concatenation.png)
 
 ### Liquid syntax
-The liquid syntax function enables you to transform event data with fine-grain control before it reaches cloud-mode destinations using the LiquidJS templating language. Use Liquid templates to clean, format, or conditionally transform data such as user properties, timestamps, or event metadata to meet the requirements of your downstream tools. Liquid templates are applied in the **Mappings** tab of your Segment workspace to enable you to integrate with your event pipeline.
-
-Segment uses liquidJS to power this functionality. For full documentation please see the [liquidjs docs](https://liquidjs.com/tutorials/intro-to-liquid.html).
+The Liquid syntax function enables you to transform event data with fine-grain control before it reaches cloud-mode destinations using the [LiquidJS templating language](https://liquidjs.com/tutorials/intro-to-liquid.html){:target="_blank”}. Use Liquid templates to clean, format, or conditionally transform data such as user properties, timestamps, or event metadata to meet the requirements of your downstream tools. Liquid templates are applied in the **Mappings** tab of your Segment workspace for you to integrate with your event pipeline.
 
 #### Whitespace
-By default liquid will generate a newline when inputing multi-line templates. To strip these newlines you may use hyphens in the syntax (`{{-`, `-}}`, `{%-`, `-%}`). See the liquidjs docs [here](https://liquidjs.com/tutorials/whitespace-control.html) for more information.
+By default, Liquid will generate a newline when inputing multi-line templates. To strip these newlines you can use hyphens in the syntax (`{{-`, `-}}`, `{%-`, `-%}`). See the [LiquidJS docs](https://liquidjs.com/tutorials/whitespace-control.html) for more information.
 
 #### Supported liquid tags and filters
 Segment supports the following LiquidJS tags and filters for mappings. Segment selected these to ensure performance, security, and compatibility with real-time event processing. Segment disabled unsupported tags and filters to prevent performance degradation or security risks.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Since rolling out the Liquid feature, we've received numerous customer questions about Liquid behavior. To help customers find answers independently, we should add a link to the official Liquid documentation on our existing docs page.

Action needed:

Add a link to the official Liquid docs (https://shopify.github.io/liquid/ ) on this page: https://segment.com/docs/connections/destinations/actions/#liquid-syntax

This will give customers a self-service option to quickly resolve their Liquid syntax questions without needing to contact support.
### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
