### PR TITLE
Segment's OneTrust wrapper automatically populates consent object [DOC-1291]

### DIFF
--- a/src/privacy/consent-management/configure-consent-management.md
+++ b/src/privacy/consent-management/configure-consent-management.md
@@ -39,7 +39,7 @@ Before you can configure consent in Segment, take the following steps:
 
 ## Step 2: Integrating your CMP with Segment
 
-Once you've created consent categories in the Segment app, you need to integrate your CMP with Segment. 
+Once you've created consent categories in the Segment app, you need to integrate your CMP with Segment and add the consent object to every event. If you're using Segment's OneTrust wrapper, the consent object automatically populates on each event. However, other methods may require you to manually include the consent object on your events. 
 
 Segment supports the following CMPs:
 
@@ -56,7 +56,7 @@ Segment supports the following CMPs:
 
 If you'd like to integrate with any other CMP, Segment requires you to build your own wrapper or use any mechanism provided it meets the following requirements for data and event generation:
   - Reads the end user consent preference from your CMP and includes the [consent object](/docs/privacy/consent-management/consent-in-segment-connections/#consent-object) in every event
-  - If using Unify and Engage, generates the [Segment Consent Preference Updated](/docs/privacy/consent-management/consent-in-unify/#segment-consent-preference-updated-event) event every time a user provides or updates their consent preferences with their anonymousId and userId
+  - If using Unify or Twilio Engage, generates the [Segment Consent Preference Updated](/docs/privacy/consent-management/consent-in-unify/#segment-consent-preference-updated-event) event every time a user provides or updates their consent preferences with their anonymousId and userId
 
 To get started building your own wrapper, follow the instructions in the [@segment/analytics-consent-tools](https://github.com/segmentio/analytics-next/tree/master/packages/consent/consent-tools){:target="_blank"} repository. 
 

--- a/src/privacy/consent-management/consent-in-segment-connections.md
+++ b/src/privacy/consent-management/consent-in-segment-connections.md
@@ -20,10 +20,10 @@ If your sources also contain the integrations object, Segment looks at the conse
 
 ## Consent object
 
-Segment requires every event from all of your sources to include the end user consent preferences, captured by your CMP or your application logic, in the form of the **consent object**. The consent object is a JSON object nestled inside of the [context object](/docs/connections/spec/common/#context) with the following format:
+Segment requires every event from all of your sources to include the end user consent preferences, captured by your CMP or your application logic, in the form of the **consent object**. 
 
-> success ""
-> The JSON keys in the consent object should represent the `categoryId` for each consent category. 
+The consent object is a JSON object nestled inside of the [context object](/docs/connections/spec/common/#context) with the following format:
+
 
 ```json
 {
@@ -41,9 +41,12 @@ Segment requires every event from all of your sources to include the end user co
 
 ```
 
-Events without the consent object continue to flow to destinations without consent enforcement. 
+> success ""
+> The JSON keys in the consent object should represent the `categoryId` for each consent category. 
 
-Events that don't include a context object, a consent object, or that include them but leave them empty, don’t affect [Profile-level consent preferences](/docs/privacy/consent-management/consent-in-unify) and flow to all destinations.
+[Segment's OneTrust wrapper](/docs/privacy/consent-management/configure-consent-management/#step-2-integrating-your-cmp-with-segment) automatically adds the consent object to your events, but you can also manually add the consent object to your events if you're using a different CMP.  
+
+Events without the consent object continue to flow to destinations without consent enforcement. Events that don't include a context object, a consent object, or that include them but leave them empty, don’t affect [Profile-level consent preferences](/docs/privacy/consent-management/consent-in-unify) and flow to all destinations.
 
 ## Reconcile consent conflicts
 


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Added info about Segment x OneTrust wrapper's behavior: it AUTOMATICALLY populates the consent object. 

### Merge timing
after approval!

### Related issues (optional)
