### PR TITLE
Snowflake and Databricks warehouse writeback info

### DIFF
--- a/src/engage/audiences/linked-audiences.md
+++ b/src/engage/audiences/linked-audiences.md
@@ -167,7 +167,9 @@ See the step-by-step video on activating Linked Audiences:
 
 ### Step 2b: Select your Destination Actions
 
-The [Destination Actions](/docs/connections/destinations/actions/) framework allows you to see and control how Segment sends the event data it receives from your sources to actions-based destinations. Each Action in a destination lists the event data it requires and the event data that is optional. Segment displays available Actions based on the destination you've connected to your Linked Audience. You can see details of each option and how to use it in the [Actions Destinations Catalog](/docs/connections/destinations/catalog/) documentation. 
+The [Destination Actions](/docs/connections/destinations/actions/) framework allows you to see and control how Segment sends the event data it receives from your sources to actions-based destinations. Each Action in a destination lists the event data it requires and the event data that is optional. Segment displays available Actions based on the destination you've connected to your Linked Audience. You can see details of each option and how to use it in the [Actions Destinations Catalog](/docs/connections/destinations/catalog/) documentation.
+
+Linked Audiences let's you to write back audience events to [Snowflake](https://www.twilio.com/docs/segment/connections/storage/catalog/snowflake#use-with-engage) and [Databricks](https://www.twilio.com/docs/segment/connections/storage/catalog/databricks#use-with-engage) warehouses.
 
 Select the Destination Action to call when the event happens, then click **Next**.
 


### PR DESCRIPTION
…nces docs

Updates Step 2b to inform users that Linked Audiences supports writing back audience events to Snowflake and Databricks warehouses. Adds links to the relevant warehouse documentation pages.

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes

Added links to Snowflake and Databricks documentation from the Linked Audiences set up page. 

### Merge timing
ASAP, when approved

### Related issues (optional)

Not application
