### PR TITLE
remove iterable strat

### DIFF
--- a/src/connections/destinations/catalog/actions-iterable-lists/index.md
+++ b/src/connections/destinations/catalog/actions-iterable-lists/index.md
@@ -1,6 +1,5 @@
 ---
 title: Iterable Lists (Actions) Destination
-strat: iterable
 hide-boilerplate: true
 id: 66a7c28810bbaf446695d27d
 hide-dossier: true

--- a/src/connections/destinations/catalog/actions-iterable/index.md
+++ b/src/connections/destinations/catalog/actions-iterable/index.md
@@ -1,6 +1,5 @@
 ---
 title: Iterable (Actions) Destination
-strat: iterable
 hide-boilerplate: true
 id: 645babd9362d97b777391325
 hide-dossier: true


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Appareantly the strat `Iterable` is not valid. On twilio-docs, the new sidebar system fails to load because it can't find this reference.

On Segment prod docs, the sidebar doesn't show up 
https://segment.com/docs/connections/destinations/catalog/actions-iterable-lists/

Two possible options here:
1 - Entry is invalid and should indeed be removed
2 - Some other data is missing and the missing sidebar is wrong. This would warrant a fix on the source of this data. 

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
