### PR TITLE
Add StackAdapt Audiences to deletion supported destinations list

### DIFF
--- a/src/privacy/faq.md
+++ b/src/privacy/faq.md
@@ -73,7 +73,6 @@ In addition to your Raw Data destinations (Amazon S3 and data warehouses), Segme
 - Optimizely Feature Experimentation (Actions)
 - Pushwoosh
 - Recombee
-- StackAdapt Audiences
 - Userpilot Cloud (Actions)
 - Xtremepush (Actions)
 


### PR DESCRIPTION
### Proposed changes

Adding destinations to the deletion supported destinations list. 
Note: only public or public beta destinations have been added.
Stackadapt Audiences in soon to be in public beta.  

- StackAdapt Audiences
- Airship (Actions)
- Angler AI
- AppFit
- Blackbaud Raiser's Edge NXT
- Blend Ai
- Encharge (Actions)
- Gleap (Action)
- Klaviyo (Actions)
- Loops (Actions)
- Optimizely Feature Experimentation (Actions)
- Pushwoosh
- Recombee
- Userpilot Cloud (Actions)
- Xtremepush (Actions)

### Merge timing

- ASAP once approved