### PR TITLE
Hide SatisMeter destination info box

### DIFF
--- a/src/connections/destinations/catalog/satismeter/index.md
+++ b/src/connections/destinations/catalog/satismeter/index.md
@@ -1,6 +1,7 @@
 ---
 title: SatisMeter Destination
 id: 54c02a5adb31d978f14a7f6f
+hide-dossier: true
 ---
 [Our SatisMeter destination code](https://github.com/segment-integrations/analytics.js-integration-satismeter){:target="_blank"} is all open-source on GitHub if you want to check it out.
 


### PR DESCRIPTION
### Proposed changes

- Hid the SatisMeter destination quick info box temporarily.
- It's apparently showing incorrect info, and I've been unable to confirm that these changes need to be made.
- For now, let's just hide it until we can get the Actions repo updated.

More context here:

https://twilio.slack.com/archives/CD3LFFTFZ/p1761036931084569

### Merge timing

- ASAP once approved
