### PR TITLE
Hide AWS S3 destination box

### DIFF
--- a/src/connections/destinations/catalog/actions-s3/index.md
+++ b/src/connections/destinations/catalog/actions-s3/index.md
@@ -1,6 +1,8 @@
 ---
 title: AWS S3 (Actions) Destination
 id: 66eaa166f650644f04389e2c
+hide-boilerplate: true
+hide-dossier: true
 private: true
 beta: true
 # versions:


### PR DESCRIPTION
### Proposed changes

- Hid both the dossier and boilerplate so we don't see an empty info box. 
- This destination is still in private beta.

### Related issues (optional)

- ASAP
