### PR TITLE
hotfix for failing develop builds

### DIFF
--- a/src/connections/destinations/actions.md
+++ b/src/connections/destinations/actions.md
@@ -243,7 +243,7 @@ You can't concatenate event variables and plain text with static values and func
 The Liquid syntax function enables you to transform event data with fine-grain control before it reaches cloud-mode destinations using the [LiquidJS templating language](https://liquidjs.com/tutorials/intro-to-liquid.html){:target="_blank”}. Use Liquid templates to clean, format, or conditionally transform data such as user properties, timestamps, or event metadata to meet the requirements of your downstream tools. Liquid templates are applied in the **Mappings** tab of your Segment workspace for you to integrate with your event pipeline.
 
 #### Whitespace
-By default, Liquid will generate a newline when inputing multi-line templates. To strip these newlines you can use hyphens in the syntax (`{{-`, `-}}`, `{%-`, `-%}`). See the [LiquidJS docs](https://liquidjs.com/tutorials/whitespace-control.html) for more information.
+By default, Liquid will generate a newline when inputing multi-line templates. To strip these newlines you can use hyphens in the syntax ({% raw %} `{{-`, `-}}`, `{%-`, `-%}` {% endraw %}). See the [LiquidJS docs](https://liquidjs.com/tutorials/whitespace-control.html) for more information.
 
 #### Supported liquid tags and filters
 Segment supports the following LiquidJS tags and filters for mappings. Segment selected these to ensure performance, security, and compatibility with real-time event processing. Segment disabled unsupported tags and filters to prevent performance degradation or security risks.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Some Liquid syntax was causing build failures in develop, this PR remedies that.
<img width="983" height="101" alt="Screenshot 2025-09-17 at 10 17 05 AM" src="https://github.com/user-attachments/assets/54827b68-e64e-4207-b690-c11be2884442" />



The page now looks like this: 
<img width="723" height="144" alt="Screenshot 2025-09-17 at 10 14 41 AM" src="https://github.com/user-attachments/assets/ba92893f-3d41-418f-a9bd-6bd21d8fe0e8" />

### Merge timing
asap!

### Related issues (optional)
#7942 
