### PR TITLE
Update V2 Journeys product limits for concurrent instances and unique identifiers [DOC-1279]

### DIFF
--- a/src/engage/journeys/v2/limits.md
+++ b/src/engage/journeys/v2/limits.md
@@ -7,15 +7,15 @@ This page outlines product limitations for Event-Triggered (V2) Journeys.
 
 ## General limits
 
-| Name                | Limit                                   | Description                                                                                                                |
-| ------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Steps               | 50                                      | Maximum number of steps per journey.                                                                                       |
-| Journey name        | 73 characters                           | Maximum length for Journey names. Names must be unique.                                                                    |
-| Step name           | 73 characters                           | Maximum length for step names.                                                                                             |
-| Branch name         | 73 characters                           | Maximum length for branch names within a split step. Branch names must be unique across the journey.                       |
-| Additional branches | 5                                       | Maximum number of branches supported in a split or Hold Until step.                                                        |
-| Delay duration      | Minimum: 5 minutes<br>Maximum: 182 days | Allowed time range for Delay and Hold Until steps.                                                                         |
-| Unique identifier   | 500 characters                          | For “Re-enter every time event occurs” rules, you must define a unique identifier. The value is limited to 500 characters. |
+| Name                | Limit                                                           | Description                                                                                                                                                                             |
+| ------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Steps               | 50                                                              | Maximum number of steps per journey.                                                                                                                                                    |
+| Journey name        | 73 characters                                                   | Maximum length for Journey names. Names must be unique.                                                                                                                                 |
+| Step name           | 73 characters                                                   | Maximum length for step names.                                                                                                                                                          |
+| Branch name         | 73 characters                                                   | Maximum length for branch names within a split step. Branch names must be unique across the journey.                                                                                    |
+| Additional branches | 5                                                               | Maximum number of branches supported in a split or Hold Until step.                                                                                                                     |
+| Delay duration      | Minimum: 5 minutes<br>Maximum: 182 days                         | Allowed time range for Delay and Hold Until steps.                                                                                                                                      |
+| Unique identifier   | Property name: 500 characters<br>Property value: 150 characters | For "Re-enter every time event occurs" rules, you must define a unique identifier. The property name is limited to 500 characters, and the property value is limited to 150 characters. |
 
 ## Journey Step Billing
 
@@ -35,7 +35,7 @@ Plans with compute credits instead of journey steps consume 1 compute credit for
 | Name                      | Limit                   | Description                                                                                                                     |
 | ------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | Requests per second (RPS) | 25 events/sec/profile   | Maximum events per second per Segment ID. Timer events are excluded. Excess events get dropped.                                 |
-| Instances per profile     | 25 concurrent instances | Maximum concurrent Journey instances per profile.                                                                               |
+| Instances per profile     | 25 concurrent instances | Maximum concurrent journey instances per profile across all journeys.                                                           |
 | Send profiles back branch | 100 instances           | Maximum count a single journey instance can pass through a Wait Until Send profiles back to the beginning of this step' branch. |
 
 ## Journey context


### PR DESCRIPTION
### Proposed changes

- Updates the Journeys V2 product limits page with recent backend limit changes.
- Specifically: Updated "Instances per profile" description to clarify the 25 concurrent instance limit applies across all journeys
- Added 150 character limit for unique identifier property values
- Clarified the distinction between unique identifier property names (500 chars) and property values (150 chars).

### Merge timing

- ASAP once approved