### PR TITLE
Update Auto-Instrumentation setup flow to use existing sources

### DIFF
--- a/src/connections/auto-instrumentation/swift-setup.md
+++ b/src/connections/auto-instrumentation/swift-setup.md
@@ -11,7 +11,7 @@ You'll learn how to connect an existing source, integrate dependencies, turn on 
 > Auto-Instrumentation is currently in Private Beta and is governed by Segment's [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}. Segment is actively iterating on and improving the Auto-Instrumentation user experience.
 
 > success "Enable Auto-Instrumentation"
-> To enable Auto-Instrumentation in your Segment workspace, reach out to your dedicated account manager.
+> To turn Auto-Instrumentation on in your Segment workspace, reach out to your dedicated account manager.
 
 ## Step 1: Get your source write key
 
@@ -74,11 +74,21 @@ typealias NavigationLink = SignalNavigationLink
 typealias TextField = SignalTextField
 typealias SecureField = SignalSecureField
 ```
-## Step 3: Verify and deploy events
+
+## Step 3: Turn on Auto-Instrumentation in your source
+
+Next, return to the source settings to turn on Auto-Instrumentation:
+
+1. Go to **Connections > Sources**.
+2. Select your source you used in Step 1.
+3. From the source's overview tab, go to **Settings > Advanced**.
+4. Toggle Auto-Instrumention on.
+
+## Step 4: Verify and deploy events
 
 After integrating the SDK and running your app, verify that Segment is collecting signals:
 
-1. In your Segment workspace, go to **Connections > Sources** and select the source you created for Auto-Instrumentation.
+1. In your Segment workspace, go to **Connections > Sources** and select the source you used for Auto-Instrumentation.
 2. In the source overview, look for the **Event Builder** tab. If the tab doesn’t appear:
   - Make sure you've installed the SDK correctly.
   - Reach out to your Segment CSM to confirm that your workspace has the necessary feature flags enabled.

--- a/src/connections/auto-instrumentation/swift-setup.md
+++ b/src/connections/auto-instrumentation/swift-setup.md
@@ -5,7 +5,7 @@ hidden: true
 
 This guide outlines the steps required to set up the Signals SDK in your Apple OS applications using Swift. 
 
-You'll learn how to add Auto-Instrumentation sources, integrate dependencies, and ensure that your setup captures and processes data as intended.  
+You'll learn how to connect an existing source, integrate dependencies, turn on Auto-Instrumentation, and verify that your setup captures and processes data as intended. 
 
 > info "Auto-Instrumentation Private Beta"
 > Auto-Instrumentation is currently in Private Beta and is governed by Segment's [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}. Segment is actively iterating on and improving the Auto-Instrumentation user experience.
@@ -13,23 +13,14 @@ You'll learn how to add Auto-Instrumentation sources, integrate dependencies, an
 > success "Enable Auto-Instrumentation"
 > To enable Auto-Instrumentation in your Segment workspace, reach out to your dedicated account manager.
 
-## Step 1: Add or enable a source and get its write key
+## Step 1: Get your source write key
 
-You can either create a new source or turn on Auto-Instrumentation for an existing source. Both methods let you retrieve the `writeKey` that you’ll need later.
+You’ll need the `writeKey` from an existing Segment source:
 
-### Create a new source
-
-1. In your Segment workspace, navigate to **Connections > Auto-Instrumentation**.
-2. Select **Add source**, give the source a name, and click **Save**.
-3. Return to **Connections > Sources** and select the new source you just set up.
-4. In the **Initialize the Client** section, copy the `writeKey` shown in the code block.
-
-### Enable Auto-Instrumentation on an existing source
-
-If you want to use an existing source, copy its `writeKey` from **Initialize the Client**. After you install the SDK (Step 2), return to the source settings to turn on Auto-Instrumentation:
-
-- **Web:** **Connections > Sources > [source] > Settings > Analytics.js > Auto-Instrumentation** and toggle it on.
-- **Mobile:** **Connections > Sources > [source] > Settings > Advanced > Auto-Instrumentation** and toggle it on.
+1. In your Segment workspace, go to **Connections > Sources**.
+2. Select your source.
+3. From the source's overview tab, go to **Settings > API Keys**.
+4. Copy the `writeKey` shown in the code block.
 
 ## Step 2: Add dependencies and initialization code
 

--- a/src/connections/auto-instrumentation/web-setup.md
+++ b/src/connections/auto-instrumentation/web-setup.md
@@ -5,7 +5,7 @@ hidden: true
 
 This guide outlines the steps required to set up the Signals SDK in your JavaScript website.
 
-You'll learn how to use an existing Segment source, integrate dependencies, turn on Auto-Instrumentation, and verify that your setup captures and processes data as intended.
+You'll learn how to connect an existing source, integrate dependencies, turn on Auto-Instrumentation, and verify that your setup captures and processes data as intended.
 
 > info "Auto-Instrumentation Private Beta"
 > Auto-Instrumentation is currently in Private Beta and is governed by Segment's [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}. Segment is actively iterating on and improving the Auto-Instrumentation user experience.

--- a/src/connections/auto-instrumentation/web-setup.md
+++ b/src/connections/auto-instrumentation/web-setup.md
@@ -17,7 +17,7 @@ You'll learn how to use an existing Segment source, integrate dependencies, turn
 
 You’ll need the `writeKey` from an existing Segment source:
 
-1. In your Segment workspace, go to to **Connections > Sources**.
+1. In your Segment workspace, go to **Connections > Sources**.
 2. Select your source.
 3. From the source's overview tab, go to **Settings > API Keys**.
 4. Copy the `writeKey` shown in the code block.
@@ -189,15 +189,20 @@ Verify that you only have **one snippet** in your site, then move to [Step 3: Ve
 
 3. Build and run your app.
 
-## Step 3: Enable Auto-Instrumentation in your source
+## Step 3: Turn on Auto-Instrumentation in your source
 
+Next, return to the source settings to turn on Auto-Instrumentation:
 
+1. Go to **Connections > Sources**.
+2. Select your source you used in Step 1.
+3. From the source's overview tab, go to **Settings > Analytics.js**.
+4. Toggle Auto-Instrumention on.
 
 ## Step 4: Verify and deploy events
 
 After integrating the SDK and running your app, verify that Segment is collecting signals:
 
-1. In your Segment workspace, return to **Connections > Sources**, then select the source you created for Auto-Instrumentation.
+1. In your Segment workspace, return to **Connections > Sources**, then select the source you used for Auto-Instrumentation.
 2. In the source overview, look for the **Event Builder** tab. If the tab doesn’t appear:
   - Make sure you've installed the SDK correctly.
   - Reach out to your Segment CSM to confirm that your workspace has the necessary feature flags enabled.

--- a/src/connections/auto-instrumentation/web-setup.md
+++ b/src/connections/auto-instrumentation/web-setup.md
@@ -11,7 +11,7 @@ You'll learn how to connect an existing source, integrate dependencies, turn on 
 > Auto-Instrumentation is currently in Private Beta and is governed by Segment's [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}. Segment is actively iterating on and improving the Auto-Instrumentation user experience.
 
 > success "Enable Auto-Instrumentation"
-> To turn on Auto-Instrumentation in your Segment workspace, reach out to your dedicated account manager.
+> To turn Auto-Instrumentation on in your Segment workspace, reach out to your dedicated account manager.
 
 ## Step 1: Get your source write key
 
@@ -202,7 +202,7 @@ Next, return to the source settings to turn on Auto-Instrumentation:
 
 After integrating the SDK and running your app, verify that Segment is collecting signals:
 
-1. In your Segment workspace, return to **Connections > Sources**, then select the source you used for Auto-Instrumentation.
+1. In your Segment workspace, go to **Connections > Sources** and select the source you used for Auto-Instrumentation.
 2. In the source overview, look for the **Event Builder** tab. If the tab doesn’t appear:
   - Make sure you've installed the SDK correctly.
   - Reach out to your Segment CSM to confirm that your workspace has the necessary feature flags enabled.

--- a/src/connections/auto-instrumentation/web-setup.md
+++ b/src/connections/auto-instrumentation/web-setup.md
@@ -5,31 +5,22 @@ hidden: true
 
 This guide outlines the steps required to set up the Signals SDK in your JavaScript website.
 
-You'll learn how to add Auto-Instrumentation sources, integrate dependencies, and ensure that your setup captures and processes data as intended.
+You'll learn how to use an existing Segment source, integrate dependencies, turn on Auto-Instrumentation, and verify that your setup captures and processes data as intended.
 
 > info "Auto-Instrumentation Private Beta"
 > Auto-Instrumentation is currently in Private Beta and is governed by Segment's [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}. Segment is actively iterating on and improving the Auto-Instrumentation user experience.
 
 > success "Enable Auto-Instrumentation"
-> To enable Auto-Instrumentation in your Segment workspace, reach out to your dedicated account manager.
+> To turn on Auto-Instrumentation in your Segment workspace, reach out to your dedicated account manager.
 
-## Step 1: Add or enable a source and get its write key
+## Step 1: Get your source write key
 
-You can either create a new source or turn on Auto-Instrumentation for an existing source. Both methods let you retrieve the `writeKey` that you’ll need later.
+You’ll need the `writeKey` from an existing Segment source:
 
-### Create a new source
-
-1. In your Segment workspace, navigate to **Connections > Auto-Instrumentation**.
-2. Select **Add source**, give the source a name, and click **Save**.
-3. Return to **Connections > Sources** and select the new source you just set up.
-4. In the **Initialize the Client** section, copy the `writeKey` shown in the code block.
-
-### Enable Auto-Instrumentation on an existing source
-
-If you want to use an existing source, copy its `writeKey` from **Initialize the client**. After you install the SDK (Step 2), return to the source settings to turn on Auto-Instrumentation:
-
-- **Web:** **Connections > Sources > [source] > Settings > Analytics.js > Auto-Instrumentation** and toggle it on.
-- **Mobile:** **Connections > Sources > [source] > Settings > Advanced > Auto-Instrumentation** and toggle it on.
+1. In your Segment workspace, go to to **Connections > Sources**.
+2. Select your source.
+3. From the source's overview tab, go to **Settings > API Keys**.
+4. Copy the `writeKey` shown in the code block.
 
 ## Step 2: Add dependencies and initialization code
 
@@ -198,7 +189,11 @@ Verify that you only have **one snippet** in your site, then move to [Step 3: Ve
 
 3. Build and run your app.
 
-## Step 3: Verify and deploy events
+## Step 3: Enable Auto-Instrumentation in your source
+
+
+
+## Step 4: Verify and deploy events
 
 After integrating the SDK and running your app, verify that Segment is collecting signals:
 


### PR DESCRIPTION
### Proposed changes

- Removed instructions for creating a new “Auto-Instrumentation source” (that path doesn't exist anymore).
- Step 1 now directs users to retrieve the `writeKey` from an existing source.
- Added Step 3 to explicitly enable Auto-Instrumentation in the source settings (web and mobile toggle paths).
- Other minor style guide cleanup.

### Merge timing

- ASAP once approved.
