### PR TITLE
Stackadapt Audience: add more details to the action destination doc

### DIFF
--- a/src/connections/destinations/catalog/actions-stackadapt-audiences/index.md
+++ b/src/connections/destinations/catalog/actions-stackadapt-audiences/index.md
@@ -17,7 +17,7 @@ This destination is maintained by StackAdapt. For any issues with the destinatio
 ## Getting started
 
 > info "Getting your StackAdapt GraphQL token"
-> If you do not have an existing StackAdapt read & write API key, contact the [StackAdapt team](https://support.stackadapt.com/hc/en-us/requests/new?ticket_form_id=360006572593){:target="\_blank"}.
+> If you do not have an existing StackAdapt read and write API key, contact the [StackAdapt team](https://support.stackadapt.com/hc/en-us/requests/new?ticket_form_id=360006572593){:target="\_blank"}.
 
 ### Setting up the StackAdapt Audiences destination in Engage
 


### PR DESCRIPTION
This pull request updates the documentation for the StackAdapt Audiences destination to improve clarity, update instructions, and fix formatting issues. The most significant changes are a complete rewrite and reorganization of the setup and audience sync instructions, clarification of mapping steps, and consistent use of external link formatting.

**Documentation improvements and reorganization:**

* Rewrote and reorganized the "Setting up the StackAdapt Audiences destination in Engage" and "Sync an Engage Audience" sections for better clarity and step-by-step guidance, including more explicit instructions for mapping and syncing audiences.
* Clarified the process for mapping fields and explained how mappings are shared across audiences, with instructions for creating new destinations if different mappings are needed.
* Updated instructions for creating a StackAdapt audience from an Engage audience, including corrections to navigation and terminology.

**Formatting and consistency:**

* Fixed formatting of external links throughout the document to use `{:target="\_blank"}` for consistency and proper rendering. [[1]](diffhunk://#diff-088ee47ca823ff1fe8de651f7cd30ede660ad73539235d8699e8e82d32d0da5dL13-R80) [[2]](diffhunk://#diff-088ee47ca823ff1fe8de651f7cd30ede660ad73539235d8699e8e82d32d0da5dL83-R91)
* Corrected formatting of info boxes and image references for improved readability.<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
