### PR TITLE
Add permissions, preview section, and tracking plan integration information for auto-instrumentation

### DIFF
--- a/src/connections/auto-instrumentation/configuration.md
+++ b/src/connections/auto-instrumentation/configuration.md
@@ -23,11 +23,12 @@ After you set up the Signals SDK to capture the signals you want to target, you 
 
 ### Getting started with rule creation
 
-1. In your Segment workspace, go to **Sources** and select a source.
-2. Open the **Event Builder**, then click **Create Rules**.
+1. Ensure you have the `Workspace Owner` or `Source Admin` role in Segment. If your source is connected to a tracking plan, you will also need, at a minimum, the `Tracking Plan Read-only` role. To view the content in the Event Builder tab, you will need, at a minimum, the `Source Read-only` role.
+2. In your Segment workspace, go to **Sources** and select a source.
+3. Open the **Event Builder**, then click **Create Rules**.
 
 > info "Where's the Event Builder tab?"
-> The Event Builder tab only appears after you've installed the Auto-Instrumentation snippet in your site or app. If you don’t see the tab, double check your implementation or reach out to your Segment CSM.
+> The Event Builder tab only appears after you've enabled Auto Instrumentation under the Analytics.js tab in the source's settings. If you don’t see the tab, reach out to your Segment CSM.
 
 ### Using the Rules Editor
 
@@ -37,6 +38,10 @@ The Rules Editor is where you define rules that transform raw signal data into a
 - Set conditions to control when events should be triggered
 - Assign custom event names
 
+#### Tracking plan integration
+
+If your source is connected to a tracking plan, you can quickly confirm that a rule’s event and properties are planned. When creating or editing a rule, choose an event by typing its name or selecting from the tracking plan’s events in a dropdown. Similarly, add properties by typing their names or selecting from the event’s properties in a dropdown. The Planned column, shown next to each property mapping and in the Event Rules table, indicates whether the property or event is planned.
+
 #### Adding event properties
 
 You can enrich your events by adding properties based on signal metadata. For example:
@@ -45,6 +50,11 @@ You can enrich your events by adding properties based on signal metadata. For ex
 - Add a boolean field like `couponApplied` to your **Order Completed** event
 
 These properties are sent alongside your event, giving your team deeper insights without requiring any manual instrumentation.
+
+#### Preview your event rule
+
+To verify that a rule is working as expected, you don't need to enter a cycle of creating and updating the rule, generating signals, then checking the source debugger for the generated event. As you create, edit, or view a rule, you can preview it in real time against the current signal buffer to see which signals match and what the resulting event will look like. Event properties are mapped to the values found in the matched signals, and complete matches are grouped by anonymous ID.
+
 
 <!-- PW, 6 August 2025: Commenting this section out for now
 


### PR DESCRIPTION
### Proposed changes
1. Added information about necessary permissions needed to use auto instrumentation
2. Added information about the preview section and tracking plan integration
3. Fixed information about how to toggle view of the Event Builder tab

### Merge timing
- ASAP once approved

### Related issues (optional)