### PR TITLE
Update ajs doc on query string support

### DIFF
--- a/src/connections/sources/catalog/libraries/website/javascript/querystring.md
+++ b/src/connections/sources/catalog/libraries/website/javascript/querystring.md
@@ -53,6 +53,3 @@ analytics.load('<WRITE_KEY>', {
   }
 })
 ```
-
-> info ""
-> The `useQueryString` option is **only** available when you load Analytics.js through the [npm package](https://www.npmjs.com/package/@segment/analytics-next){:target="_blank"}.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
Update AJS documentation to remove the section that says query string is only supported for npm. We tested and confirmed that it works for the snippet version also. 

<!--Tell us what you did and why-->

### Merge timing
<!-- When should this get merged/published?-->
ASAP once approved

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
