### PR TITLE
Add callout about ID sync edge case

### DIFF
--- a/src/engage/audiences/index.md
+++ b/src/engage/audiences/index.md
@@ -37,6 +37,9 @@ Select `and not who` to indicate users that have not performed an event. For exa
 
 You can also specify two different types of time-windows, `within` and `in between`. The `within` property lets you specify an event that occurred in the last `x` number of days, while `in between` lets you specify events that occurred over a rolling time window in the past. A common use case is to look at all customers that were active 30 to 90 days ago, but have not completed an action in the last 30 days.
 
+> warning "ID Sync configuration and space-level ID Strategy aren't applied for Audience Exit events"
+> Segment sends all ID combinations for Audience Exit events downstream to remove a user from the external audience.
+
 ### Building audiences with traits
 
 You can also build audiences using Custom Traits, Computed Traits, SQL Traits, and audience memberships.

--- a/src/engage/trait-activation/id-sync.md
+++ b/src/engage/trait-activation/id-sync.md
@@ -58,6 +58,7 @@ With Customized setup, you can choose which identifiers you want to map downstre
 - Segment doesn't maintain ID Sync history, which means that any changes are irreversible. 
 - You can only select a maximum of three identifiers with an `All` strategy.
 - Segment recommends that you map Segment properties to destination properties using [Destination Actions](/docs/connections/destinations/actions/#components-of-a-destination-action) instead of ID Sync. If you use ID Sync to map properties, Segment adds the property values as traits and identifiers to your Profiles. 
+- ID Sync configuration and space-level ID Strategy aren't applied for Audience Exit events. Segment sends all ID combinations for Audience Exit events downstream to remove a user from the external audience.
 
 
 ## FAQs


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added a callout noting that Audience Exit events don't respect ID sync rules - this is expected behavior. [Slack thread for ref](https://twilio.slack.com/archives/C7F3N3RV4/p1730109816700899)
 
### Merge timing
asap!

### Related issues (optional)

