### PR TITLE
Add BigQuery and Redshift warehouse writeback support to Engage

### DIFF
--- a/src/connections/storage/catalog/bigquery/index.md
+++ b/src/connections/storage/catalog/bigquery/index.md
@@ -147,6 +147,27 @@ Segment recommends enabling IP allowlists for added security. All Segment users 
 
 Users with workspaces in the EU must allowlist `3.251.148.96/29`.
 
+## Use with Engage 
+
+After you connect BigQuery, you can add a BigQuery Activation from Engage. [Linked Audiences](/docs/engage/audiences/linked-audiences/) writes audience enter/exit events to your warehouse, and [Event-Triggered Journeys](/docs/engage/journeys/v2/) writes journey step events. 
+
+Segment recommends using a service account with appropriate permissions for the BigQuery user. For more information, see [create a service account for Segment](#create-a-service-account-for-segment).
+
+### Schema and table selection (beta)
+
+When you create a BigQuery Activation from Engage, choose the dataset and either select an existing table or enter a new table name. Engage writes to exactly what you specify.
+
+### Sync behavior for Engage (beta)
+
+For Engage writebacks, Segment starts a warehouse sync after each run completes (for example, when an audience run finishes). This replaces a fixed hourly cadence for these writebacks.
+
+> warning ""
+> Changing the BigQuery destination's general sync schedule does **not** affect Engage writebacks. Engage controls when these writes occur.
+
+### Data format and limits
+
+Engage writebacks use Track events. The full event payload is stored in a single stringified JSON column in the target table.
+
 ## Best Practices
 
 ### Use views

--- a/src/connections/storage/catalog/databricks/index.md
+++ b/src/connections/storage/catalog/databricks/index.md
@@ -111,6 +111,27 @@ Once connected, you'll see a confirmation screen with next steps and more info o
 
 {% include content/storage-do-include.md %}
 
+## Use with Engage 
+
+After you connect Databricks, you can add a Databricks Activation from Engage. [Linked Audiences](/docs/engage/audiences/linked-audiences/) writes audience enter/exit events to your warehouse, and [Event-Triggered Journeys](/docs/engage/journeys/v2/) writes journey step events. 
+
+Segment recommends using OAuth (M2M) authentication with a service principal. For more information, see [add the service principal client ID and OAuth secret](#step-5-add-the-service-principal-client-id-and-oauth-secret).
+
+### Schema and table selection (beta)
+
+When you create a Databricks Activation from Engage, choose the schema and either select an existing table or enter a new table name. Engage writes to exactly what you specify.
+
+### Sync behavior for Engage (beta)
+
+For Engage writebacks, Segment starts a warehouse sync after each run completes (for example, when an audience run finishes). This replaces a fixed hourly cadence for these writebacks.
+
+> warning ""
+> Changing the Databricks destination's general sync schedule does **not** affect Engage writebacks. Engage controls when these writes occur.
+
+### Data format and limits
+
+Engage writebacks use Track events. The full event payload is stored in a single stringified JSON column in the target table.
+
 ## Security
 
 Segment recommends enabling IP allowlists for added security. All Segment users with workspaces hosted in the US who use allowlists in their warehouses must update those allowlists to include the following ranges:

--- a/src/connections/storage/catalog/redshift/index.md
+++ b/src/connections/storage/catalog/redshift/index.md
@@ -93,6 +93,27 @@ Segment recommends enabling IP allowlists for added security. All Segment users 
 
 Users with workspaces in the EU must allowlist `3.251.148.96/29`.
 
+## Use with Engage 
+
+After you connect Redshift, you can add a Redshift Activation from Engage. [Linked Audiences](/docs/engage/audiences/linked-audiences/) writes audience enter/exit events to your warehouse, and [Event-Triggered Journeys](/docs/engage/journeys/v2/) writes journey step events. 
+
+Segment recommends creating a dedicated database user for Segment to use. For more information, see [create a database user](#create-a-database-user).
+
+### Schema and table selection (beta)
+
+When you create a Redshift Activation from Engage, choose the schema and either select an existing table or enter a new table name. Engage writes to exactly what you specify.
+
+### Sync behavior for Engage (beta)
+
+For Engage writebacks, Segment starts a warehouse sync after each run completes (for example, when an audience run finishes). This replaces a fixed hourly cadence for these writebacks.
+
+> warning ""
+> Changing the Redshift destination's general sync schedule does **not** affect Engage writebacks. Engage controls when these writes occur.
+
+### Data format and limits
+
+Engage writebacks use Track events. The full event payload is stored in a single stringified JSON column in the target table.
+
 ## Best practices
 
 ### Networking

--- a/src/engage/audiences/linked-audiences.md
+++ b/src/engage/audiences/linked-audiences.md
@@ -167,7 +167,9 @@ See the step-by-step video on activating Linked Audiences:
 
 ### Step 2b: Select your Destination Actions
 
-The [Destination Actions](/docs/connections/destinations/actions/) framework allows you to see and control how Segment sends the event data it receives from your sources to actions-based destinations. Each Action in a destination lists the event data it requires and the event data that is optional. Segment displays available Actions based on the destination you've connected to your Linked Audience. You can see details of each option and how to use it in the [Actions Destinations Catalog](/docs/connections/destinations/catalog/) documentation. 
+The [Destination Actions](/docs/connections/destinations/actions/) framework allows you to see and control how Segment sends the event data it receives from your sources to actions-based destinations. Each Action in a destination lists the event data it requires and the event data that is optional. Segment displays available Actions based on the destination you've connected to your Linked Audience. You can see details of each option and how to use it in the [Actions Destinations Catalog](/docs/connections/destinations/catalog/) documentation.
+
+Linked Audiences let's you to write back audience events to [Snowflake](https://www.twilio.com/docs/segment/connections/storage/catalog/snowflake#use-with-engage) and [Databricks](https://www.twilio.com/docs/segment/connections/storage/catalog/databricks#use-with-engage) warehouses.
 
 Select the Destination Action to call when the event happens, then click **Next**.
 

--- a/src/engage/audiences/linked-audiences.md
+++ b/src/engage/audiences/linked-audiences.md
@@ -169,7 +169,7 @@ See the step-by-step video on activating Linked Audiences:
 
 The [Destination Actions](/docs/connections/destinations/actions/) framework allows you to see and control how Segment sends the event data it receives from your sources to actions-based destinations. Each Action in a destination lists the event data it requires and the event data that is optional. Segment displays available Actions based on the destination you've connected to your Linked Audience. You can see details of each option and how to use it in the [Actions Destinations Catalog](/docs/connections/destinations/catalog/) documentation.
 
-Linked Audiences let's you to write back audience events to [Snowflake](https://www.twilio.com/docs/segment/connections/storage/catalog/snowflake#use-with-engage) and [Databricks](https://www.twilio.com/docs/segment/connections/storage/catalog/databricks#use-with-engage) warehouses.
+Linked Audiences let's you to write back audience events to [Snowflake](https://www.twilio.com/docs/segment/connections/storage/catalog/snowflake#use-with-engage), [Databricks](https://www.twilio.com/docs/segment/connections/storage/catalog/databricks#use-with-engage), [BigQuery](https://www.twilio.com/docs/segment/connections/storage/catalog/bigquery#use-with-engage), and [Redshift](https://www.twilio.com/docs/segment/connections/storage/catalog/redshift#use-with-engage) warehouses.
 
 Select the Destination Action to call when the event happens, then click **Next**.
 


### PR DESCRIPTION
## Summary
- Extends Linked Audiences warehouse writeback functionality to support BigQuery and Redshift
- Adds "Use with Engage" documentation section to BigQuery, Redshift, and Databricks warehouse docs
- Updates Linked Audiences docs to reference all four supported warehouses (Snowflake, Databricks, BigQuery, Redshift)

## Changes
- **linked-audiences.md**: Updated Step 2b to include BigQuery and Redshift in the list of warehouses that support audience event writeback
- **bigquery/index.md**: Added "Use with Engage" section with schema/table selection, sync behavior, and data format details
- **redshift/index.md**: Added "Use with Engage" section with schema/table selection, sync behavior, and data format details
- **databricks/index.md**: Added "Use with Engage" section for consistency with other warehouse docs

### Merge timing
-- 4/14/26
