### PR TITLE
Add Twilio Legal language to select pages

### DIFF
--- a/src/api/public-api/index.md
+++ b/src/api/public-api/index.md
@@ -104,4 +104,4 @@ The destination’s Instance ID is specific to a single destination within your 
 
 
 > warning ""
-> Twilio Segment has measures in place to not provide services to U.S. sanctioned countries, including Cuba, Iran, Syria, and North Korea.
+> In compliance with applicable regulations and requirements, and to reinforce our commitment as a trusted partner for our customer communication needs, Twilio has measures in place to not provide services to U.S. sanctioned countries in accordance with applicable sanctions, laws, and regulations.

--- a/src/connections/index.md
+++ b/src/connections/index.md
@@ -61,4 +61,4 @@ Yes, you are able to submit an integration request [here](https://segment.com/re
 
 
 > warning ""
-> Twilio Segment has measures in place to not provide services to U.S. sanctioned countries, including Cuba, Iran, Syria, and North Korea.
+> In compliance with applicable regulations and requirements, and to reinforce our commitment as a trusted partner for our customer communication needs, Twilio has measures in place to not provide services to U.S. sanctioned countries in accordance with applicable sanctions, laws, and regulations.

--- a/src/getting-started/02-simple-install.md
+++ b/src/getting-started/02-simple-install.md
@@ -445,7 +445,7 @@ You can click around and load pages to see your Segment calls in action, watch t
 > **Note**: When you're done with this test source and destination, you can delete them. This prevents you from getting unplanned "demo" data in your production environment later.
 
 > warning ""
-> Twilio Segment has measures in place to not provide services to U.S. sanctioned countries, including Cuba, Iran, Syria, and North Korea.
+> In compliance with applicable regulations and requirements, and to reinforce our commitment as a trusted partner for our customer communication needs, Twilio has measures in place to not provide services to U.S. sanctioned countries in accordance with applicable sanctions, laws, and regulations.
 
 <div class="double">
   {% include components/reference-button.html href="/getting-started/01-what-is-segment/" newtab="false" icon="symbols/arrow-left.svg" title="What is Segment" description="The basics of the Segment platform and what you can do with it." variant="related" subtitle="back" %}

--- a/src/index.md
+++ b/src/index.md
@@ -26,4 +26,4 @@ Learn how to use Segment to collect, responsibly manage, and integrate your cust
 
 
 > warning ""
-> Twilio Segment has measures in place to not provide services to U.S. sanctioned countries, including Cuba, Iran, Syria, and North Korea.
+> In compliance with applicable regulations and requirements, and to reinforce our commitment as a trusted partner for our customer communication needs, Twilio has measures in place to not provide services to U.S. sanctioned countries in accordance with applicable sanctions, laws, and regulations.

--- a/src/segment-app/index.md
+++ b/src/segment-app/index.md
@@ -83,4 +83,4 @@ The Privacy Portal allows you to inspect data coming into your Segment account, 
 
 
 > warning ""
-> Twilio Segment has measures in place to not provide services to U.S. sanctioned countries, including Cuba, Iran, Syria, and North Korea.
+> In compliance with applicable regulations and requirements, and to reinforce our commitment as a trusted partner for our customer communication needs, Twilio has measures in place to not provide services to U.S. sanctioned countries in accordance with applicable sanctions, laws, and regulations.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Twilio's legal team reached out to a PM and wanted a specific legal disclaimer added to four docs pages, so here we are. 

### Merge timing
asap please

### Related issues (optional)

