### PR TITLE
Update Reddit Audiences index with hashing warning

### DIFF
--- a/src/connections/destinations/catalog/actions-reddit-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-reddit-audiences/index.md
@@ -29,7 +29,7 @@ This destination is maintained by Reddit. For any issues with the destination, [
 9. Navigate to the engage space that contains the audience, and select it in the **Audiences** tab.
 10. Click **Add Destination**.
 
-> warning ""
-> Reddit Audiences destination automatically hashes `email`, `iOS Ad ID` and `Android Ad ID` fields when syncing the audience to Reddit.
+> info "Automatic hashing"
+> Segment automatically hashes the `email`, `iOS Ad ID`, and `Android Ad ID` fields before sending audiences to Reddit.
 
 {% include components/actions-fields.html %}


### PR DESCRIPTION
Added a note that the destination automatically hashes email and Mobile Ids when syncing to the destination

### Proposed changes
Added a note that the destination hashes email and MAID to address common question

### Merge timing
Once approved

### Related issues (optional)
