### PR TITLE
Updated Auto Retry Section.md

### DIFF
--- a/src/connections/reverse-etl/manage-retl.md
+++ b/src/connections/reverse-etl/manage-retl.md
@@ -34,9 +34,6 @@ To check the status of your extractions:
 
 ## Automatic retry handling
 
-> info "Automatic retry handling might not yet be available in your workspace"
-> To ensure overall system stability and performance, Segment is releasing automatic retry handling to all workspaces in a phased rollout program. Segment expects this feature to be available to all customers by January 31, 2025.
-
 Segment automatically retries events that were extracted from your data warehouse but failed to load for up to 14 days or 5 syncs following a partially successful sync or a sync failure. 
 
 Segment checks for the latest changes in your data before loading the failed records on a subsequent (automatically scheduled or manually triggered) sync to ensure the data loaded into Segment isn’t stale and only the latest version of the data is loaded to destination. If the error causing the load failure is coming from an upstream tool, you can fix the error in the upstream tool to resolve the load error on a subsequent sync.


### PR DESCRIPTION
Updated auto retry info box that mentioned that Auto-Retry may not be available in your workspace and it'll be available to all workspaces by 31 Jan, 2025. 

We've now released auto retry feature to all customers across tiers

<!--Thanks for helping! Remove these comments as you go.-->



<!--Tell us what you did and why-->
Removed the callout on Auto Retry not being available for all workspaces as it has now been rolled out across customer tiers. 

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved

### Related issues (optional)
