### PR TITLE
Segment no longer supports unlimited retention periods [hotfix]

### DIFF
--- a/src/privacy/data-retention-policy.md
+++ b/src/privacy/data-retention-policy.md
@@ -23,7 +23,7 @@ Segment’s enforcement of this data retention policy for active customers begin
 
 An active customer is a Business or Team Tier customer that has an active Segment contract with no outstanding invoices and no locked workspace, or a Free Tier workspace that has had event traffic or user activity in the past 30 days. 
 
-Segment enforces a data retention period of up to 3 years for Business Tier customers. Segment **no longer supports** unlimited data retention, but continues to honor any limited, previously agreed upon retention period. If your business requires a longer retention period, please contact your sales team to discuss available options.on.
+Segment enforces a data retention period of up to 3 years for Business Tier customers. Segment **no longer supports** unlimited data retention, but continues to honor any limited, previously agreed upon retention period. If your business requires a longer retention period, please contact your sales team to discuss available options.
 
 ### Data retention period
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Sales was interpreting the previous language to mean that the unlimited retention period would be honored if someone had a workspace prior to the data retention period being in place - this PR should fix that. 

### Merge timing
After approval from ~~legal~~, ~~product~~, and eng

### Related issues (optional)
#7377 
