### PR TITLE
doc:add callout for SFMC async action regarding no observability

### DIFF
--- a/src/_includes/components/actions-fields.html
+++ b/src/_includes/components/actions-fields.html
@@ -153,6 +153,20 @@ Build your own Mappings. Combine supported [triggers](/docs/connections/destinat
 </div>
 {% endif %}
 
+
+<!-- Call out text for SFMC async action saying "Delivery confirmation and error tracking are not available with this action."-->
+{% if action.id == 'dWicdKRXDTEW63wrHTmACJ' %}
+<div class="premonition info">
+  <div class="fa fa-check-circle"></div>
+  <div class="content">
+    <p class="header">Delivery confirmation and error tracking are not available with this action.</p>
+    <p markdown=1>
+        This action is designed for asynchronous processing, which means that Segment cannot provide real-time delivery confirmation or error tracking for events sent through this action.
+    </p>
+  </div>
+</div>
+{% endif %}
+
 {% if action.fields.size > 0 %}
 <p class="button button-hollow" data-toggle="collapse" data-target=".settings-content-{{action.slug}}">Click to show / hide fields</p>
 <div class="collapse settings-content-{{action.slug}} show">


### PR DESCRIPTION
JIRA Ticket: https://twilio-engineering.atlassian.net/browse/STRATCONN-6664

<!--Thanks for helping! Remove these comments as you go.-->

### Proposed changes
This pull request adds a user-facing informational message to the UI for a specific asynchronous SFMC action, clarifying the limitations regarding delivery confirmation and error tracking.

User interface improvements:

* Added a callout in `actions-fields.html` for the SFMC async action (`action.id == 'dWicdKRXDTEW63wrHTmACJ'`) to inform users that delivery confirmation and error tracking are not available due to the asynchronous nature of the action.
<!--Tell us what you did and why-->
<img width="1512" height="982" alt="Screenshot 2026-04-05 at 4 13 10 PM" src="https://github.com/user-attachments/assets/11e05b7e-e243-49f9-ac23-0e33c1f402a1" />



### Merge timing
ASAP once approved as Action is PUBLIC
<!-- When should this get merged/published?
- ASAP once approved 
- On a specific date?
- Depending on a specific project?-->

### Related issues (optional)
None
<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
