### PR TITLE
chore: remove video from engage/journeys

### DIFF
--- a/src/engage/journeys/index.md
+++ b/src/engage/journeys/index.md
@@ -7,11 +7,6 @@ redirect_from:
 
 Journeys, a feature of [Engage](/docs/engage/), provides a way for marketers to personalize experiences through planning how and when to engage customers with the right campaigns and messages.
 
-<video width="690px" controls autoplay aria-label="Demo video setting up a new journey with entry and true/false split conditions.">
-  <source src="images/journeys-teaser.webm" type="video/webm">
-  <source src="images/journeys-teaser.mp4" type="video/mp4">
-</video>
-
 Journeys let you define steps in a user's journey based on event behavior and traits. You can build Journeys from your tracking events, traits, computed traits, or audiences. At each step of a journey, you can send your list of users to any Engage-compatible destination.
 
 ## Getting started


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

The docs platform does not support embedded videos. Michael talked to Paul about this and he said it was fine to remove the video for now to unblock serialization, as it can be added any time in the future. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

Merge ASAP!

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
