### PR TITLE
Delete Profile Identifier API private beta [DOC-1299]

### DIFF
--- a/src/unify/identity-resolution/delete-profile-identifier-api.md
+++ b/src/unify/identity-resolution/delete-profile-identifier-api.md
@@ -36,7 +36,7 @@ You need one of these roles to delete identifiers:
 - Identity Admin
 - Unify and Engage Admin
 
-See [the Roles documentation](/docs/segment-app/iam/roles/) for more detailss.
+See [the Roles documentation](/docs/segment-app/iam/roles/) for more details.
 
 If you use [Profiles Sync](/docs/unify/profiles-sync/overview/), you must also:
 


### PR DESCRIPTION
### Proposed changes

- Added documentation for the new Delete Profile Identifier API (will enter private beta during the content freeze).
- Covers API usage, authentication, request format, and response codes
- Explains how deletions propagate across Unify systems/connected data warehouses.

### Merge timing

- 7 November 2025