### PR TITLE
[Develop] removed beta tag from microsoft bing capi

### DIFF
--- a/src/connections/destinations/catalog/actions-ms-bing-capi/index.md
+++ b/src/connections/destinations/catalog/actions-ms-bing-capi/index.md
@@ -1,7 +1,9 @@
 ---
 title: Microsoft Bing CAPI Destination
+hide-boilerplate: true
+hide-dossier: false
+strat: microsoft-bing-capi
 id: 68b82be249b48bae343517c7
-beta: true
 redirect_from: "/connections/destinations/catalog/microsoft-bing-capi/"
 ---
 


### PR DESCRIPTION
Since Microsoft bing CAPI is GA now, removed beta flag from the docs.

### Merge timing
<!-- When should this get merged/published?
- ASAP once approved?
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
