### PR TITLE
Add callout explaining that Auto-Instrumentation is unavailable in EU workspaces

### DIFF
--- a/src/connections/auto-instrumentation/configuration.md
+++ b/src/connections/auto-instrumentation/configuration.md
@@ -13,6 +13,9 @@ This guide assumes that you've already added the Signals SDK to your application
 > info "Auto-Instrumentation in public beta"
 > Auto-Instrumentation is in public beta, and Segment is actively working on this feature. Some functionality may change before it becomes generally available.                  
 
+> info "Regional availability"
+> Auto-Instrumentation isn't supported in EU workspaces.
+
 ## Converting signals to events
 
 After you set up the Signals SDK to capture the signals you want to target, you can create rules in your Segment workspace to translate the captured signals into traditional Segment analytics events. These rules are deployed in your application the next time a user launches your app.

--- a/src/connections/auto-instrumentation/event-builder.md
+++ b/src/connections/auto-instrumentation/event-builder.md
@@ -10,6 +10,9 @@ You can use it to create Track, Identify, Page, and other event types directly f
 > info "Auto-Instrumentation Private Beta"
 > Auto-Instrumentation is currently in Private Beta and is governed by Segment's [First Access and Beta Preview Terms](https://www.twilio.com/en-us/legal/tos){:target="_blank"}. Segment is actively iterating on and improving the Auto-Instrumentation user experience.
 
+> info "Regional availability"
+> Auto-Instrumentation isn't supported in EU workspaces.
+
 ## Access the Event Builder
 
 The Event Builder appears as a tab within each source, next to the Debugger. If you don't see the Event Builder tab, first confirm that you've installed the required Auto-Instrumentation SDK. 

--- a/src/connections/auto-instrumentation/index.md
+++ b/src/connections/auto-instrumentation/index.md
@@ -29,6 +29,9 @@ Auto-Instrumentation simplifies tracking in your websites and apps by removing t
 > info "Auto-Instrumentation in public beta"
 > Auto-Instrumentation is in public beta, and Segment is actively working on this feature. Some functionality may change before it becomes generally available.
 
+> info "Regional availability"
+> Auto-Instrumentation isn't supported in EU workspaces.
+
 ## Background
 
 Collecting high-quality analytics data is essential, but traditional tracking setups often fall behind as business needs change. Instrumentation updates take time away from other engineering priorities, and these delays reduce visibility and increase the burden on engineering teams.

--- a/src/connections/auto-instrumentation/kotlin-setup.md
+++ b/src/connections/auto-instrumentation/kotlin-setup.md
@@ -10,6 +10,9 @@ This guide shows how to install and configure the library, as well as how to ena
 > info "Auto-Instrumentation in public beta"
 > Auto-Instrumentation is in public beta, and Segment is actively working on this feature. Some functionality may change before it becomes generally available.
 
+> info "Regional availability"
+> Auto-Instrumentation isn't supported in EU workspaces.
+
 ## Before you start
 
 To use Signals with Android, you need:

--- a/src/connections/auto-instrumentation/swift-setup.md
+++ b/src/connections/auto-instrumentation/swift-setup.md
@@ -10,6 +10,9 @@ Learn how to connect an existing source, integrate dependencies, turn on Auto-In
 > info "Auto-Instrumentation in public beta"
 > Auto-Instrumentation is in public beta, and Segment is actively working on this feature. Some functionality may change before it becomes generally available.
 
+> info "Regional availability"
+> Auto-Instrumentation isn't supported in EU workspaces.
+
 ## Step 1: Get your source write key
 
 You need the `writeKey` from an existing Segment source. To find it:

--- a/src/connections/auto-instrumentation/web-setup.md
+++ b/src/connections/auto-instrumentation/web-setup.md
@@ -10,6 +10,9 @@ Learn how to connect an existing source, integrate dependencies, turn on Auto-In
 > info "Auto-Instrumentation in public beta"
 > Auto-Instrumentation is in public beta, and Segment is actively working on this feature. Some functionality may change before it becomes generally available.
 
+> info "Regional availability"
+> Auto-Instrumentation isn't supported in EU workspaces.
+
 ## Step 1: Get your source write key
 
 You need the `writeKey` from an existing Segment source. To find it:


### PR DESCRIPTION

### Proposed changes

- Added a callout explaining that Auto-Instrumentation isn't available in EU workspaces.

### Merge timing

- ASAP once approved