### PR TITLE
Fix broken Mixpanel source anchor link + clean up a bunch of stuff

### DIFF
--- a/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/mixpanel-swift.md
+++ b/src/connections/sources/catalog/libraries/mobile/apple/destination-plugins/mixpanel-swift.md
@@ -207,7 +207,7 @@ Segment sends one event per Page call.
 
 ### Incrementing properties
 
-To increment at the property level, tell Segment which properties you want to increment using the **Properties to increment** setting and Segment calls Mixpanel's `increment` for you when you attach a number to the property (for example, `'items purchased': 5`)
+To increment values for specific properties, add them to the **Properties to increment** setting in your Mixpanel destination. Segment calls Mixpanel’s `increment` method automatically whenever you include a numeric property in an event (for example, `'items purchased': 5`).
 
 ### Screen
 


### PR DESCRIPTION
### Proposed changes

- Updated the broken link `#group-using-device-mode` to `[Identify traits list](#identify)`. This is part of the migration cleanup work.
- The original anchor (#group-using-device-mode) referenced a legacy section that no longer exists. Its content (the Mixpanel special traits mapping table) now appears under the Identify section.
- While I was in there, I noticed... a bunch of style fixes.  So I took care of them. 
- I also reworded a bunch of weird/repetitive/unclear phrasing.
- Converted an HTML table to Markdown.
- Cleaned up some Swift code samples that weren't formatted correctly.

### Merge timing

- ASAP once approved
