### PR TITLE
[ STRATCONN-6284 ] : [Salesforce Marketing cloud ] updated actions salesforce marketing cloud docs for the primary Keys

### DIFF
--- a/src/_data/catalog/destinations.yml
+++ b/src/_data/catalog/destinations.yml
@@ -113196,11 +113196,11 @@ items:
       label: Data Extension Primary Keys
       type: OBJECT
       description: >-
-        The primary key(s) that uniquely identify a row in the data extension.
-        On the left-hand side, input the SFMC key name. On the right-hand side,
-        map the Segment field that contains the corresponding value. When
-        multiple primary keys are provided, SFMC will update an existing row if
-        all primary keys match, otherwise a new row will be created
+        The Primary Key is a unique identifier for each row in the Data Extension.
+        In the mapping configuration, enter the SFMC Key Name on the left and map the corresponding Segment Field on the right. 
+        Each Data Extension supports only one Primary Key.
+        When data is sent to SFMC, the system will update an existing row if the Primary Key matches; otherwise, 
+        it will create a new record.
       placeholder: ''
       required: true
       multiple: false
@@ -113284,11 +113284,11 @@ items:
       label: Data Extension Primary Keys
       type: OBJECT
       description: >-
-        The primary key(s) that uniquely identify a row in the data extension.
-        On the left-hand side, input the SFMC key name. On the right-hand side,
-        map the Segment field that contains the corresponding value. When
-        multiple primary keys are provided, SFMC will update an existing row if
-        all primary keys match, otherwise a new row will be created
+        The Primary Key is a unique identifier for each row in the Data Extension.
+        In the mapping configuration, enter the SFMC Key Name on the left and map the corresponding Segment Field on the right. 
+        Each Data Extension supports only one Primary Key.
+        When data is sent to SFMC, the system will update an existing row if the Primary Key matches; otherwise, 
+        it will create a new record.
       placeholder: ''
       defaultValue:
         contactKey:
@@ -113342,11 +113342,11 @@ items:
       label: Data Extension Primary Keys
       type: OBJECT
       description: >-
-        The primary key(s) that uniquely identify a row in the data extension.
-        On the left-hand side, input the SFMC key name. On the right-hand side,
-        map the Segment field that contains the corresponding value. When
-        multiple primary keys are provided, SFMC will update an existing row if
-        all primary keys match, otherwise a new row will be created
+        The Primary Key is a unique identifier for each row in the Data Extension.
+        In the mapping configuration, enter the SFMC Key Name on the left and map the corresponding Segment Field on the right. 
+        Each Data Extension supports only one Primary Key.
+        When data is sent to SFMC, the system will update an existing row if the Primary Key matches; otherwise, 
+        it will create a new record.
       placeholder: ''
       required: true
       multiple: false
@@ -113678,11 +113678,11 @@ items:
       label: Data Extension Primary Keys
       type: OBJECT
       description: >-
-        The primary key(s) that uniquely identify a row in the data extension.
-        On the left-hand side, input the SFMC key name. On the right-hand side,
-        map the Segment field that contains the corresponding value. When
-        multiple primary keys are provided, SFMC will update an existing row if
-        all primary keys match, otherwise a new row will be created
+        The Primary Key is a unique identifier for each row in the Data Extension.
+        In the mapping configuration, enter the SFMC Key Name on the left and map the corresponding Segment Field on the right. 
+        Each Data Extension supports only one Primary Key.
+        When data is sent to SFMC, the system will update an existing row if the Primary Key matches; otherwise, 
+        it will create a new record.
       placeholder: ''
       defaultValue:
         contactKey:

--- a/src/_data/catalog/destinations.yml
+++ b/src/_data/catalog/destinations.yml
@@ -113193,7 +113193,7 @@ items:
     - id: pmd7jmGQmHH6ic2sRggK92
       sortOrder: 2
       fieldKey: keys
-      label: Data Extension Primary Keys
+      label: Data Extension Primary Key
       type: OBJECT
       description: >-
         The Primary Key is a unique identifier for each row in the Data Extension.
@@ -113281,7 +113281,7 @@ items:
     - id: o4kSusbWjwb1jKvy1HmKE5
       sortOrder: 2
       fieldKey: keys
-      label: Data Extension Primary Keys
+      label: Data Extension Primary Key
       type: OBJECT
       description: >-
         The Primary Key is a unique identifier for each row in the Data Extension.
@@ -113339,7 +113339,7 @@ items:
     - id: oj2wfkcgfnRFBmuEwHwVMS
       sortOrder: 0
       fieldKey: keys
-      label: Data Extension Primary Keys
+      label: Data Extension Primary Key
       type: OBJECT
       description: >-
         The Primary Key is a unique identifier for each row in the Data Extension.
@@ -113675,7 +113675,7 @@ items:
     - id: oGg6NmbtphpMxQv5PjTpMs
       sortOrder: 0
       fieldKey: keys
-      label: Data Extension Primary Keys
+      label: Data Extension Primary Key
       type: OBJECT
       description: >-
         The Primary Key is a unique identifier for each row in the Data Extension.


### PR DESCRIPTION
<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

One customer reached out to us asking questions regarding use the primary key for the data extension fields but as segment is designed we can only have one primary key and that primary key is visible in data extension primary key section . To use fields in data extenstion fields we need to create seperate fields for that .

### Merge timing

-  ASAP once approved

<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
Related to https://twilio-engineering.atlassian.net/browse/STRATCONN-6284